### PR TITLE
:sparkles: Add superuser-only Tito ticket sales dashboard

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -13,7 +13,7 @@ from thunderdome.views import (
     sync_from_pretalx_view,
 )
 from tickets.views import claim_ticket_view, create_tickets_view, tickets_info, tickets_list_view
-from titowebhooks.views import sprint_tickets_view, tito_webhook
+from titowebhooks.views import sprint_tickets_view, tito_sales_dashboard_view, tito_webhook
 
 admin_header = f"DjangoCon US Automation v{__version__}"
 admin.site.enable_nav_sidebar = False
@@ -35,6 +35,7 @@ urlpatterns = [
     path("tickets/list/", tickets_list_view, name="tickets_list"),
     path("tickets/claim/", claim_ticket_view, name="claim_ticket"),
     path("sprints/tickets/", sprint_tickets_view, name="sprint_tickets"),
+    path("tito/sales/", tito_sales_dashboard_view, name="tito_sales_dashboard"),
     path("thunderdome/", submissions_view, name="thunderdome_submissions"),
     path("thunderdome/bulk-state/", bulk_set_state_view, name="thunderdome_bulk_state"),
     path("thunderdome/sync/", sync_from_pretalx_view, name="thunderdome_sync"),

--- a/templates/titowebhooks/sales_dashboard.html
+++ b/templates/titowebhooks/sales_dashboard.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+
+{% block body_class %}flex flex-col p-4 min-h-screen text-white bg-green-900 bg-gradient-to-b from-green-900 to-black via-green-950{% endblock %}
+{% block main_class %}flex-1 mx-auto text-white{% endblock %}
+
+{% block title %}Ticket Sales - DjangoCon US Automation{% endblock %}
+
+{% block content %}
+    <div class="p-6 mx-auto max-w-5xl">
+        <div class="flex justify-between items-center mb-6">
+            <div>
+                <a href="/" class="text-sm text-gray-400 hover:text-gray-200">&larr; Home</a>
+                <h1 class="text-3xl font-bold">Ticket Sales</h1>
+                {% if tito_event %}
+                    <p class="mt-1 text-sm text-gray-400">{{ tito_event.name }} &middot; data cached for {{ cache_ttl|floatformat:0 }}s</p>
+                {% endif %}
+            </div>
+        </div>
+
+        {% if error %}
+            <div class="p-4 mb-6 bg-red-800 rounded-lg">{{ error }}</div>
+        {% else %}
+
+            {% if activities %}
+                <h2 class="mb-3 text-xl font-semibold">Activities</h2>
+                <div class="overflow-hidden mb-8 bg-green-800 bg-opacity-30 rounded-lg">
+                    <table class="w-full">
+                        <thead class="bg-green-700 bg-opacity-50">
+                            <tr>
+                                <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Activity</th>
+                                <th class="py-3 px-4 text-xs font-medium tracking-wider text-right uppercase">Sold / Capacity</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-green-700">
+                            {% for activity in activities %}
+                                <tr class="transition-colors hover:bg-green-700 hover:bg-opacity-20">
+                                    <td class="py-3 px-4 text-sm">{{ activity.name }}</td>
+                                    <td class="py-3 px-4 text-sm font-mono text-right">
+                                        <span class="{% if activity.registrations_count > 0 %}text-green-400{% else %}text-gray-400{% endif %}">
+                                            {{ activity.registrations_count|default:0 }}
+                                        </span>
+                                        <span class="text-gray-500">/</span>
+                                        <span class="text-gray-300">{% if activity.capacity %}{{ activity.capacity }}{% else %}&infin;{% endif %}</span>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+
+            {% if releases %}
+                <h2 class="mb-3 text-xl font-semibold">Tickets</h2>
+                <div class="overflow-hidden bg-green-800 bg-opacity-30 rounded-lg">
+                    <table class="w-full">
+                        <thead class="bg-green-700 bg-opacity-50">
+                            <tr>
+                                <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Release</th>
+                                <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase">State</th>
+                                <th class="py-3 px-4 text-xs font-medium tracking-wider text-right uppercase">Sold / Capacity</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-green-700">
+                            {% for release in releases %}
+                                <tr class="transition-colors hover:bg-green-700 hover:bg-opacity-20">
+                                    <td class="py-3 px-4 text-sm">{{ release.title }}</td>
+                                    <td class="py-3 px-4 text-sm text-center">
+                                        <span class="inline-flex py-0.5 px-2 text-xs rounded-full
+                                            {% if release.state == 'on_sale' %}bg-green-800 text-green-200
+                                            {% elif release.state == 'paused' %}bg-yellow-800 text-yellow-200
+                                            {% else %}bg-gray-700 text-gray-300{% endif %}">
+                                            {{ release.state|default:"unknown" }}
+                                        </span>
+                                    </td>
+                                    <td class="py-3 px-4 text-sm font-mono text-right">
+                                        <span class="{% if release.tickets_count > 0 %}text-green-400{% else %}text-gray-400{% endif %}">
+                                            {{ release.tickets_count|default:0 }}
+                                        </span>
+                                        <span class="text-gray-500">/</span>
+                                        <span class="text-gray-300">{% if release.quantity %}{{ release.quantity }}{% else %}&infin;{% endif %}</span>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+
+            {% if not activities and not releases %}
+                <p class="text-gray-400">No data returned from Tito.</p>
+            {% endif %}
+
+        {% endif %}
+    </div>
+{% endblock %}

--- a/titowebhooks/tito_api.py
+++ b/titowebhooks/tito_api.py
@@ -1,0 +1,38 @@
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+TITO_API_BASE = "https://api.tito.io/v3"
+
+
+def _headers(api_token):
+    return {
+        "Authorization": f"Token token={api_token}",
+        "Accept": "application/json",
+    }
+
+
+def get_releases(account_slug, event_slug, api_token):
+    """Fetch all ticket releases for an event."""
+    url = f"{TITO_API_BASE}/{account_slug}/{event_slug}/releases"
+    try:
+        response = requests.get(url, headers=_headers(api_token), timeout=10)
+        response.raise_for_status()
+        return response.json().get("releases", [])
+    except Exception as exc:
+        logger.warning("Failed to fetch tito releases: %s", exc)
+        return None
+
+
+def get_activities(account_slug, event_slug, api_token):
+    """Fetch all activities for an event."""
+    url = f"{TITO_API_BASE}/{account_slug}/{event_slug}/activities"
+    try:
+        response = requests.get(url, headers=_headers(api_token), timeout=10)
+        response.raise_for_status()
+        return response.json().get("activities", [])
+    except Exception as exc:
+        logger.warning("Failed to fetch tito activities: %s", exc)
+        return None

--- a/titowebhooks/views.py
+++ b/titowebhooks/views.py
@@ -6,6 +6,8 @@ import json
 
 from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
+from django.contrib.auth.decorators import user_passes_test
+from django.core.cache import cache
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
@@ -13,7 +15,12 @@ from django_q.tasks import async_task
 from rich import print
 
 from emailoctopus.models import Campaign
-from titowebhooks.models import TitoWebhookEvent
+from titowebhooks.models import TitoEvent, TitoWebhookEvent
+from titowebhooks.tito_api import get_activities, get_releases
+
+superuser_required = user_passes_test(lambda u: u.is_active and u.is_superuser)
+
+TITO_CACHE_TTL = 300  # 5 minutes
 
 LEADER_QUESTION_ID = 1216404
 JOINER_QUESTION_ID = 1216405
@@ -194,3 +201,42 @@ def sprint_tickets_view(request: HttpRequest) -> HttpResponse:
         "friday_count": friday_count,
     }
     return render(request, "titowebhooks/sprint_tickets.html", context)
+
+
+@superuser_required
+def tito_sales_dashboard_view(request: HttpRequest) -> HttpResponse:
+    tito_event = TitoEvent.objects.filter(api_token__gt="").first()
+
+    releases = None
+    activities = None
+    error = None
+
+    if tito_event:
+        cache_key_releases = f"tito_releases_{tito_event.account_slug}_{tito_event.event_slug}"
+        cache_key_activities = f"tito_activities_{tito_event.account_slug}_{tito_event.event_slug}"
+
+        releases = cache.get(cache_key_releases)
+        if releases is None:
+            releases = get_releases(tito_event.account_slug, tito_event.event_slug, tito_event.api_token)
+            if releases is not None:
+                cache.set(cache_key_releases, releases, TITO_CACHE_TTL)
+
+        activities = cache.get(cache_key_activities)
+        if activities is None:
+            activities = get_activities(tito_event.account_slug, tito_event.event_slug, tito_event.api_token)
+            if activities is not None:
+                cache.set(cache_key_activities, activities, TITO_CACHE_TTL)
+
+        if releases is None and activities is None:
+            error = "Could not reach the Tito API. Check the API token and try again."
+    else:
+        error = "No Tito event with an API token is configured."
+
+    context = {
+        "tito_event": tito_event,
+        "releases": releases or [],
+        "activities": activities or [],
+        "error": error,
+        "cache_ttl": TITO_CACHE_TTL,
+    }
+    return render(request, "titowebhooks/sales_dashboard.html", context)


### PR DESCRIPTION
Closes #72.

## Summary
- New read-only dashboard at `/tito/sales/` (superuser-only).
- Fetches **Activities** (name, registrations/capacity) and **Ticket Releases** (title, state, sold/capacity) live from the Tito API v3.
- Uses the `api_token`, `account_slug`, and `event_slug` already stored on the first `TitoEvent` DB record with a token.
- API responses are cached for 5 minutes so page loads don't hammer Tito.
- Shows a clear error message if no token is configured or the API is unreachable.
- No write operations — nothing in Tito can be created or modified from this view.