### PR TITLE
Show your upcoming shifts on the volunteer sign-up page

### DIFF
--- a/volunteers/templates/volunteers/shift_list.html
+++ b/volunteers/templates/volunteers/shift_list.html
@@ -26,6 +26,24 @@
             {% endif %}
         </div>
 
+        {% if my_upcoming %}
+            <section class="print-hide p-4 bg-green-800 rounded-lg border border-yellow-300">
+                <h2 class="mb-2 text-lg font-semibold text-yellow-300">Your upcoming shifts</h2>
+                <ul class="space-y-1 text-sm text-green-100">
+                    {% for signup in my_upcoming %}
+                        <li>
+                            <time datetime="{{ signup.shift.starts_at|date:'c' }}" class="whitespace-nowrap">{{ signup.shift.starts_at|date:"D g:i A" }}</time>
+                            · {{ signup.shift.title }}
+                            <span class="text-green-300">({{ signup.shift.role.name }})</span>
+                        </li>
+                    {% endfor %}
+                </ul>
+                <a href="{% url 'volunteers:my_shifts' %}" class="inline-block mt-2 text-sm text-yellow-300 underline hover:text-yellow-200">
+                    See my full schedule &amp; calendar feed
+                </a>
+            </section>
+        {% endif %}
+
         {% if messages %}
             {% for message in messages %}
                 <div class="print-hide p-4 rounded-md {% if message.tags == 'success' %}bg-green-700 border border-green-600 text-green-100{% elif message.tags == 'error' %}bg-red-700 border border-red-600 text-red-100{% else %}bg-blue-800 border border-blue-600 text-blue-100{% endif %}">
@@ -75,7 +93,7 @@
                             </div>
                             <div class="grid gap-3 {% if slot.list|length > 1 %}md:grid-cols-2{% endif %}">
                                 {% for shift in slot.list %}
-                                    <div class="flex flex-col gap-2 p-4 bg-green-900 rounded-lg border border-green-700 shift-card">
+                                    <div class="flex flex-col gap-2 p-4 bg-green-900 rounded-lg border {% if shift.id in my_shift_ids %}border-yellow-300{% else %}border-green-700{% endif %} shift-card">
                                         <div>
                                             <p class="text-lg font-semibold text-yellow-100">{{ shift.title }}</p>
                                             <p class="text-sm text-green-300">

--- a/volunteers/tests/test_signups.py
+++ b/volunteers/tests/test_signups.py
@@ -186,6 +186,31 @@ def test_shift_list_needs_help_filter(client, role):
     assert open_shift.id != staffed_shift.id
 
 
+def test_shift_list_shows_my_upcoming_summary(auth_client, user, role):
+    shift = make_shift(role, title="My Reg Shift")
+    VolunteerSignup.objects.create(shift=shift, user=user)
+
+    resp = auth_client.get(reverse("volunteers:shifts"))
+    body = resp.content.decode()
+    assert "Your upcoming shifts" in body
+    assert "My Reg Shift" in body
+    assert reverse("volunteers:my_shifts") in body
+
+
+def test_shift_list_summary_excludes_cancelled(auth_client, user, role):
+    shift = make_shift(role, title="Cancelled Shift")
+    VolunteerSignup.objects.create(shift=shift, user=user, cancelled=True)
+
+    resp = auth_client.get(reverse("volunteers:shifts"))
+    assert "Your upcoming shifts" not in resp.content.decode()
+
+
+def test_shift_list_no_summary_for_anonymous(client, role):
+    make_shift(role, title="Reg Desk")
+    resp = client.get(reverse("volunteers:shifts"))
+    assert "Your upcoming shifts" not in resp.content.decode()
+
+
 def test_dashboard_filters_by_role_and_location(auth_client, role):
     staff = User.objects.create_user(username="staffer", email="staff@example.com", password="pw12345!", is_staff=True)
     auth_client.force_login(staff)

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -74,9 +74,15 @@ def shift_list_view(request):
             VolunteerSignup.objects.filter(user=request.user, cancelled=False).values_list("shift_id", flat=True)
         )
         my_hours = total_volunteer_hours(request.user)
+        my_upcoming = (
+            VolunteerSignup.objects.filter(user=request.user, cancelled=False, shift__ends_at__gte=timezone.now())
+            .select_related("shift", "shift__role")
+            .order_by("shift__starts_at")[:3]
+        )
     else:
         my_shift_ids = set()
         my_hours = 0
+        my_upcoming = []
 
     days = defaultdict(list)
     for shift in shifts:
@@ -86,6 +92,7 @@ def shift_list_view(request):
         "page_title": "Volunteer Sign-up",
         "days": sorted(days.items()),
         "my_shift_ids": my_shift_ids,
+        "my_upcoming": my_upcoming,
         "my_hours": my_hours,
         "max_hours": max_volunteer_hours(),
         "roles": roles,


### PR DESCRIPTION
Closes #98. Part of #92.

Makes the public shift list work as the signed-in volunteer landing page (per the homepage CTA in #97/#100):

- **"Your upcoming shifts" summary** at the top for signed-in volunteers with active future signups — next 3 shifts with day/time and role, plus a link to the full schedule & calendar feed on My Shifts.
- **Claimed shifts highlighted** — cards you're signed up for get a yellow border, matching the summary strip, so your schedule is scannable while browsing for more.

Cancelled and past signups don't trigger the summary; anonymous users see no change. Tests cover all three cases.