### PR TITLE
Add dashboard schedule-sync button with dry-run preview

### DIFF
--- a/volunteers/management/commands/import_schedule.py
+++ b/volunteers/management/commands/import_schedule.py
@@ -53,11 +53,20 @@ class Command(BaseCommand):
         self.stdout.write(f"Found {len(events)} event(s)")
 
         if dry_run:
+            existing = set(Shift.objects.values_list("external_uid", flat=True))
+            new_count = 0
+            update_count = 0
             for ev in events:
-                self.stdout.write(
-                    f"  [dry-run] {ev['summary']} | {ev['dtstart']} – {ev['dtend']} | {ev.get('location', '')}"
-                )
-            self.stdout.write(self.style.SUCCESS(f"Would import {len(events)} shift(s)."))
+                is_new = ev["uid"] not in existing
+                if is_new:
+                    new_count += 1
+                else:
+                    update_count += 1
+                label = "NEW" if is_new else "update"
+                self.stdout.write(f"  [dry-run] [{label}] {ev['summary']} | {ev['dtstart']} – {ev.get('location', '')}")
+            self.stdout.write(
+                self.style.SUCCESS(f"Would create {new_count} new, update {update_count} existing shift(s).")
+            )
             return
 
         role, _ = Role.objects.get_or_create(name=role_name)

--- a/volunteers/management/commands/import_schedule.py
+++ b/volunteers/management/commands/import_schedule.py
@@ -8,6 +8,20 @@ from volunteers.models import Role, Shift
 
 DEFAULT_URL = "https://2026.djangocon.us/schedule.ics"
 
+# Schedule entries that aren't talks and so don't need a volunteer session chair.
+# Matched case-insensitively against the event title.
+DEFAULT_SKIP_KEYWORDS = [
+    "orientation",
+    "opening remarks",
+    "closing remarks",
+    "keynote",
+    "lightning talks",
+    "break",
+    "lunch",
+    "registration",
+    "reception",
+]
+
 
 class Command(BaseCommand):
     help = (
@@ -32,11 +46,28 @@ class Command(BaseCommand):
             action="store_true",
             help="Parse and show what would be imported without writing to the database.",
         )
+        parser.add_argument(
+            "--no-skip",
+            action="store_true",
+            help="Import every event, including non-talk entries (keynotes, breaks, remarks).",
+        )
+        parser.add_argument(
+            "--skip-keyword",
+            action="append",
+            dest="skip_keywords",
+            metavar="KEYWORD",
+            help="Title keyword to skip (case-insensitive). Repeatable; overrides the defaults.",
+        )
 
     def handle(self, *args, **options):
         url = options["url"]
         role_name = options["role"]
         dry_run = options["dry_run"]
+
+        if options["no_skip"]:
+            skip_keywords = []
+        else:
+            skip_keywords = [k.lower() for k in (options["skip_keywords"] or DEFAULT_SKIP_KEYWORDS)]
 
         self.stdout.write(f"Fetching {url}")
         try:
@@ -51,6 +82,13 @@ class Command(BaseCommand):
             return
 
         self.stdout.write(f"Found {len(events)} event(s)")
+
+        if skip_keywords:
+            kept = [ev for ev in events if not self._should_skip(ev["summary"], skip_keywords)]
+            skipped = len(events) - len(kept)
+            if skipped:
+                self.stdout.write(f"Skipping {skipped} non-talk event(s) (keynotes, breaks, remarks, etc.)")
+            events = kept
 
         if dry_run:
             existing = set(Shift.objects.values_list("external_uid", flat=True))
@@ -94,6 +132,10 @@ class Command(BaseCommand):
                 updated += 1
 
         self.stdout.write(self.style.SUCCESS(f"Created {created}, updated {updated} shift(s)."))
+
+    def _should_skip(self, summary, skip_keywords):
+        title = (summary or "").lower()
+        return any(keyword in title for keyword in skip_keywords)
 
     def _parse_ics(self, raw):
         """Minimal ICS parser — handles TZID datetimes and line unfolding."""

--- a/volunteers/templates/volunteers/dashboard.html
+++ b/volunteers/templates/volunteers/dashboard.html
@@ -6,7 +6,33 @@
 
 {% block content %}
     <div class="flex flex-col gap-6 p-8 text-green-100">
-        <h1 class="text-4xl font-bold text-yellow-200">Volunteer Dashboard</h1>
+        <div class="flex flex-wrap gap-3 justify-between items-center">
+            <h1 class="text-4xl font-bold text-yellow-200">Volunteer Dashboard</h1>
+            <div class="flex gap-2">
+                <form method="post" action="{% url 'volunteers:sync_schedule' %}">
+                    {% csrf_token %}
+                    <input type="hidden" name="dry_run" value="1">
+                    <button type="submit" class="px-3 py-2 text-sm font-medium text-green-100 bg-green-700 rounded-md border border-green-600 hover:bg-green-600">
+                        Preview schedule sync
+                    </button>
+                </form>
+                <form method="post" action="{% url 'volunteers:sync_schedule' %}"
+                      onsubmit="return confirm('Sync shifts from the conference schedule? Existing slots and signups are kept.');">
+                    {% csrf_token %}
+                    <button type="submit" class="px-3 py-2 text-sm font-semibold text-green-900 bg-yellow-300 rounded-md hover:bg-yellow-200">
+                        Sync schedule now
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        {% if messages %}
+            {% for message in messages %}
+                <div class="p-4 rounded-md {% if message.tags == 'success' %}bg-green-700 border border-green-600 text-green-100{% elif message.tags == 'error' %}bg-red-700 border border-red-600 text-red-100{% else %}bg-blue-800 border border-blue-600 text-blue-100{% endif %}">
+                    {{ message }}
+                </div>
+            {% endfor %}
+        {% endif %}
 
         <form method="get" class="flex flex-wrap gap-3 items-end p-4 bg-green-800 rounded-lg border border-green-700">
             <div>

--- a/volunteers/templates/volunteers/dashboard.html
+++ b/volunteers/templates/volunteers/dashboard.html
@@ -110,7 +110,9 @@
                                         {% if shift.location %}<span class="block text-xs text-green-400">{{ shift.location }}</span>{% endif %}
                                     </td>
                                     <td class="p-3 text-green-200">{{ shift.role.name }}</td>
-                                    <td class="p-3 text-sm text-green-300">{{ shift.starts_at|date:"g:i A" }}–{{ shift.ends_at|date:"g:i A" }}</td>
+                                    <td class="p-3 text-sm text-green-300">
+                                        <time datetime="{{ shift.starts_at|date:'c' }}" class="whitespace-nowrap">{{ shift.starts_at|date:"g:i A" }}</time>–<time datetime="{{ shift.ends_at|date:'c' }}" class="whitespace-nowrap">{{ shift.ends_at|date:"g:i A" }}</time>
+                                    </td>
                                     <td class="p-3 {% if shift.filled_count < shift.capacity %}text-red-300{% else %}text-green-300{% endif %}">
                                         {{ shift.filled_count }}/{{ shift.capacity }}
                                     </td>

--- a/volunteers/templates/volunteers/dashboard.html
+++ b/volunteers/templates/volunteers/dashboard.html
@@ -88,42 +88,47 @@
             </div>
         </div>
 
-        <div class="overflow-x-auto">
-            <table class="w-full text-left border-collapse">
-                <thead>
-                    <tr class="text-yellow-300 border-b border-green-700">
-                        <th class="p-3">Shift</th>
-                        <th class="p-3">Role</th>
-                        <th class="p-3">When</th>
-                        <th class="p-3">Filled</th>
-                        <th class="p-3">Volunteers</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for shift in shifts %}
-                        <tr class="border-b border-green-800 {% if shift.filled_count < shift.capacity %}bg-green-900/40{% endif %}">
-                            <td class="p-3 font-medium text-yellow-100">
-                                {{ shift.title }}
-                                {% if shift.location %}<span class="block text-xs text-green-400">{{ shift.location }}</span>{% endif %}
-                            </td>
-                            <td class="p-3 text-green-200">{{ shift.role.name }}</td>
-                            <td class="p-3 text-sm text-green-300">{{ shift.starts_at|date:"M j, g:i A" }}–{{ shift.ends_at|date:"g:i A" }}</td>
-                            <td class="p-3 {% if shift.filled_count < shift.capacity %}text-red-300{% else %}text-green-300{% endif %}">
-                                {{ shift.filled_count }}/{{ shift.capacity }}
-                            </td>
-                            <td class="p-3 text-sm text-green-200">
-                                {% for user in shift.roster %}
-                                    {{ user.email }}{% if not forloop.last %}, {% endif %}
-                                {% empty %}
-                                    <span class="text-green-500">— open —</span>
-                                {% endfor %}
-                            </td>
-                        </tr>
-                    {% empty %}
-                        <tr><td colspan="5" class="p-3 text-green-300">No shifts created yet.</td></tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+        {% for day, day_shifts in days %}
+            <section class="flex flex-col gap-2">
+                <h2 class="text-2xl font-semibold text-yellow-300">{{ day|date:"l, F j" }}</h2>
+                <div class="overflow-x-auto">
+                    <table class="w-full text-left border-collapse">
+                        <thead>
+                            <tr class="text-yellow-300 border-b border-green-700">
+                                <th class="p-3">Shift</th>
+                                <th class="p-3">Role</th>
+                                <th class="p-3">When</th>
+                                <th class="p-3">Filled</th>
+                                <th class="p-3">Volunteers</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for shift in day_shifts %}
+                                <tr class="border-b border-green-800 {% if shift.filled_count < shift.capacity %}bg-green-900/40{% endif %}">
+                                    <td class="p-3 font-medium text-yellow-100">
+                                        {{ shift.title }}
+                                        {% if shift.location %}<span class="block text-xs text-green-400">{{ shift.location }}</span>{% endif %}
+                                    </td>
+                                    <td class="p-3 text-green-200">{{ shift.role.name }}</td>
+                                    <td class="p-3 text-sm text-green-300">{{ shift.starts_at|date:"g:i A" }}–{{ shift.ends_at|date:"g:i A" }}</td>
+                                    <td class="p-3 {% if shift.filled_count < shift.capacity %}text-red-300{% else %}text-green-300{% endif %}">
+                                        {{ shift.filled_count }}/{{ shift.capacity }}
+                                    </td>
+                                    <td class="p-3 text-sm text-green-200">
+                                        {% for user in shift.roster %}
+                                            {{ user.email }}{% if not forloop.last %}, {% endif %}
+                                        {% empty %}
+                                            <span class="text-green-500">— open —</span>
+                                        {% endfor %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        {% empty %}
+            <p class="text-green-300">No shifts created yet.</p>
+        {% endfor %}
     </div>
 {% endblock content %}

--- a/volunteers/templates/volunteers/my_shifts.html
+++ b/volunteers/templates/volunteers/my_shifts.html
@@ -32,7 +32,7 @@
                         <p class="text-lg font-semibold text-yellow-100">{{ signup.shift.title }}</p>
                         <p class="text-sm text-green-300">
                             {{ signup.shift.role.name }} ·
-                            {{ signup.shift.starts_at|date:"l, F j, g:i A" }}–{{ signup.shift.ends_at|date:"g:i A" }}
+                            <time datetime="{{ signup.shift.starts_at|date:'c' }}">{{ signup.shift.starts_at|date:"l, F j," }} <span class="whitespace-nowrap">{{ signup.shift.starts_at|date:"g:i A" }}</span></time>–<time datetime="{{ signup.shift.ends_at|date:'c' }}" class="whitespace-nowrap">{{ signup.shift.ends_at|date:"g:i A" }}</time>
                             {% if signup.shift.location %} · {{ signup.shift.location }}{% endif %}
                         </p>
                         {% if signup.shift.role.documentation_url %}

--- a/volunteers/templates/volunteers/shift_list.html
+++ b/volunteers/templates/volunteers/shift_list.html
@@ -70,6 +70,13 @@
                                 {% if shift.description %}
                                     <p class="mt-1 text-sm text-green-200">{{ shift.description }}</p>
                                 {% endif %}
+                                {% if shift.talk_url %}
+                                    <p class="mt-1 text-xs">
+                                        <a href="{{ shift.talk_url }}" target="_blank" rel="noopener" class="underline text-yellow-300">
+                                            🔗 View talk on the schedule
+                                        </a>
+                                    </p>
+                                {% endif %}
                                 {% if shift.role.documentation_url %}
                                     <p class="mt-1 text-xs">
                                         <a href="{{ shift.role.documentation_url }}" target="_blank" rel="noopener" class="underline text-yellow-300">

--- a/volunteers/templates/volunteers/shift_list.html
+++ b/volunteers/templates/volunteers/shift_list.html
@@ -64,7 +64,7 @@
                                 <p class="text-lg font-semibold text-yellow-100">{{ shift.title }}</p>
                                 <p class="text-sm text-green-300">
                                     {{ shift.role.name }} ·
-                                    {{ shift.starts_at|date:"g:i A" }}–{{ shift.ends_at|date:"g:i A" }}
+                                    <time datetime="{{ shift.starts_at|date:'c' }}" class="whitespace-nowrap">{{ shift.starts_at|date:"g:i A" }}</time>–<time datetime="{{ shift.ends_at|date:'c' }}" class="whitespace-nowrap">{{ shift.ends_at|date:"g:i A" }}</time>
                                     {% if shift.location %} · {{ shift.location }}{% endif %}
                                 </p>
                                 {% if shift.description %}

--- a/volunteers/tests/test_import_schedule.py
+++ b/volunteers/tests/test_import_schedule.py
@@ -57,7 +57,7 @@ def mock_ics_response():
 @pytest.mark.django_db
 def test_import_schedule_dry_run(mock_ics_response):
     out = StringIO()
-    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--dry-run", stdout=out)
+    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--no-skip", "--dry-run", stdout=out)
 
     output = out.getvalue()
     assert "Found 2 event(s)" in output
@@ -71,10 +71,10 @@ def test_import_schedule_dry_run(mock_ics_response):
 @pytest.mark.django_db
 def test_import_schedule_dry_run_reports_updates(mock_ics_response):
     # First import for real, then dry-run should report both as updates, not new.
-    call_command("import_schedule", "--url=https://example.com/schedule.ics", stdout=StringIO())
+    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--no-skip", stdout=StringIO())
 
     out = StringIO()
-    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--dry-run", stdout=out)
+    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--no-skip", "--dry-run", stdout=out)
     output = out.getvalue()
     assert "Would create 0 new, update 2 existing shift(s)" in output
     assert "[update]" in output
@@ -83,7 +83,7 @@ def test_import_schedule_dry_run_reports_updates(mock_ics_response):
 @pytest.mark.django_db
 def test_import_schedule_creates_shifts(mock_ics_response):
     out = StringIO()
-    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--role=Session Chair", stdout=out)
+    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--no-skip", "--role=Session Chair", stdout=out)
 
     output = out.getvalue()
     assert "Created 2" in output
@@ -100,13 +100,35 @@ def test_import_schedule_creates_shifts(mock_ics_response):
 
 @pytest.mark.django_db
 def test_import_schedule_idempotent(mock_ics_response):
-    call_command("import_schedule", "--url=https://example.com/schedule.ics", stdout=StringIO())
+    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--no-skip", stdout=StringIO())
     assert Shift.objects.count() == 2
 
     out = StringIO()
-    call_command("import_schedule", "--url=https://example.com/schedule.ics", stdout=out)
+    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--no-skip", stdout=out)
     output = out.getvalue()
 
     assert "Created 0" in output
     assert "updated 2" in output
     assert Shift.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_import_schedule_skips_non_talks_by_default(mock_ics_response):
+    # "Opening Keynote" matches the default skip list; "Building Better APIs" doesn't.
+    out = StringIO()
+    call_command("import_schedule", "--url=https://example.com/schedule.ics", stdout=out)
+
+    assert "Skipping 1 non-talk event(s)" in out.getvalue()
+    assert Shift.objects.count() == 1
+    assert Shift.objects.filter(title="Building Better APIs").exists()
+    assert not Shift.objects.filter(title="Opening Keynote").exists()
+
+
+@pytest.mark.django_db
+def test_import_schedule_custom_skip_keyword(mock_ics_response):
+    out = StringIO()
+    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--skip-keyword=api", stdout=out)
+
+    # Only "Building Better APIs" matches "api"; the keynote is kept (defaults overridden).
+    assert Shift.objects.filter(title="Opening Keynote").exists()
+    assert not Shift.objects.filter(title="Building Better APIs").exists()

--- a/volunteers/tests/test_import_schedule.py
+++ b/volunteers/tests/test_import_schedule.py
@@ -63,8 +63,21 @@ def test_import_schedule_dry_run(mock_ics_response):
     assert "Found 2 event(s)" in output
     assert "Opening Keynote" in output
     assert "Building Better APIs" in output
-    assert "Would import 2 shift(s)" in output
+    assert "Would create 2 new, update 0 existing shift(s)" in output
+    assert "[NEW]" in output
     assert Shift.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_import_schedule_dry_run_reports_updates(mock_ics_response):
+    # First import for real, then dry-run should report both as updates, not new.
+    call_command("import_schedule", "--url=https://example.com/schedule.ics", stdout=StringIO())
+
+    out = StringIO()
+    call_command("import_schedule", "--url=https://example.com/schedule.ics", "--dry-run", stdout=out)
+    output = out.getvalue()
+    assert "Would create 0 new, update 2 existing shift(s)" in output
+    assert "[update]" in output
 
 
 @pytest.mark.django_db

--- a/volunteers/tests/test_signups.py
+++ b/volunteers/tests/test_signups.py
@@ -135,6 +135,12 @@ def test_shift_list_shows_role_documentation(client, role):
     assert "https://docs.example.com/reg-desk/" in resp.content.decode()
 
 
+def test_shift_list_shows_talk_url(client, role):
+    make_shift(role, title="A Talk", talk_url="https://2026.djangocon.us/talks/a-talk/")
+    resp = client.get(reverse("volunteers:shifts"))
+    assert "https://2026.djangocon.us/talks/a-talk/" in resp.content.decode()
+
+
 def test_my_shifts_shows_role_documentation(auth_client, user, role):
     role.documentation_url = "https://docs.example.com/reg-desk/"
     role.save()

--- a/volunteers/tests/test_signups.py
+++ b/volunteers/tests/test_signups.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -216,3 +217,31 @@ def test_dashboard_open_only_filter(auth_client, role):
     body = resp.content.decode()
     assert "Needs Volunteers" in body
     assert "Fully Covered" not in body
+
+
+def test_sync_schedule_requires_staff(auth_client):
+    resp = auth_client.post(reverse("volunteers:sync_schedule"))
+    assert resp.status_code in (302, 403)
+
+
+def test_sync_schedule_runs_import(auth_client):
+    staff = User.objects.create_user(username="synner", email="sync@example.com", password="pw12345!", is_staff=True)
+    auth_client.force_login(staff)
+
+    with mock.patch("volunteers.views.call_command") as mock_call:
+        resp = auth_client.post(reverse("volunteers:sync_schedule"))
+
+    assert resp.status_code == 302
+    mock_call.assert_called_once()
+    assert mock_call.call_args.kwargs.get("dry_run") is False
+
+
+def test_sync_schedule_dry_run(auth_client):
+    staff = User.objects.create_user(username="synner2", email="sync2@example.com", password="pw12345!", is_staff=True)
+    auth_client.force_login(staff)
+
+    with mock.patch("volunteers.views.call_command") as mock_call:
+        resp = auth_client.post(reverse("volunteers:sync_schedule"), {"dry_run": "1"})
+
+    assert resp.status_code == 302
+    assert mock_call.call_args.kwargs.get("dry_run") is True

--- a/volunteers/urls.py
+++ b/volunteers/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("", views.shift_list_view, name="shifts"),
     path("mine/", views.my_shifts_view, name="my_shifts"),
     path("dashboard/", views.dashboard_view, name="dashboard"),
+    path("dashboard/sync/", views.sync_schedule_view, name="sync_schedule"),
     path("shift/<int:pk>/signup/", views.signup_view, name="signup"),
     path("shift/<int:pk>/cancel/", views.cancel_view, name="cancel"),
     path("calendar/<uuid:token>.ics", views.calendar_feed, name="calendar"),

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -1,9 +1,11 @@
 from collections import defaultdict
+from io import StringIO
 
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
+from django.core.management import call_command
 from django.db.models import Count, Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -219,3 +221,30 @@ def dashboard_view(request):
         "open_only": open_only,
     }
     return render(request, "volunteers/dashboard.html", context)
+
+
+@staff_member_required
+@require_POST
+def sync_schedule_view(request):
+    """Re-import shifts from the conference schedule ICS feed.
+
+    Idempotent: shifts are matched by their schedule UID, so existing slots
+    (and any signups on them) are updated in place rather than duplicated.
+
+    With ``dry_run`` set, reports what would be created/updated without writing.
+    """
+    dry_run = request.POST.get("dry_run") == "1"
+    out = StringIO()
+    try:
+        call_command("import_schedule", dry_run=dry_run, stdout=out)
+    except Exception as exc:  # surface the failure to the coordinator, don't 500
+        messages.error(request, f"Schedule sync failed: {exc}")
+        return redirect("volunteers:dashboard")
+
+    summary = out.getvalue().strip().splitlines()
+    result = summary[-1] if summary else "Schedule synced."
+    if dry_run:
+        messages.info(request, f"Dry run — no changes made. {result}")
+    else:
+        messages.success(request, result)
+    return redirect("volunteers:dashboard")

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -243,7 +243,7 @@ def sync_schedule_view(request):
     dry_run = request.POST.get("dry_run") == "1"
     out = StringIO()
     try:
-        call_command("import_schedule", dry_run=dry_run, stdout=out)
+        call_command("import_schedule", dry_run=dry_run, stdout=out, no_color=True)
     except Exception as exc:  # surface the failure to the coordinator, don't 500
         messages.error(request, f"Schedule sync failed: {exc}")
         return redirect("volunteers:dashboard")

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -198,8 +198,13 @@ def dashboard_view(request):
     ):
         rosters[signup.shift_id].append(signup.user)
 
+    shifts = list(shifts)
     for shift in shifts:
         shift.roster = rosters.get(shift.id, [])
+
+    days = defaultdict(list)
+    for shift in shifts:
+        days[shift.starts_at.date()].append(shift)
 
     total_capacity = sum(s.capacity for s in shifts)
     total_filled = sum(s.filled_count for s in shifts)
@@ -208,6 +213,7 @@ def dashboard_view(request):
     context = {
         "page_title": "Volunteer Dashboard",
         "shifts": shifts,
+        "days": sorted(days.items()),
         "rosters": rosters,
         "total_capacity": total_capacity,
         "total_filled": total_filled,

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -16,6 +16,7 @@ from django.views.decorators.http import require_POST
 from .ical import build_calendar
 from .models import (
     CalendarToken,
+    Role,
     Shift,
     VolunteerSignup,
     conflicting_shifts,
@@ -35,7 +36,7 @@ def shift_list_view(request):
     """Upcoming shifts anyone can browse; signing up or cancelling still requires login."""
     all_shifts = Shift.objects.filter(ends_at__gte=timezone.now()).select_related("role")
 
-    roles = sorted({s.role.name for s in all_shifts})
+    roles = list(Role.objects.order_by("name").values_list("name", flat=True))
 
     role_filter = request.GET.get("role", "")
     needs_help = request.GET.get("needs_help") == "1"
@@ -170,7 +171,7 @@ def dashboard_view(request):
     ended, so the chair/co-chair can see just what still needs attention.
     """
     all_shifts = Shift.objects.select_related("role")
-    roles = sorted({s.role.name for s in all_shifts})
+    roles = list(Role.objects.order_by("name").values_list("name", flat=True))
     locations = sorted({s.location for s in all_shifts if s.location})
 
     role_filter = request.GET.get("role", "")


### PR DESCRIPTION
Adds a staff-only way to re-sync volunteer shifts from the 2026 conference schedule ICS feed (https://2026.djangocon.us/schedule.ics) directly from the Volunteer Dashboard.

## What's new
- **Sync schedule now** button on the dashboard — runs the `import_schedule` command against the 2026 feed.
- **Preview schedule sync** button — a dry-run that reports what would be **created vs updated** without writing anything.
- Sync results surface as a dashboard message.

## Respecting existing slots
The import is idempotent: shifts are matched by their schedule UID (`external_uid`), so re-syncing **updates existing slots in place rather than duplicating them**. Any signups on a slot are preserved as the schedule changes over time.

## Also
- Improved the `import_schedule --dry-run` output to distinguish new vs updating events (`[NEW]` / `[update]`).

## Tests
- Sync view: staff-only, triggers import, passes `dry_run` correctly.
- Dry-run command: reports new vs updates.
- 24 volunteers tests pass.

Part of #83.