### PR TITLE
:sparkles: Add custom 404 and 500 error templates

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Page Not Found — DjangoCon US Automation</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="icon" href="https://fav.farm/🦄" />
+        <style>
+            body {
+                display: flex;
+                padding: 1rem;
+                min-height: 100vh;
+                color: white;
+                background: linear-gradient(to bottom, #14532d, #052e16, black);
+                margin: 0;
+                font-family: system-ui, -apple-system, sans-serif;
+            }
+            main {
+                margin: auto;
+                text-align: center;
+            }
+            .error-code {
+                font-size: 8rem;
+                font-weight: 800;
+                line-height: 1;
+                margin: 0 0 0.5rem;
+                letter-spacing: -0.025em;
+                opacity: 0.9;
+            }
+            .error-title {
+                font-size: 1.5rem;
+                font-weight: 600;
+                margin: 0 0 0.5rem;
+            }
+            .error-message {
+                font-size: 1.125rem;
+                margin: 0 0 2rem;
+                opacity: 0.8;
+            }
+            a {
+                display: inline-block;
+                color: white;
+                background: rgba(255, 255, 255, 0.1);
+                border: 1px solid rgba(255, 255, 255, 0.25);
+                border-radius: 0.5rem;
+                padding: 0.625rem 1.5rem;
+                text-decoration: none;
+                font-size: 1rem;
+                transition: background 0.2s;
+            }
+            a:hover {
+                background: rgba(255, 255, 255, 0.2);
+            }
+        </style>
+    </head>
+    <body>
+        <main>
+            <p class="error-code">404</p>
+            <h1 class="error-title">Page Not Found</h1>
+            <p class="error-message">The page you're looking for doesn't exist.</p>
+            <a href="/">Go back home</a>
+        </main>
+    </body>
+</html>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Server Error — DjangoCon US Automation</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="icon" href="https://fav.farm/🦄" />
+        <style>
+            body {
+                display: flex;
+                padding: 1rem;
+                min-height: 100vh;
+                color: white;
+                background: linear-gradient(to bottom, #14532d, #052e16, black);
+                margin: 0;
+                font-family: system-ui, -apple-system, sans-serif;
+            }
+            main {
+                margin: auto;
+                text-align: center;
+            }
+            .error-code {
+                font-size: 8rem;
+                font-weight: 800;
+                line-height: 1;
+                margin: 0 0 0.5rem;
+                letter-spacing: -0.025em;
+                opacity: 0.9;
+            }
+            .error-title {
+                font-size: 1.5rem;
+                font-weight: 600;
+                margin: 0 0 0.5rem;
+            }
+            .error-message {
+                font-size: 1.125rem;
+                margin: 0 0 2rem;
+                opacity: 0.8;
+            }
+            a {
+                display: inline-block;
+                color: white;
+                background: rgba(255, 255, 255, 0.1);
+                border: 1px solid rgba(255, 255, 255, 0.25);
+                border-radius: 0.5rem;
+                padding: 0.625rem 1.5rem;
+                text-decoration: none;
+                font-size: 1rem;
+                transition: background 0.2s;
+            }
+            a:hover {
+                background: rgba(255, 255, 255, 0.2);
+            }
+        </style>
+    </head>
+    <body>
+        <main>
+            <p class="error-code">500</p>
+            <h1 class="error-title">Server Error</h1>
+            <p class="error-message">Something went wrong on our end. Please try again later.</p>
+            <a href="/">Go back home</a>
+        </main>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- Adds standalone `404.html` and `500.html` templates in `templates/`
- No template inheritance (`{% extends %}`) so they render reliably even during database or template loader failures
- Styled to match the site's green gradient theme with a large error code, descriptive message, and a "Go back home" button

Closes #51