### PR TITLE
Add travel safety check-in call-to-action to homepage

### DIFF
--- a/config/tests/test_homepage.py
+++ b/config/tests/test_homepage.py
@@ -15,6 +15,8 @@ class TestHomepageVolunteerCTA:
         assert "Volunteer at DjangoCon US" in content
         assert "sign in when you're ready" in content
         assert reverse("volunteers:my_shifts") not in content
+        assert reverse("travel_safety:register") in content
+        assert "Travel Safety Check-in" in content
 
     def test_authenticated_sees_cta_and_my_shifts(self, client):
         user = User.objects.create_user(username="vol", email="vol@example.com", password="pw")

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -27,6 +27,16 @@
             {% endif %}
         </div>
 
+        <div class="flex flex-col gap-2">
+            <a href="{% url 'travel_safety:register' %}"
+               class="block py-4 px-6 text-2xl font-bold text-white bg-sky-700 rounded-lg shadow hover:bg-sky-600">
+                ✈️ Travel Safety Check-in
+            </a>
+            <p class="text-sm text-green-300">
+                Traveling internationally? Register your plans so we can check on your safe arrival.
+            </p>
+        </div>
+
         {% django_simple_nav "config.nav.MainNav" %}
 
         <div class="text-xl">version {{ app_version }}</div>


### PR DESCRIPTION
Adds a second homepage CTA below the volunteer button: "✈️ Travel Safety Check-in" linking to the public travel-safety registration form (`travel_safety:register`), styled in sky blue so it reads as a distinct action from the yellow volunteer CTA, with a one-line hint aimed at international attendees. Test updated.