### PR TITLE
:sparkles: Add online filter and dedup fixes to sprint tickets view (#75)

### DIFF
--- a/templates/titowebhooks/sprint_tickets.html
+++ b/templates/titowebhooks/sprint_tickets.html
@@ -12,14 +12,27 @@
                 <a href="/" class="text-sm text-gray-400 hover:text-gray-200">&larr; Home</a>
                 <h1 class="text-3xl font-bold">Sprint Tickets</h1>
             </div>
-            <a href="?format=csv"
-               class="py-2 px-4 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
-                Download CSV
-            </a>
+            <div class="flex gap-2">
+                {% if include_online %}
+                    <a href="?"
+                       class="py-2 px-4 font-semibold text-white bg-gray-700 rounded-lg hover:bg-gray-600 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                        Hide online
+                    </a>
+                {% else %}
+                    <a href="?include_online=1"
+                       class="py-2 px-4 font-semibold text-white bg-gray-700 rounded-lg hover:bg-gray-600 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                        Show online too
+                    </a>
+                {% endif %}
+                <a href="?format=csv{% if include_online %}&include_online=1{% endif %}"
+                   class="py-2 px-4 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                    Download CSV
+                </a>
+            </div>
         </div>
 
         <div class="p-4 mb-6 bg-green-800 bg-opacity-50 rounded-lg">
-            <div class="grid grid-cols-5 gap-4 text-center">
+            <div class="grid {% if include_online %}grid-cols-6{% else %}grid-cols-5{% endif %} gap-4 text-center">
                 <div>
                     <p class="text-2xl font-bold">{{ total_count }}</p>
                     <p class="text-sm text-gray-300">Total</p>
@@ -40,6 +53,12 @@
                     <p class="text-2xl font-bold text-green-400">{{ friday_count }}</p>
                     <p class="text-sm text-gray-300">Friday</p>
                 </div>
+                {% if include_online %}
+                    <div>
+                        <p class="text-2xl font-bold text-purple-400">{{ online_count }}</p>
+                        <p class="text-sm text-gray-300">Online</p>
+                    </div>
+                {% endif %}
             </div>
         </div>
 
@@ -60,6 +79,11 @@
                             <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase" colspan="2">
                                 Friday
                             </th>
+                            {% if include_online %}
+                                <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase">
+                                    Online
+                                </th>
+                            {% endif %}
                             <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">
                                 Ticket Date
                             </th>
@@ -70,6 +94,7 @@
                             <th class="py-1 px-4 text-xs font-medium tracking-wider text-center text-gray-400 uppercase">Joining</th>
                             <th class="py-1 px-4 text-xs font-medium tracking-wider text-center text-gray-400 uppercase">Leading</th>
                             <th class="py-1 px-4 text-xs font-medium tracking-wider text-center text-gray-400 uppercase">Joining</th>
+                            {% if include_online %}<th></th>{% endif %}
                             <th></th>
                         </tr>
                     </thead>
@@ -126,8 +151,17 @@
                                         <span class="text-gray-600">-</span>
                                     {% endif %}
                                 </td>
+                                {% if include_online %}
+                                    <td class="py-3 px-4 text-center whitespace-nowrap">
+                                        {% if ticket.online %}
+                                            <span class="inline-flex py-1 px-3 text-xs font-semibold leading-5 text-purple-200 bg-purple-800 rounded-full">Yes</span>
+                                        {% else %}
+                                            <span class="text-gray-600">-</span>
+                                        {% endif %}
+                                    </td>
+                                {% endif %}
                                 <td class="py-3 px-4 text-sm whitespace-nowrap">
-                                    {{ ticket.created_at }}
+                                    {{ ticket.created_at|date:"Y-m-d H:i" }}
                                 </td>
                             </tr>
                         {% endfor %}

--- a/titowebhooks/tests/test_views.py
+++ b/titowebhooks/tests/test_views.py
@@ -5,7 +5,12 @@ import json
 from unittest.mock import patch
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from titowebhooks.models import TitoWebhookEvent
+from titowebhooks.views import EVENT_SLUG, JOINER_QUESTION_ID, LEADER_QUESTION_ID
 
 TEST_PAYLOAD = {
     "_type": "ticket",
@@ -89,3 +94,154 @@ class TestTitoWebhookView(TestCase):
         signature = make_signature(payload_bytes, "wrong-token")
         response = self._post_webhook(payload_bytes, headers={"HTTP_TITO_SIGNATURE": signature})
         assert response.status_code == 403
+
+
+def _sprint_payload(*, email, release_title, created_at, leading="No", joining="No", name=None):
+    return {
+        "name": name or email.split("@")[0],
+        "email": email,
+        "release_title": release_title,
+        "created_at": created_at,
+        "event": {"slug": EVENT_SLUG},
+        "answers": [
+            {"question": {"id": LEADER_QUESTION_ID}, "humanized_response": leading},
+            {"question": {"id": JOINER_QUESTION_ID}, "humanized_response": joining},
+        ],
+    }
+
+
+@pytest.mark.django_db
+class TestSprintTicketsView(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.staff = User.objects.create_user(
+            username="staff", password="x", email="staff@example.com", is_staff=True
+        )
+        self.client.force_login(self.staff)
+
+    def _create_event(self, payload):
+        TitoWebhookEvent.objects.create(trigger="ticket.completed", payload=payload)
+
+    def test_excludes_online_sprints_by_default(self):
+        self._create_event(
+            _sprint_payload(
+                email="inperson@example.com",
+                release_title="Sprint (In Person) - Thursday",
+                created_at="2026-09-01T10:00:00Z",
+                leading="Yes",
+            )
+        )
+        self._create_event(
+            _sprint_payload(
+                email="onliner@example.com",
+                release_title="Online Sprint - Thursday",
+                created_at="2026-09-02T10:00:00Z",
+            )
+        )
+
+        response = self.client.get(reverse("sprint_tickets"))
+
+        assert response.status_code == 200
+        emails = [t["email"] for t in response.context["sprint_tickets"]]
+        assert "inperson@example.com" in emails
+        assert "onliner@example.com" not in emails
+        assert response.context["total_count"] == 1
+
+    def test_include_online_query_param_shows_online(self):
+        self._create_event(
+            _sprint_payload(
+                email="inperson@example.com",
+                release_title="Sprint (In Person) - Thursday",
+                created_at="2026-09-01T10:00:00Z",
+            )
+        )
+        self._create_event(
+            _sprint_payload(
+                email="onliner@example.com",
+                release_title="Online Sprint - Thursday",
+                created_at="2026-09-02T10:00:00Z",
+            )
+        )
+
+        response = self.client.get(reverse("sprint_tickets") + "?include_online=1")
+
+        assert response.status_code == 200
+        emails = [t["email"] for t in response.context["sprint_tickets"]]
+        assert {"inperson@example.com", "onliner@example.com"} <= set(emails)
+        assert response.context["online_count"] == 1
+        assert response.context["include_online"] is True
+
+    def test_email_dedup_is_case_insensitive(self):
+        self._create_event(
+            _sprint_payload(
+                email="Mixed@Example.com",
+                release_title="Sprint (In Person) - Thursday",
+                created_at="2026-09-01T10:00:00Z",
+                leading="Yes",
+            )
+        )
+        self._create_event(
+            _sprint_payload(
+                email="mixed@example.com",
+                release_title="Sprint (In Person) - Friday",
+                created_at="2026-09-02T10:00:00Z",
+                joining="Yes",
+            )
+        )
+
+        response = self.client.get(reverse("sprint_tickets"))
+
+        tickets = response.context["sprint_tickets"]
+        assert len(tickets) == 1
+        ticket = tickets[0]
+        assert ticket["email"] == "mixed@example.com"
+        assert ticket["thursday"] is True
+        assert ticket["thursday_leading"] == "Yes"
+        assert ticket["friday"] is True
+        assert ticket["friday_joining"] == "Yes"
+
+    def test_ignores_other_events_and_non_sprint_releases(self):
+        self._create_event(
+            _sprint_payload(
+                email="other-event@example.com",
+                release_title="Sprint (In Person) - Thursday",
+                created_at="2026-09-01T10:00:00Z",
+            )
+            | {"event": {"slug": "djangocon-us-2023"}}
+        )
+        self._create_event(
+            _sprint_payload(
+                email="conf-only@example.com",
+                release_title="In-person Conference",
+                created_at="2026-09-01T10:00:00Z",
+            )
+        )
+
+        response = self.client.get(reverse("sprint_tickets"))
+
+        assert response.context["total_count"] == 0
+
+    def test_csv_download_excludes_online_by_default(self):
+        self._create_event(
+            _sprint_payload(
+                email="inperson@example.com",
+                release_title="Sprint (In Person) - Thursday",
+                created_at="2026-09-01T10:00:00Z",
+            )
+        )
+        self._create_event(
+            _sprint_payload(
+                email="onliner@example.com",
+                release_title="Online Sprint - Thursday",
+                created_at="2026-09-02T10:00:00Z",
+            )
+        )
+
+        response = self.client.get(reverse("sprint_tickets") + "?format=csv")
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/csv"
+        body = response.content.decode()
+        assert "inperson@example.com" in body
+        assert "onliner@example.com" not in body
+        assert "Online" in body.splitlines()[0]

--- a/titowebhooks/views.py
+++ b/titowebhooks/views.py
@@ -3,6 +3,7 @@ import csv
 import hashlib
 import hmac
 import json
+from datetime import datetime, timezone
 
 from django.conf import settings
 from django.contrib import messages
@@ -82,7 +83,18 @@ def _get_answer(answers, question_id):
     return ""
 
 
-def _extract_sprint_tickets():
+def _parse_created_at(value: str):
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_online_release(release_title: str) -> bool:
+    return "online" in release_title.lower()
+
+
+def _extract_sprint_tickets(include_online: bool = False):
     events = TitoWebhookEvent.objects.filter(trigger="ticket.completed")
     # Collect per email+release, keeping most recent
     by_email_release = {}
@@ -100,9 +112,13 @@ def _extract_sprint_tickets():
         if "Sprint" not in release_title:
             continue
 
+        is_online = _is_online_release(release_title)
+        if is_online and not include_online:
+            continue
+
         answers = payload.get("answers", [])
-        email = payload.get("email", "")
-        created_at = payload.get("created_at", "")
+        email = (payload.get("email") or "").strip().lower()
+        created_at = _parse_created_at(payload.get("created_at", "")) or datetime.min.replace(tzinfo=timezone.utc)
 
         key = (email, release_title)
         if key not in by_email_release or created_at > by_email_release[key]["created_at"]:
@@ -110,6 +126,7 @@ def _extract_sprint_tickets():
                 "name": payload.get("name", ""),
                 "email": email,
                 "release_title": release_title,
+                "is_online": is_online,
                 "leading": _get_answer(answers, LEADER_QUESTION_ID),
                 "joining": _get_answer(answers, JOINER_QUESTION_ID),
                 "created_at": created_at,
@@ -129,12 +146,16 @@ def _extract_sprint_tickets():
                 "friday": False,
                 "friday_leading": "",
                 "friday_joining": "",
+                "online": False,
                 "created_at": ticket["created_at"],
             }
 
         if ticket["created_at"] > people[email]["created_at"]:
             people[email]["created_at"] = ticket["created_at"]
             people[email]["name"] = ticket["name"]
+
+        if ticket["is_online"]:
+            people[email]["online"] = True
 
         if "Thursday" in ticket["release_title"]:
             people[email]["thursday"] = True
@@ -150,7 +171,8 @@ def _extract_sprint_tickets():
 
 @staff_member_required
 def sprint_tickets_view(request: HttpRequest) -> HttpResponse:
-    sprint_tickets = _extract_sprint_tickets()
+    include_online = request.GET.get("include_online") == "1"
+    sprint_tickets = _extract_sprint_tickets(include_online=include_online)
 
     if request.GET.get("format") == "csv":
         response = HttpResponse(content_type="text/csv")
@@ -166,6 +188,7 @@ def sprint_tickets_view(request: HttpRequest) -> HttpResponse:
                 "Friday",
                 "Friday Leading",
                 "Friday Joining",
+                "Online",
                 "Ticket Date",
             ]
         )
@@ -180,7 +203,8 @@ def sprint_tickets_view(request: HttpRequest) -> HttpResponse:
                     "Yes" if ticket["friday"] else "",
                     ticket["friday_leading"],
                     ticket["friday_joining"],
-                    ticket["created_at"],
+                    "Yes" if ticket["online"] else "",
+                    ticket["created_at"].isoformat() if ticket["created_at"] else "",
                 ]
             )
         return response
@@ -189,6 +213,7 @@ def sprint_tickets_view(request: HttpRequest) -> HttpResponse:
     joiners_count = sum(1 for t in sprint_tickets if t["thursday_joining"] == "Yes" or t["friday_joining"] == "Yes")
     thursday_count = sum(1 for t in sprint_tickets if t["thursday"])
     friday_count = sum(1 for t in sprint_tickets if t["friday"])
+    online_count = sum(1 for t in sprint_tickets if t["online"])
 
     context = {
         "sprint_tickets": sprint_tickets,
@@ -197,6 +222,8 @@ def sprint_tickets_view(request: HttpRequest) -> HttpResponse:
         "joiners_count": joiners_count,
         "thursday_count": thursday_count,
         "friday_count": friday_count,
+        "online_count": online_count,
+        "include_online": include_online,
     }
     return render(request, "titowebhooks/sprint_tickets.html", context)
 


### PR DESCRIPTION
## Summary
- `/sprints/tickets/` now defaults to in-person only, with a "Show online too" / "Hide online" toggle that also threads into the CSV download
- Email dedup is case-insensitive and `created_at` is parsed to a `datetime` for stable sorting/comparison
- Adds first test coverage for the sprint tickets view: default filtering, `?include_online=1`, case-insensitive consolidation, slug/release filtering, CSV output

Refs #75. Scoped to current-year prep — historical (past 3 years) backfill is deferred per discussion.