### PR TITLE
:sparkles: Add Download Historical sprint attendees CSV (#75)

### DIFF
--- a/templates/titowebhooks/sprint_tickets.html
+++ b/templates/titowebhooks/sprint_tickets.html
@@ -28,6 +28,11 @@
                    class="py-2 px-4 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                     Download CSV
                 </a>
+                <a href="?scope=historical&format=csv{% if include_online %}&include_online=1{% endif %}"
+                   title="In-person sprint attendees across the last {{ historical_years }} conference years"
+                   class="py-2 px-4 font-semibold text-white bg-green-700 rounded-lg hover:bg-green-800 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                    Download Historical
+                </a>
             </div>
         </div>
 

--- a/titowebhooks/tests/test_views.py
+++ b/titowebhooks/tests/test_views.py
@@ -245,3 +245,158 @@ class TestSprintTicketsView(TestCase):
         assert "inperson@example.com" in body
         assert "onliner@example.com" not in body
         assert "Online" in body.splitlines()[0]
+
+
+def _historical_payload(*, email, release_title, created_at, year, leading="No", joining="No", name=None):
+    slug = f"djangocon-us-{year}"
+    return {
+        "name": name or email.split("@")[0],
+        "email": email,
+        "release_title": release_title,
+        "created_at": created_at,
+        "event": {"slug": slug, "title": f"DjangoCon US {year}"},
+        "answers": [
+            {"question": {"id": LEADER_QUESTION_ID}, "humanized_response": leading},
+            {"question": {"id": JOINER_QUESTION_ID}, "humanized_response": joining},
+        ],
+    }
+
+
+@pytest.mark.django_db
+class TestHistoricalSprintTicketsCsv(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.staff = User.objects.create_user(
+            username="staff", password="x", email="staff@example.com", is_staff=True
+        )
+        self.client.force_login(self.staff)
+
+    def _create_event(self, payload):
+        TitoWebhookEvent.objects.create(trigger="ticket.completed", payload=payload)
+
+    def _download(self, query=""):
+        response = self.client.get(reverse("sprint_tickets") + "?scope=historical&format=csv" + query)
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/csv"
+        assert "sprint_tickets_historical.csv" in response["Content-Disposition"]
+        return response.content.decode()
+
+    def test_spans_multiple_years_with_event_and_year_columns(self):
+        self._create_event(
+            _historical_payload(
+                email="alice@example.com",
+                release_title="Sprint (In Person) - Thursday",
+                created_at="2024-09-01T10:00:00Z",
+                year=2024,
+            )
+        )
+        self._create_event(
+            _historical_payload(
+                email="bob@example.com",
+                release_title="Sprint (In Person) - Friday",
+                created_at="2026-09-01T10:00:00Z",
+                year=2026,
+            )
+        )
+
+        body = self._download()
+
+        header = body.splitlines()[0]
+        assert header.startswith("Year,Event,Name,Email")
+        assert "DjangoCon US 2024" in body
+        assert "DjangoCon US 2026" in body
+        assert "alice@example.com" in body
+        assert "bob@example.com" in body
+
+    def test_excludes_online_sprints_by_default(self):
+        self._create_event(
+            _historical_payload(
+                email="inperson@example.com",
+                release_title="Sprint (In Person) - Thursday",
+                created_at="2025-09-01T10:00:00Z",
+                year=2025,
+            )
+        )
+        self._create_event(
+            _historical_payload(
+                email="onliner@example.com",
+                release_title="Online Sprint - Thursday",
+                created_at="2025-09-02T10:00:00Z",
+                year=2025,
+            )
+        )
+
+        body = self._download()
+
+        assert "inperson@example.com" in body
+        assert "onliner@example.com" not in body
+
+    def test_include_online_query_param_shows_online(self):
+        self._create_event(
+            _historical_payload(
+                email="onliner@example.com",
+                release_title="Online Sprint - Thursday",
+                created_at="2025-09-02T10:00:00Z",
+                year=2025,
+            )
+        )
+
+        body = self._download(query="&include_online=1")
+
+        assert "onliner@example.com" in body
+
+    def test_one_row_per_person_per_year_merges_days(self):
+        self._create_event(
+            _historical_payload(
+                email="repeat@example.com",
+                release_title="Sprint (In Person) - Thursday",
+                created_at="2025-09-01T10:00:00Z",
+                year=2025,
+                leading="Yes",
+            )
+        )
+        self._create_event(
+            _historical_payload(
+                email="repeat@example.com",
+                release_title="Sprint (In Person) - Friday",
+                created_at="2025-09-02T10:00:00Z",
+                year=2025,
+                joining="Yes",
+            )
+        )
+        # Same person, different year -> separate row.
+        self._create_event(
+            _historical_payload(
+                email="repeat@example.com",
+                release_title="Sprint (In Person) - Thursday",
+                created_at="2024-09-01T10:00:00Z",
+                year=2024,
+            )
+        )
+
+        body = self._download()
+        rows = [line for line in body.splitlines()[1:] if "repeat@example.com" in line]
+        assert len(rows) == 2
+        merged_2025 = next(r for r in rows if r.startswith("2025"))
+        # Both Thursday (leading) and Friday (joining) captured on one row.
+        assert merged_2025.count("Yes") >= 2
+
+    def test_limits_to_most_recent_three_years(self):
+        for year in (2022, 2023, 2024, 2025, 2026):
+            self._create_event(
+                _historical_payload(
+                    email=f"y{year}@example.com",
+                    release_title="Sprint (In Person) - Thursday",
+                    created_at=f"{year}-09-01T10:00:00Z",
+                    year=year,
+                )
+            )
+
+        body = self._download()
+
+        # Most recent year is 2026, so window is 2024-2026.
+        assert "y2026@example.com" in body
+        assert "y2025@example.com" in body
+        assert "y2024@example.com" in body
+        assert "y2023@example.com" not in body
+        assert "y2022@example.com" not in body

--- a/titowebhooks/views.py
+++ b/titowebhooks/views.py
@@ -3,6 +3,7 @@ import csv
 import hashlib
 import hmac
 import json
+import re
 from datetime import datetime, timezone
 
 from django.conf import settings
@@ -24,6 +25,10 @@ superuser_required = user_passes_test(lambda u: u.is_active and u.is_superuser)
 LEADER_QUESTION_ID = 1216404
 JOINER_QUESTION_ID = 1216405
 EVENT_SLUG = "djangocon-us-2026"
+
+# How many conference years the "Download Historical" export reaches back, counting
+# from the most recent year present in the data (e.g. 3 -> current + two prior years).
+HISTORICAL_YEARS = 3
 
 
 def verify_tito_signature(payload_body: bytes, signature: str, security_token: str) -> bool:
@@ -92,6 +97,116 @@ def _parse_created_at(value: str):
 
 def _is_online_release(release_title: str) -> bool:
     return "online" in release_title.lower()
+
+
+def _event_year(payload: dict) -> int | None:
+    """Best-effort conference year for a webhook payload.
+
+    Prefers the year embedded in the event slug (e.g. ``djangocon-us-2023``),
+    then falls back to the event start/end dates, then the ticket created_at.
+    """
+    event = payload.get("event", {}) or {}
+    for source in (event.get("slug", ""), event.get("end_date", ""), event.get("start_date", "")):
+        match = re.search(r"(20\d{2})", source or "")
+        if match:
+            return int(match.group(1))
+    created_at = _parse_created_at(payload.get("created_at", ""))
+    return created_at.year if created_at else None
+
+
+def _extract_historical_sprints(include_online: bool = False, years: int | None = HISTORICAL_YEARS):
+    """One row per person per conference year, across all events in the webhook log.
+
+    Used by the "Download Historical" export so the sprints team can see who has
+    attended in-person sprints over the last few years. Online sprints are excluded
+    unless ``include_online`` is set. ``years`` limits the result to the most recent
+    N conference years present in the data (``None`` keeps every year).
+    """
+    events = TitoWebhookEvent.objects.filter(trigger="ticket.completed")
+    # Collect per email+year+release, keeping most recent.
+    by_email_year_release = {}
+
+    for event in events:
+        payload = event.payload
+        if not payload:
+            continue
+
+        release_title = payload.get("release_title", "")
+        if "Sprint" not in release_title:
+            continue
+
+        is_online = _is_online_release(release_title)
+        if is_online and not include_online:
+            continue
+
+        year = _event_year(payload)
+        if year is None:
+            continue
+
+        answers = payload.get("answers", [])
+        email = (payload.get("email") or "").strip().lower()
+        created_at = _parse_created_at(payload.get("created_at", "")) or datetime.min.replace(tzinfo=timezone.utc)
+        event_data = payload.get("event", {}) or {}
+        event_title = event_data.get("title", "") or event_data.get("slug", "")
+
+        key = (email, year, release_title)
+        if key not in by_email_year_release or created_at > by_email_year_release[key]["created_at"]:
+            by_email_year_release[key] = {
+                "name": payload.get("name", ""),
+                "email": email,
+                "year": year,
+                "event_title": event_title,
+                "release_title": release_title,
+                "is_online": is_online,
+                "leading": _get_answer(answers, LEADER_QUESTION_ID),
+                "joining": _get_answer(answers, JOINER_QUESTION_ID),
+                "created_at": created_at,
+            }
+
+    # Limit to the most recent N conference years present in the data.
+    if years and by_email_year_release:
+        max_year = max(t["year"] for t in by_email_year_release.values())
+        cutoff = max_year - years + 1
+        by_email_year_release = {k: v for k, v in by_email_year_release.items() if v["year"] >= cutoff}
+
+    # Consolidate to one row per person per year.
+    people = {}
+    for ticket in by_email_year_release.values():
+        person_key = (ticket["email"], ticket["year"])
+        if person_key not in people:
+            people[person_key] = {
+                "name": ticket["name"],
+                "email": ticket["email"],
+                "year": ticket["year"],
+                "event_title": ticket["event_title"],
+                "thursday": False,
+                "thursday_leading": "",
+                "thursday_joining": "",
+                "friday": False,
+                "friday_leading": "",
+                "friday_joining": "",
+                "online": False,
+                "created_at": ticket["created_at"],
+            }
+
+        person = people[person_key]
+        if ticket["created_at"] > person["created_at"]:
+            person["created_at"] = ticket["created_at"]
+            person["name"] = ticket["name"]
+
+        if ticket["is_online"]:
+            person["online"] = True
+
+        if "Thursday" in ticket["release_title"]:
+            person["thursday"] = True
+            person["thursday_leading"] = ticket["leading"]
+            person["thursday_joining"] = ticket["joining"]
+        elif "Friday" in ticket["release_title"]:
+            person["friday"] = True
+            person["friday_leading"] = ticket["leading"]
+            person["friday_joining"] = ticket["joining"]
+
+    return sorted(people.values(), key=lambda t: (-t["year"], (t["name"] or "").lower()))
 
 
 def _extract_sprint_tickets(include_online: bool = False):
@@ -169,9 +284,54 @@ def _extract_sprint_tickets(include_online: bool = False):
     return sorted(people.values(), key=lambda t: t["created_at"], reverse=True)
 
 
+def _historical_sprints_csv(include_online: bool) -> HttpResponse:
+    rows = _extract_historical_sprints(include_online=include_online)
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = 'attachment; filename="sprint_tickets_historical.csv"'
+    writer = csv.writer(response)
+    writer.writerow(
+        [
+            "Year",
+            "Event",
+            "Name",
+            "Email",
+            "Thursday",
+            "Thursday Leading",
+            "Thursday Joining",
+            "Friday",
+            "Friday Leading",
+            "Friday Joining",
+            "Online",
+            "Ticket Date",
+        ]
+    )
+    for row in rows:
+        writer.writerow(
+            [
+                row["year"],
+                row["event_title"],
+                row["name"],
+                row["email"],
+                "Yes" if row["thursday"] else "",
+                row["thursday_leading"],
+                row["thursday_joining"],
+                "Yes" if row["friday"] else "",
+                row["friday_leading"],
+                row["friday_joining"],
+                "Yes" if row["online"] else "",
+                row["created_at"].isoformat() if row["created_at"] else "",
+            ]
+        )
+    return response
+
+
 @staff_member_required
 def sprint_tickets_view(request: HttpRequest) -> HttpResponse:
     include_online = request.GET.get("include_online") == "1"
+
+    if request.GET.get("scope") == "historical" and request.GET.get("format") == "csv":
+        return _historical_sprints_csv(include_online=include_online)
+
     sprint_tickets = _extract_sprint_tickets(include_online=include_online)
 
     if request.GET.get("format") == "csv":
@@ -224,6 +384,7 @@ def sprint_tickets_view(request: HttpRequest) -> HttpResponse:
         "friday_count": friday_count,
         "online_count": online_count,
         "include_online": include_online,
+        "historical_years": HISTORICAL_YEARS,
     }
     return render(request, "titowebhooks/sprint_tickets.html", context)
 


### PR DESCRIPTION
## Summary

Closes #75.

The sprints team wants the name, email, and conference year for in-person sprint attendees going back a few years, for prep work. The existing **Sprint Tickets** page (`/sprints/tickets/`) only covers the current event (`djangocon-us-2026`), so this adds a **Download Historical** button that exports a CSV spanning the most recent 3 conference years present in the webhook log.

## What's included

- **`_event_year(payload)`** — best-effort conference year from the event slug (`djangocon-us-2023`), falling back to event start/end dates, then `created_at`.
- **`_extract_historical_sprints(...)`** — one row per person *per conference year* across all `ticket.completed` webhook events, with `Year` and `Event` columns. Dedups per email/year/release keeping the most recent, and merges Thursday/Friday onto a single row.
- **`Download Historical` button** next to the existing **Download CSV** button.
- Online sprints are **excluded by default**, matching the existing page (respects `?include_online=1`).
- The window is limited to the most recent `HISTORICAL_YEARS` (3) years *present in the data*, so it tracks the data rather than the wall clock.

CSV columns: `Year, Event, Name, Email, Thursday, Thursday Leading, Thursday Joining, Friday, Friday Leading, Friday Joining, Online, Ticket Date`.

## Note on data completeness

As discussed on the issue, historical webhook coverage has gaps (periods where fly.io services were down). This export surfaces everything we *do* have captured; it's not a guarantee of completeness for past years.

## Testing

Added `TestHistoricalSprintTicketsCsv` covering multi-year spanning, online exclusion / inclusion, one-row-per-person-per-year merging, and the 3-year window. Full `titowebhooks/tests/test_views.py` suite passes (15 tests).