### PR TITLE
Fix timezone flake in dashboard date-filter test

### DIFF
--- a/volunteers/tests/test_signups.py
+++ b/volunteers/tests/test_signups.py
@@ -307,7 +307,10 @@ def test_dashboard_date_filter(auth_client, role):
     make_shift(role, title="Day One", start_offset_hours=24)
     make_shift(role, title="Day Two", start_offset_hours=24 + 48)
 
-    d1 = (timezone.now() + datetime.timedelta(hours=24)).date().isoformat()
+    # The dashboard filters by conference-local (TIME_ZONE) dates, so compute the
+    # target date in local time — .date() on the UTC value is a day ahead late in
+    # the local evening.
+    d1 = timezone.localtime(timezone.now() + datetime.timedelta(hours=24)).date().isoformat()
     resp = auth_client.get(reverse("volunteers:dashboard"), {"date": d1})
     body = resp.content.decode()
     assert "Day One" in body


### PR DESCRIPTION
`test_dashboard_date_filter` computed its target date with `.date()` on a UTC datetime, but the dashboard filters `starts_at__date` in conference-local time (`TIME_ZONE = America/Chicago`). Between 7pm and midnight Chicago time — which includes typical UTC CI runs (00:00–05:00 UTC) — the UTC date is a day ahead, the filter matches nothing, and the test fails.

Fix: compute the date via `timezone.localtime(...)`, matching how the view resolves dates. Verified failing before / passing after at 02:50 UTC.