### PR TITLE
Refactor ticket and venueless views

### DIFF
--- a/automation/urls.py
+++ b/automation/urls.py
@@ -3,8 +3,7 @@ from django.urls import include, path
 from django.views.generic import TemplateView
 
 from automation import __version__
-from tickets.views import tickets_info
-from tickets.views import venueless_view
+from tickets.views import tickets_info, venueless_view
 from titowebhooks.views import tito_webhook
 
 admin_header = f"DjangoCon US Automation v{__version__}"

--- a/templates/tickets/info.html
+++ b/templates/tickets/info.html
@@ -1,29 +1,29 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="max-w-2xl mx-auto p-6 bg-green-800 rounded-lg shadow-lg">
-    <h1 class="text-3xl font-bold mb-4 text-yellow-200">DjangoCon US Tickets</h1>
+    <div class="p-6 mx-auto max-w-2xl bg-green-800 rounded-lg shadow-lg">
+        <h1 class="mb-4 text-3xl font-bold text-yellow-200">DjangoCon US Tickets</h1>
 
-    {% if tickets_available %}
-        <p class="text-green-100 mb-6">
-            Welcome to the DjangoCon US ticket portal! You can access Venueless, our virtual conference platform, by clicking the button below.
-        </p>
-        <a href="{% url 'venueless_view' %}" class="inline-block px-6 py-3 bg-yellow-500 text-green-900 font-semibold rounded-lg hover:bg-yellow-400 transition-colors duration-300">
-            Access Venueless
-        </a>
-        <p class="text-green-200 mt-4 text-sm">
-            Note: Each link can only be used once. If you need to re-enter Venueless, please return to this page and click the button again.
-        </p>
-    {% else %}
-        <p class="text-green-100 mb-6">
-            We're sorry, but there are currently no available tickets for accessing Venueless.
-        </p>
-        <p class="text-green-100 mb-6">
-            If you believe this is an error or need assistance, please reach out to us at:
-        </p>
-        <a href="mailto:hello@djangocon.us" class="inline-block px-6 py-3 bg-yellow-500 text-green-900 font-semibold rounded-lg hover:bg-yellow-400 transition-colors duration-300">
-            hello@djangocon.us
-        </a>
-    {% endif %}
-</div>
+        {% if tickets_available %}
+            <p class="mb-6 text-green-100">
+                Welcome to the DjangoCon US ticket portal! You can access Venueless, our virtual conference platform, by clicking the button below.
+            </p>
+            <a href="{% url 'venueless_view' %}" class="inline-block py-3 px-6 font-semibold text-green-900 bg-yellow-500 rounded-lg transition-colors duration-300 hover:bg-yellow-400">
+                Access Venueless
+            </a>
+            <p class="mt-4 text-sm text-green-200">
+                Note: Each link can only be used once. If you need to re-enter Venueless, please return to this page and click the button again.
+            </p>
+        {% else %}
+            <p class="mb-6 text-green-100">
+                We're sorry, but there are currently no available tickets for accessing Venueless.
+            </p>
+            <p class="mb-6 text-green-100">
+                If you believe this is an error or need assistance, please reach out to us at:
+            </p>
+            <a href="mailto:hello@djangocon.us" class="inline-block py-3 px-6 font-semibold text-green-900 bg-yellow-500 rounded-lg transition-colors duration-300 hover:bg-yellow-400">
+                hello@djangocon.us
+            </a>
+        {% endif %}
+    </div>
 {% endblock content %}

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -1,7 +1,6 @@
 from django.db import transaction
 from django.http import HttpResponse
-from django.shortcuts import redirect
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.utils import timezone
 from django.views.decorators.http import require_GET
 
@@ -10,7 +9,7 @@ from .models import TicketLink
 
 def tickets_info(request):
     tickets_available = TicketLink.objects.filter(date_link_accessed__isnull=True).exists()
-    return render(request, 'tickets/info.html', {'tickets_available': tickets_available})
+    return render(request, "tickets/info.html", {"tickets_available": tickets_available})
 
 
 @require_GET


### PR DESCRIPTION
This update adds a new view that we can send people to and tell them if we have any tickets left. If no tickets are left, it tells people to contact hello@djangocon.us (see screenshots below). 

New view (the one we will link people to): http://localhost:8000/tickets/ 

The old view that will redirect people to Venueless and take a ticket out of the queue: http://localhost:8000/tickets/go/

## We have tickets

This page is landing page before people accept a ticket.

<img width="854" alt="Xnapper-2024-09-15-20 17 58" src="https://github.com/user-attachments/assets/2b11f824-ad2a-4134-b5be-232d08a02878">

## No tickets left screen

Note: My screenshot app is "helpful" and removes email addresses. The black bar reads hello@djangocon.us

<img width="824" alt="Xnapper-2024-09-15-20 16 17" src="https://github.com/user-attachments/assets/d7329631-e7e2-4ed3-9067-e68eb750455f">

