### PR TITLE
Remove deprecated allauth settings and add LOGGING config

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -183,16 +183,49 @@ AUTHENTICATION_BACKENDS = [
 
 # Django Allauth settings
 
-ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
 ACCOUNT_EMAIL_VERIFICATION = "none"
 ACCOUNT_LOGIN_METHODS = {"email"}
 ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
-ACCOUNT_USERNAME_REQUIRED = False
 LOGIN_REDIRECT_URL = "/"
 SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
 SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
+
+# Logging
+#
+# Without this, DEBUG=False swallows 500 tracebacks entirely and the container
+# logs show nothing. django.request is what logs unhandled view exceptions.
+
+DJANGO_LOG_LEVEL = env.str("DJANGO_LOG_LEVEL", default="INFO")
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "{asctime} {levelname} {name} {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": DJANGO_LOG_LEVEL,
+    },
+    "loggers": {
+        "django.request": {
+            "handlers": ["console"],
+            "level": "ERROR",
+            "propagate": False,
+        },
+    },
+}
 
 # Email Octopus API settings
 


### PR DESCRIPTION
Follow-up from investigating #89.

## Deprecated allauth settings

Production logs a deprecation warning on every boot:

```
settings.ACCOUNT_AUTHENTICATION_METHOD is deprecated, use: settings.ACCOUNT_LOGIN_METHODS = {'email'}
settings.ACCOUNT_USERNAME_REQUIRED is deprecated, use: settings.ACCOUNT_SIGNUP_FIELDS = ['email*', 'password1*', 'password2*']
```

Both modern replacements were already set, so the legacy pair was redundant. Removed. `ACCOUNT_USER_MODEL_USERNAME_FIELD` is left alone deliberately — it is not deprecated, and changing it would alter signup behavior.

## LOGGING

With `DEBUG=False` and no `LOGGING` block, Django silently discards 500 tracebacks. The production web container currently has **18 log lines total**, all boot messages — which is why the login 500 in #89 could not be diagnosed from logs at all. There is no Sentry project wired to this app either.

This adds a console logging config with `django.request` at ERROR, so unhandled view exceptions actually surface. Level is overridable via `DJANGO_LOG_LEVEL`.

Verified locally by triggering a real 500:

```
2026-07-24 13:20:17,159 ERROR django.request Internal Server Error: /accounts/github/login/
    raise SocialApp.DoesNotExist()
allauth.socialaccount.models.SocialApp.DoesNotExist
```

Boot is now warning-free, `manage.py check` is clean, and all 89 tests pass.

## Not included

Two other things surfaced while investigating #89, left out of this PR deliberately:

- **`SECRET_KEY` is unset in production** — it is falling back to the committed `django-insecure-…` default in `settings.py`. Worth fixing separately and urgently; it needs the value set in Coolify first.
- **Email is entirely unconfigured in production** (`EMAIL_HOST=localhost`, `DEFAULT_FROM_EMAIL=webmaster@localhost`). That is #90.