### PR TITLE
Add superuser-only volunteer interest report

### DIFF
--- a/config/nav.py
+++ b/config/nav.py
@@ -46,6 +46,7 @@ NAV_ITEMS = [
             NavItem(title="Sign Up to Volunteer", url="volunteers:shifts"),
             NavItem(title="My Shifts", url="volunteers:my_shifts"),
             NavItem(title="Volunteer Dashboard", url="volunteers:dashboard", permissions=["is_staff"]),
+            NavItem(title="Volunteer Interest Report", url="volunteer_interest", permissions=["is_superuser"]),
         ],
     ),
     NavItem(title="Sign In", url="account_login", extra_context={"anonymous_only": True}),

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,7 +13,13 @@ from thunderdome.views import (
     sync_from_pretalx_view,
 )
 from tickets.views import claim_ticket_view, create_tickets_view, tickets_info, tickets_list_view
-from titowebhooks.views import sprint_tickets_view, tito_sales_dashboard_view, tito_sync_view, tito_webhook
+from titowebhooks.views import (
+    sprint_tickets_view,
+    tito_sales_dashboard_view,
+    tito_sync_view,
+    tito_webhook,
+    volunteer_interest_view,
+)
 
 admin_header = f"DjangoCon US Automation v{__version__}"
 admin.site.enable_nav_sidebar = False
@@ -32,6 +38,7 @@ urlpatterns = [
     path("tickets/claim/", claim_ticket_view, name="claim_ticket"),
     path("sprints/tickets/", sprint_tickets_view, name="sprint_tickets"),
     path("tito/sales/", tito_sales_dashboard_view, name="tito_sales_dashboard"),
+    path("tito/volunteer-interest/", volunteer_interest_view, name="volunteer_interest"),
     path("tito/sync/", tito_sync_view, name="tito_sync"),
     path("thunderdome/", submissions_view, name="thunderdome_submissions"),
     path("thunderdome/bulk-state/", bulk_set_state_view, name="thunderdome_bulk_state"),

--- a/templates/titowebhooks/volunteer_interest.html
+++ b/templates/titowebhooks/volunteer_interest.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+
+{% block body_class %}flex flex-col p-4 min-h-screen text-white bg-green-900 bg-gradient-to-b from-green-900 to-black via-green-950{% endblock %}
+
+{% block main_class %}flex-1 mx-auto text-white{% endblock %}
+
+{% block title %}Volunteer Interest - DjangoCon US Automation{% endblock %}
+
+{% block content %}
+    <div class="p-6 mx-auto max-w-7xl">
+        <div class="flex justify-between items-center mb-6">
+            <div>
+                <a href="/" class="text-sm text-gray-400 hover:text-gray-200">&larr; Home</a>
+                <h1 class="text-3xl font-bold">Volunteer Interest</h1>
+                <p class="mt-1 text-sm text-gray-300">
+                    Attendees who answered &ldquo;Yes!&rdquo; to volunteering on their Ti.to ticket.
+                </p>
+            </div>
+            <div class="flex gap-2">
+                <a href="?format=csv"
+                   class="py-2 px-4 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">Download CSV</a>
+            </div>
+        </div>
+
+        <div class="p-4 mb-6 bg-green-800 bg-opacity-50 rounded-lg">
+            <div class="grid grid-cols-3 gap-4 text-center">
+                <div>
+                    <p class="text-2xl font-bold text-green-400">{{ total_count }}</p>
+                    <p class="text-sm text-gray-300">Interested</p>
+                </div>
+                <div>
+                    <p class="text-2xl font-bold text-green-400">{{ signed_up_count }}</p>
+                    <p class="text-sm text-gray-300">Already signed up</p>
+                </div>
+                <div>
+                    <p class="text-2xl font-bold text-yellow-300">{{ not_signed_up_count }}</p>
+                    <p class="text-sm text-gray-300">To reach out to</p>
+                </div>
+            </div>
+        </div>
+
+        {% if people %}
+            <div class="overflow-x-auto">
+                <table class="overflow-hidden w-full bg-green-800 bg-opacity-30 rounded-lg">
+                    <thead class="bg-green-700 bg-opacity-50">
+                        <tr>
+                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Name</th>
+                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Email</th>
+                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Company</th>
+                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Ticket</th>
+                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Date</th>
+                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Signed Up</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-green-700">
+                        {% for person in people %}
+                            <tr class="transition-colors hover:bg-green-700 hover:bg-opacity-20">
+                                <td class="py-2 px-4 text-sm">{{ person.name }}</td>
+                                <td class="py-2 px-4 text-sm">
+                                    <a href="mailto:{{ person.email }}"
+                                       class="text-yellow-300 underline hover:text-yellow-200">{{ person.email }}</a>
+                                </td>
+                                <td class="py-2 px-4 text-sm">{{ person.company_name }}</td>
+                                <td class="py-2 px-4 text-sm">{{ person.release_title }}</td>
+                                <td class="py-2 px-4 text-sm">{{ person.created_at|date:"Y-m-d" }}</td>
+                                <td class="py-2 px-4 text-sm">
+                                    {% if person.has_signed_up %}
+                                        <span class="text-green-400">Yes</span>
+                                    {% else %}
+                                        <span class="text-yellow-300">Not yet</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <div class="p-6 text-center bg-green-800 bg-opacity-30 rounded-lg">
+                <p class="text-gray-300">No attendees have answered &ldquo;Yes!&rdquo; to volunteering yet.</p>
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/titowebhooks/tests/test_volunteer_interest.py
+++ b/titowebhooks/tests/test_volunteer_interest.py
@@ -1,0 +1,143 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from titowebhooks.models import TitoWebhookEvent
+
+User = get_user_model()
+
+URL = "/tito/volunteer-interest/"
+
+
+def make_event(email, name="Someone", trigger="ticket.completed", answer="Yes!", **extra):
+    """Build a Ti.to webhook event shaped like the real payloads."""
+    payload = {
+        "_type": "ticket",
+        "email": email,
+        "name": name,
+        "company_name": extra.get("company_name", ""),
+        "reference": extra.get("reference", "ABCD-1"),
+        "release": {"title": extra.get("release_title", "Individual")},
+        "created_at": extra.get("created_at", "2026-04-03T12:00:00.000-05:00"),
+        "responses": {},
+    }
+    if answer is not None:
+        payload["responses"]["are-you-interested-in-volunteering-at-th"] = answer
+    return TitoWebhookEvent.objects.create(trigger=trigger, payload=payload, payload_text="")
+
+
+@pytest.fixture
+def superuser_client(client, db):
+    user = User.objects.create_user(
+        username="root", email="root@example.com", password="pw12345!", is_staff=True, is_superuser=True
+    )
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+def test_requires_superuser_when_anonymous(client):
+    response = client.get(URL)
+    assert response.status_code in (302, 403)
+
+
+@pytest.mark.django_db
+def test_requires_superuser_when_merely_staff(client):
+    staff = User.objects.create_user(username="staffer", email="staff@example.com", password="pw12345!", is_staff=True)
+    client.force_login(staff)
+
+    response = client.get(URL)
+
+    assert response.status_code in (302, 403)
+
+
+@pytest.mark.django_db
+def test_lists_only_people_who_answered_yes(superuser_client):
+    make_event("yes@example.com", name="Yes Person")
+    make_event("no@example.com", name="No Person", answer=None)
+
+    response = superuser_client.get(URL)
+
+    assert response.status_code == 200
+    assert b"yes@example.com" in response.content
+    assert b"no@example.com" not in response.content
+
+
+@pytest.mark.django_db
+def test_deduplicates_multiple_events_for_one_person(superuser_client):
+    """Ti.to fires several webhooks per ticket; the person should appear once."""
+    make_event("dupe@example.com", name="Dupe Person", trigger="ticket.completed")
+    make_event("dupe@example.com", name="Dupe Person", trigger="ticket.updated")
+    make_event("dupe@example.com", name="Dupe Person", trigger="ticket.updated")
+
+    response = superuser_client.get(URL)
+
+    assert response.context["total_count"] == 1
+    assert response.content.count(b"dupe@example.com") == 2  # mailto href + link text
+
+
+@pytest.mark.django_db
+def test_excludes_people_whose_latest_event_voided_the_ticket(superuser_client):
+    make_event("void@example.com", name="Void Person", trigger="ticket.completed")
+    make_event("void@example.com", name="Void Person", trigger="ticket.voided")
+
+    response = superuser_client.get(URL)
+
+    assert response.context["total_count"] == 0
+    assert b"void@example.com" not in response.content
+
+
+@pytest.mark.django_db
+def test_email_matching_is_case_insensitive(superuser_client):
+    make_event("Mixed@Example.com", name="Mixed Case", trigger="ticket.completed")
+    make_event("mixed@example.com", name="Mixed Case", trigger="ticket.updated")
+
+    response = superuser_client.get(URL)
+
+    assert response.context["total_count"] == 1
+
+
+@pytest.mark.django_db
+def test_csv_download(superuser_client):
+    make_event("csv@example.com", name="CSV Person", company_name="Acme", reference="ZZZZ-1")
+
+    response = superuser_client.get(URL + "?format=csv")
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/csv"
+    assert "volunteer_interest.csv" in response["Content-Disposition"]
+    body = response.content.decode()
+    assert "csv@example.com" in body
+    assert "Acme" in body
+    assert "ZZZZ-1" in body
+
+
+@pytest.mark.django_db
+def test_flags_people_who_already_signed_up(superuser_client):
+    from volunteers.models import Role, Shift, VolunteerSignup
+
+    volunteer = User.objects.create_user(username="vol", email="signed@example.com", password="pw12345!")
+    role = Role.objects.create(name="Room Chair")
+    shift = Shift.objects.create(
+        role=role,
+        starts_at="2026-08-26T09:00:00Z",
+        ends_at="2026-08-26T10:00:00Z",
+        capacity=2,
+    )
+    VolunteerSignup.objects.create(shift=shift, user=volunteer)
+
+    make_event("signed@example.com", name="Signed Up")
+    make_event("unsigned@example.com", name="Not Signed Up")
+
+    response = superuser_client.get(URL)
+
+    assert response.context["total_count"] == 2
+    assert response.context["signed_up_count"] == 1
+    assert response.context["not_signed_up_count"] == 1
+
+
+@pytest.mark.django_db
+def test_empty_state(superuser_client):
+    response = superuser_client.get(URL)
+
+    assert response.status_code == 200
+    assert response.context["total_count"] == 0

--- a/titowebhooks/views.py
+++ b/titowebhooks/views.py
@@ -19,12 +19,20 @@ from rich import print
 
 from emailoctopus.models import Campaign
 from titowebhooks.models import TitoHistoricalEvent, TitoWebhookEvent
+from volunteers.models import VolunteerSignup
 
 superuser_required = user_passes_test(lambda u: u.is_active and u.is_superuser)
 
 LEADER_QUESTION_ID = 1216404
 JOINER_QUESTION_ID = 1216405
 EVENT_SLUG = "djangocon-us-2026"
+
+# Ti.to stores question answers twice: an "answers" list keyed by question id, and a
+# "responses" object keyed by the question slug. The slug is truncated by Ti.to, hence
+# the cut-off "-th". Querying "responses" lets Postgres do the filtering for us.
+VOLUNTEER_QUESTION_SLUG = "are-you-interested-in-volunteering-at-th"
+VOLUNTEER_RESPONSE_LOOKUP = f"payload__responses__{VOLUNTEER_QUESTION_SLUG}"
+VOLUNTEER_YES = "Yes!"
 
 # How many conference years the "Download Historical" export reaches back, counting
 # from the most recent year present in the data (e.g. 3 -> current + two prior years).
@@ -417,3 +425,82 @@ def tito_sync_view(request: HttpRequest) -> HttpResponse:
     async_task("titowebhooks.sync.sync_tito_events")
     messages.success(request, "Tito sync queued. Refresh in a moment to see updated data.")
     return redirect("tito_sales_dashboard")
+
+
+def _extract_volunteer_interest() -> list[dict]:
+    """Attendees who answered "Yes!" to the volunteering question on their ticket.
+
+    Ti.to fires several webhooks per ticket (completed, updated, voided...), so the
+    same person shows up many times. We keep only the most recent event per email
+    address, then drop anyone whose latest event voided their ticket - they should
+    not land on an outreach list.
+    """
+    events = TitoWebhookEvent.objects.filter(**{VOLUNTEER_RESPONSE_LOOKUP: VOLUNTEER_YES}).order_by("timestamp")
+
+    latest_by_email: dict[str, TitoWebhookEvent] = {}
+    for event in events:
+        email = ((event.payload or {}).get("email") or "").strip().lower()
+        if email:
+            latest_by_email[email] = event  # ascending order, so the last write wins
+
+    people = []
+    for email, event in latest_by_email.items():
+        if event.trigger == "ticket.voided":
+            continue
+        payload = event.payload or {}
+        people.append(
+            {
+                "name": payload.get("name") or "",
+                "email": email,
+                "company_name": payload.get("company_name") or "",
+                "reference": payload.get("reference") or "",
+                "release_title": (payload.get("release") or {}).get("title") or "",
+                "created_at": _parse_created_at(payload.get("created_at")),
+                "trigger": event.trigger,
+            }
+        )
+
+    return sorted(people, key=lambda p: p["name"].lower())
+
+
+def _volunteer_interest_csv(people: list[dict]) -> HttpResponse:
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = 'attachment; filename="volunteer_interest.csv"'
+    writer = csv.writer(response)
+    writer.writerow(["Name", "Email", "Company", "Ticket Reference", "Ticket Type", "Ticket Date"])
+    for person in people:
+        writer.writerow(
+            [
+                person["name"],
+                person["email"],
+                person["company_name"],
+                person["reference"],
+                person["release_title"],
+                person["created_at"].isoformat() if person["created_at"] else "",
+            ]
+        )
+    return response
+
+
+@superuser_required
+def volunteer_interest_view(request: HttpRequest) -> HttpResponse:
+    people = _extract_volunteer_interest()
+
+    if request.GET.get("format") == "csv":
+        return _volunteer_interest_csv(people)
+
+    signed_up_emails = set(
+        VolunteerSignup.objects.filter(cancelled=False).exclude(user__email="").values_list("user__email", flat=True)
+    )
+    signed_up_emails = {email.strip().lower() for email in signed_up_emails}
+
+    for person in people:
+        person["has_signed_up"] = person["email"] in signed_up_emails
+
+    context = {
+        "people": people,
+        "total_count": len(people),
+        "signed_up_count": sum(1 for p in people if p["has_signed_up"]),
+        "not_signed_up_count": sum(1 for p in people if not p["has_signed_up"]),
+    }
+    return render(request, "titowebhooks/volunteer_interest.html", context)


### PR DESCRIPTION
Closes #95.

Attendees can answer "Are you interested in volunteering at the event?" on their Ti.to ticket. That answer already arrives in the webhook payload and is stored, so this surfaces it as an outreach list for the volunteer chairs. No new Ti.to integration needed.

## Access

Gated with the existing `superuser_required` decorator (`titowebhooks/views.py:24`), per the request for superuser-only access. Nav entry is `permissions=["is_superuser"]`.

Note this is stricter than the neighbouring Tito dashboards, some of which are `@staff_member_required`. Included is a test asserting a merely-*staff* user is rejected — a case the existing Tito dashboard tests do not cover.

## Query

Ti.to stores answers twice: an `answers` list keyed by question id, and a `responses` object keyed by question slug. Querying the latter pushes filtering into Postgres instead of walking JSON in Python:

```python
VOLUNTEER_RESPONSE_LOOKUP = f"payload__responses__{VOLUNTEER_QUESTION_SLUG}"
TitoWebhookEvent.objects.filter(**{VOLUNTEER_RESPONSE_LOOKUP: "Yes!"})
```

(The slug `are-you-interested-in-volunteering-at-th` is truncated by Ti.to — that cut-off `-th` is theirs, not a typo.)

## Two wrinkles in the real data

Both found by querying production, and both are why the raw count misleads:

1. **Ti.to fires several webhooks per ticket** (`ticket.completed`, `ticket.updated`, `ticket.voided`, `ticket.unsnoozed`), so the same person appears repeatedly. Production has **39 events for 18 distinct people** — counting rows roughly doubles the list. The report keeps only the most recent event per email address, matched case-insensitively.
2. **One of those tickets was later voided.** Someone whose latest event is `ticket.voided` should not be on an outreach list, so they are excluded — leaving **17**, not the 18 quoted in the issue.

## The page

- Stat row: interested / already signed up / still to reach out to
- Table with name, email (mailto link), company, ticket type, date, and whether they have already taken a shift
- Cross-references `VolunteerSignup` (excluding cancelled) by email, so chairs can see who expressed interest but has not yet signed up — the actual outreach list
- CSV download via `?format=csv`, following the existing convention in `sprint_tickets_view`

## Verification

98 tests pass (9 new), covering the superuser gate, the anonymous and staff-only rejection paths, dedup across multiple events, void exclusion, case-insensitive email matching, the signup cross-reference, CSV output, and the empty state.

## Note

`just lint` reports `ruff format` failing on `titowebhooks/tests/test_views.py`. That is pre-existing on `main` — I verified it fails on a clean checkout — so it is left untouched here rather than mixing an unrelated reformat into this diff. All files in this PR are ruff-clean.