### PR TITLE
Add volunteer call-to-action to homepage

### DIFF
--- a/config/tests/test_homepage.py
+++ b/config/tests/test_homepage.py
@@ -1,0 +1,27 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestHomepageVolunteerCTA:
+    def test_anonymous_sees_cta_and_signin_hint(self, client):
+        response = client.get(reverse("home"))
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert reverse("volunteers:shifts") in content
+        assert "Volunteer at DjangoCon US" in content
+        assert "sign in when you're ready" in content
+        assert reverse("volunteers:my_shifts") not in content
+
+    def test_authenticated_sees_cta_and_my_shifts(self, client):
+        user = User.objects.create_user(username="vol", email="vol@example.com", password="pw")
+        client.force_login(user)
+        response = client.get(reverse("home"))
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert reverse("volunteers:shifts") in content
+        assert "Volunteer at DjangoCon US" in content
+        assert reverse("volunteers:my_shifts") in content

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -11,6 +11,22 @@
             <div class="text-green-300">Automations</div>
         </div>
 
+        <div class="flex flex-col gap-2">
+            <a href="{% url 'volunteers:shifts' %}"
+               class="block py-4 px-6 text-2xl font-bold text-green-900 bg-yellow-300 rounded-lg shadow hover:bg-yellow-200">
+                🙋 Volunteer at DjangoCon US
+            </a>
+            {% if user.is_authenticated %}
+                <a href="{% url 'volunteers:my_shifts' %}" class="text-sm text-yellow-300 underline hover:text-yellow-200">
+                    View my shifts
+                </a>
+            {% else %}
+                <p class="text-sm text-green-300">
+                    Browse open shifts — sign in when you're ready to claim one.
+                </p>
+            {% endif %}
+        </div>
+
         {% django_simple_nav "config.nav.MainNav" %}
 
         <div class="text-xl">version {{ app_version }}</div>


### PR DESCRIPTION
Closes #97. Part of #92.

Adds a prominent, state-aware volunteer CTA to the homepage, visually distinct from the nav link groups (solid yellow button vs. underlined links):

- **Everyone** gets a "🙋 Volunteer at DjangoCon US" button linking to the public shift list (`volunteers:shifts`), which already handles both auth states — signed-in users can sign up directly; guests can browse and are prompted to sign in per shift.
- **Signed in** → a secondary "View my shifts" link.
- **Anonymous** → a hint that they can browse first and sign in when ready.

Includes tests for both states (`config/tests/test_homepage.py`).