### PR TITLE
Add passwordless email sign-in (login code + magic link)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -185,6 +185,9 @@ AUTHENTICATION_BACKENDS = [
 
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
 ACCOUNT_EMAIL_VERIFICATION = "none"
+# Passwordless sign-in: allauth emails a short-lived code (and our email template
+# adds a clickable link that prefills it). See #91/#99.
+ACCOUNT_LOGIN_BY_CODE_ENABLED = True
 ACCOUNT_LOGIN_METHODS = {"email"}
 ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]
 # NOTE: do not set ACCOUNT_USER_MODEL_USERNAME_FIELD = None. We use the stock

--- a/config/tests/test_login_by_code.py
+++ b/config/tests/test_login_by_code.py
@@ -1,0 +1,69 @@
+import re
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.urls import reverse
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+
+
+def request_code(client, email):
+    return client.post(reverse("account_request_login_code"), {"email": email})
+
+
+@pytest.mark.django_db
+class TestLoginByCode:
+    def test_login_page_offers_email_link(self, client):
+        response = client.get(reverse("account_login"))
+        assert reverse("account_request_login_code") in response.content.decode()
+
+    def test_request_form_renders(self, client):
+        response = client.get(reverse("account_request_login_code"))
+        assert response.status_code == 200
+        assert "Send Sign-In Email" in response.content.decode()
+
+    def test_request_code_sends_email_with_code_and_link(self, client, user):
+        response = request_code(client, user.email)
+        assert response.status_code == 302
+        assert response.url.startswith(reverse("account_confirm_login_code"))
+        assert len(mail.outbox) == 1
+        body = mail.outbox[0].body
+        code = re.search(r"\?code=([A-Z0-9]+)", body).group(1)
+        assert code in body
+        assert reverse("account_confirm_login_code") in body
+
+    def test_link_prefills_code_on_confirm_page(self, client, user):
+        request_code(client, user.email)
+        code = re.search(r"\?code=([A-Z0-9]+)", mail.outbox[0].body).group(1)
+        response = client.get(reverse("account_confirm_login_code") + f"?code={code}")
+        assert response.status_code == 200
+        assert f'value="{code}"' in response.content.decode()
+
+    def test_confirming_code_signs_user_in(self, client, user):
+        request_code(client, user.email)
+        code = re.search(r"\?code=([A-Z0-9]+)", mail.outbox[0].body).group(1)
+        response = client.post(reverse("account_confirm_login_code"), {"code": code})
+        assert response.status_code == 302
+        response = client.get(reverse("home"))
+        assert response.context["user"].is_authenticated
+
+    def test_wrong_code_rejected(self, client, user):
+        request_code(client, user.email)
+        # Depending on the code format, allauth either re-renders the form (200) or
+        # invalidates the attempt and bounces back to the request page (302).
+        response = client.post(reverse("account_confirm_login_code"), {"code": "WRONG1"})
+        assert response.status_code in (200, 302)
+        response = client.get(reverse("home"))
+        assert not response.context["user"].is_authenticated
+
+    def test_unknown_email_does_not_reveal_account_state(self, client):
+        response = request_code(client, "nobody@example.com")
+        assert response.status_code == 302
+        assert len(mail.outbox) == 1
+        assert "code=" not in mail.outbox[0].body

--- a/templates/account/confirm_login_code.html
+++ b/templates/account/confirm_login_code.html
@@ -1,0 +1,55 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    <div class="flex flex-col gap-6 p-8 mx-auto max-w-lg text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+        <div class="mb-4 text-4xl font-bold text-yellow-200">
+            Enter Your Sign-In Code
+        </div>
+
+        <p class="text-green-200">
+            We sent a code to
+            {% if email %}<strong>{{ email }}</strong>{% else %}your email{% endif %}.
+            Enter it below, or use the link in the email. It expires shortly.
+        </p>
+
+        {% if form.errors %}
+            <div class="p-4 text-red-200 bg-red-800 bg-opacity-50 rounded-lg">
+                <div class="mb-2 text-sm font-medium">Please correct the following errors:</div>
+                {{ form.errors }}
+            </div>
+        {% endif %}
+
+        <form method="POST" action="{% url 'account_confirm_login_code' %}" class="space-y-4">
+            {% csrf_token %}
+
+            <div class="text-left">
+                <label for="{{ form.code.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                    Sign-in code
+                </label>
+                <input type="text"
+                       name="{{ form.code.name }}"
+                       id="{{ form.code.id_for_label }}"
+                       class="p-3 w-full font-mono text-xl tracking-widest text-center text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                       value="{% if form.code.value %}{{ form.code.value }}{% elif request.GET.code %}{{ request.GET.code }}{% endif %}"
+                       autocomplete="one-time-code"
+                       autofocus
+                       required>
+            </div>
+
+            {{ redirect_field }}
+
+            <button type="submit"
+                    class="py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                Sign In
+            </button>
+        </form>
+
+        <div class="pt-4 text-sm text-gray-400 border-t border-green-700">
+            <a href="{% url 'account_request_login_code' %}" class="text-yellow-300 underline hover:text-yellow-200">
+                Send a new code
+            </a>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/account/email/login_code_message.txt
+++ b/templates/account/email/login_code_message.txt
@@ -1,0 +1,12 @@
+{% extends "account/email/base_message.txt" %}
+{% load i18n %}
+
+{% block content %}{% autoescape off %}{% blocktranslate %}Your sign-in code is listed below. Please enter it in your open browser window.{% endblocktranslate %}
+
+{{ code }}
+
+{% blocktranslate %}Or, in the same browser you requested the code from, open this link to sign in:{% endblocktranslate %}
+
+{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.get_host }}{% url 'account_confirm_login_code' %}?code={{ code }}
+
+{% blocktranslate %}This mail can be safely ignored if you did not initiate this action.{% endblocktranslate %}{% endautoescape %}{% endblock content %}

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -65,6 +65,11 @@
                 🐙 Sign In with GitHub
             </a>
 
+            <a href="{% url 'account_request_login_code' %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}"
+               class="block py-3 px-4 w-full text-lg font-semibold text-green-900 bg-yellow-300 rounded-lg hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                ✉️ Email Me a Sign-In Link
+            </a>
+
             <div class="text-sm text-gray-400">
                 <a href="{% url 'account_signup' %}" class="text-yellow-300 underline hover:text-yellow-200">
                     Don't have an account? Sign up

--- a/templates/account/request_login_code.html
+++ b/templates/account/request_login_code.html
@@ -1,0 +1,52 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    <div class="flex flex-col gap-6 p-8 mx-auto max-w-lg text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+        <div class="mb-4 text-4xl font-bold text-yellow-200">
+            Email Me a Sign-In Link
+        </div>
+
+        <p class="text-green-200">
+            No password needed — we'll email you a sign-in code and link.
+        </p>
+
+        {% if form.errors %}
+            <div class="p-4 text-red-200 bg-red-800 bg-opacity-50 rounded-lg">
+                <div class="mb-2 text-sm font-medium">Please correct the following errors:</div>
+                {{ form.errors }}
+            </div>
+        {% endif %}
+
+        <form method="POST" action="{% url 'account_request_login_code' %}" class="space-y-4">
+            {% csrf_token %}
+
+            <div class="text-left">
+                <label for="{{ form.email.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                    Email
+                </label>
+                <input type="email"
+                       name="{{ form.email.name }}"
+                       id="{{ form.email.id_for_label }}"
+                       class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                       {% if form.email.value %}value="{{ form.email.value }}"{% endif %}
+                       placeholder="you@example.com"
+                       required>
+            </div>
+
+            {{ redirect_field }}
+
+            <button type="submit"
+                    class="py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                Send Sign-In Email
+            </button>
+        </form>
+
+        <div class="pt-4 text-sm text-gray-400 border-t border-green-700">
+            <a href="{% url 'account_login' %}" class="text-yellow-300 underline hover:text-yellow-200">
+                Other sign-in options
+            </a>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Closes #99. Part of #91.

Enables allauth's built-in login-by-code and layers a clickable link on top:

- `ACCOUNT_LOGIN_BY_CODE_ENABLED = True` — allauth (65.13.1) emails a short-lived sign-in code (3-minute default timeout, 3 attempts).
- **Login page** gets a "✉️ Email Me a Sign-In Link" button beside GitHub, carrying `?next` through.
- **Styled overrides** for `request_login_code.html` and `confirm_login_code.html` matching the existing account pages.
- **Email template override** adds a link to `account_confirm_login_code?code=…`; the confirm page prefills the code from the query string, so clicking the link in the same browser is one-click sign-in. The code remains usable on its own (e.g., reading mail on a phone), since the flow is session-bound.
- Unknown emails get allauth's stock "unknown account" mail — no account enumeration, and no silent account creation; registration stays via GitHub or the signup form.

Tests cover the login-page button, request form, email contents (code + link), prefill, successful sign-in, wrong-code rejection, and the unknown-email path.

**Note:** the email path stays inert in production until #90 (SMTP) is configured — sending will raise `ConnectionRefusedError` just like password reset does today. The GitHub button is unaffected.