### PR TITLE
:bug: Sort tags case-insensitively in thunderdome

### DIFF
--- a/thunderdome/models.py
+++ b/thunderdome/models.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.db.models import Avg
+from django.db.models.functions import Lower
 
 
 class Event(models.Model):
@@ -26,7 +27,7 @@ class Tag(models.Model):
     pretalx_id = models.CharField(max_length=100, blank=True, null=True, unique=True)
 
     class Meta:
-        ordering = ["name"]
+        ordering = [Lower("name")]
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Closes #68.

## Summary
- Switches `Tag.Meta.ordering` from `["name"]` to `[Lower("name")]` so tags sort alphabetically regardless of case (e.g. "community" no longer appears after "WebSockets").