### PR TITLE
:art: Add styled allauth/socialaccount templates

### DIFF
--- a/templates/allauth/layouts/base.html
+++ b/templates/allauth/layouts/base.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}
+    {% block head_title %}{% endblock head_title %} - DjangoCon US
+{% endblock title %}
+
+{% block content %}
+    <div class="max-w-md mx-auto bg-green-800/50 rounded-lg p-8 shadow-lg">
+        {% if messages %}
+            <div class="mb-4">
+                {% for message in messages %}
+                    <div class="p-3 rounded {% if message.tags %}bg-{{ message.tags }}-600{% else %}bg-blue-600{% endif %}">
+                        {{ message }}
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+        {% block body %}
+            {% block inner_content %}
+            {% endblock inner_content %}
+        {% endblock body %}
+    </div>
+{% endblock content %}

--- a/templates/socialaccount/login.html
+++ b/templates/socialaccount/login.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}Sign In - DjangoCon US{% endblock title %}
+
+{% block content %}
+    <div class="max-w-md mx-auto bg-green-800/50 rounded-lg p-8 shadow-lg">
+        {% if process == "connect" %}
+            <h1 class="text-2xl font-bold mb-4">
+                {% blocktrans with provider.name as provider %}Connect {{ provider }}{% endblocktrans %}
+            </h1>
+            <p class="mb-6 text-green-200">
+                {% blocktrans with provider.name as provider %}You are about to connect a new third-party account from {{ provider }}.{% endblocktrans %}
+            </p>
+        {% else %}
+            <h1 class="text-2xl font-bold mb-4">
+                {% blocktrans with provider.name as provider %}Sign In Via {{ provider }}{% endblocktrans %}
+            </h1>
+            <p class="mb-6 text-green-200">
+                {% blocktrans with provider.name as provider %}You are about to sign in using a third-party account from {{ provider }}.{% endblocktrans %}
+            </p>
+        {% endif %}
+        <form method="post">
+            {% csrf_token %}
+            <button type="submit" class="w-full bg-green-600 hover:bg-green-500 text-white font-bold py-3 px-6 rounded-lg transition duration-200">
+                {% trans "Continue" %}
+            </button>
+        </form>
+    </div>
+{% endblock content %}


### PR DESCRIPTION
The allauth/layouts/base.html and socialaccount/login.html templates were never committed, so the GitHub login page fell back to allauth's unstyled default.