### PR TITLE
Redesign homepage with side-by-side volunteer and travel panels

### DIFF
--- a/config/tests/test_homepage.py
+++ b/config/tests/test_homepage.py
@@ -6,24 +6,28 @@ User = get_user_model()
 
 
 @pytest.mark.django_db
-class TestHomepageVolunteerCTA:
-    def test_anonymous_sees_cta_and_signin_hint(self, client):
+class TestHomepagePanels:
+    def test_everyone_sees_both_panels(self, client):
         response = client.get(reverse("home"))
         assert response.status_code == 200
         content = response.content.decode()
         assert reverse("volunteers:shifts") in content
-        assert "Volunteer at DjangoCon US" in content
-        assert "sign in when you're ready" in content
-        assert reverse("volunteers:my_shifts") not in content
+        assert "DjangoCon US Volunteers" in content
         assert reverse("travel_safety:register") in content
-        assert "Travel Safety Check-in" in content
+        assert "Traveling to DjangoCon US" in content
 
-    def test_authenticated_sees_cta_and_my_shifts(self, client):
+    def test_anonymous_sees_signin_row(self, client):
+        response = client.get(reverse("home"))
+        content = response.content.decode()
+        assert reverse("account_login") in content
+        assert "Sign In or Register" in content
+        assert reverse("volunteers:my_shifts") not in content
+
+    def test_authenticated_sees_my_shifts_and_nav(self, client):
         user = User.objects.create_user(username="vol", email="vol@example.com", password="pw")
         client.force_login(user)
         response = client.get(reverse("home"))
-        assert response.status_code == 200
         content = response.content.decode()
-        assert reverse("volunteers:shifts") in content
-        assert "Volunteer at DjangoCon US" in content
         assert reverse("volunteers:my_shifts") in content
+        assert "Sign In or Register" not in content
+        assert reverse("account_logout") in content

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -5,39 +5,44 @@
 {% block title %}DjangoCon US - Homepage{% endblock title %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-12 max-w-lg text-center text-green-200 bg-green-900 rounded-xl shadow-inner">
+    <div class="flex flex-col gap-8 p-12 mx-auto max-w-3xl text-center text-green-200 bg-green-900 rounded-xl shadow-inner">
         <div class="text-6xl font-bold sm:tracking-tight">
             <div class="text-yellow-200">DjangoCon US</div>
             <div class="text-green-300">Automations</div>
         </div>
 
-        <div class="flex flex-col gap-2">
+        <div class="grid gap-6 md:grid-cols-2">
             <a href="{% url 'volunteers:shifts' %}"
-               class="block py-4 px-6 text-2xl font-bold text-green-900 bg-yellow-300 rounded-lg shadow hover:bg-yellow-200">
-                🙋 Volunteer at DjangoCon US
+               class="flex flex-col gap-3 justify-center p-8 text-green-900 bg-yellow-300 rounded-xl shadow hover:bg-yellow-200">
+                <span class="text-5xl">🙋</span>
+                <span class="text-2xl font-bold">DjangoCon US Volunteers</span>
+                <span class="text-sm">
+                    Sign up for shifts, see your schedule, and pick up more times.
+                </span>
             </a>
-            {% if user.is_authenticated %}
-                <a href="{% url 'volunteers:my_shifts' %}" class="text-sm text-yellow-300 underline hover:text-yellow-200">
-                    View my shifts
-                </a>
-            {% else %}
-                <p class="text-sm text-green-300">
-                    Browse open shifts — sign in when you're ready to claim one.
-                </p>
-            {% endif %}
-        </div>
 
-        <div class="flex flex-col gap-2">
             <a href="{% url 'travel_safety:register' %}"
-               class="block py-4 px-6 text-2xl font-bold text-white bg-sky-700 rounded-lg shadow hover:bg-sky-600">
-                ✈️ Travel Safety Check-in
+               class="flex flex-col gap-3 justify-center p-8 text-white bg-sky-700 rounded-xl shadow hover:bg-sky-600">
+                <span class="text-5xl">✈️</span>
+                <span class="text-2xl font-bold">Traveling to DjangoCon US</span>
+                <span class="text-sm">
+                    Register your travel plans so we can check on your safe arrival.
+                </span>
             </a>
-            <p class="text-sm text-green-300">
-                Traveling internationally? Register your plans so we can check on your safe arrival.
-            </p>
         </div>
 
-        {% django_simple_nav "config.nav.MainNav" %}
+        {% if user.is_authenticated %}
+            <a href="{% url 'volunteers:my_shifts' %}" class="text-sm text-yellow-300 underline hover:text-yellow-200">
+                View my shifts
+            </a>
+
+            {% django_simple_nav "config.nav.MainNav" %}
+        {% else %}
+            <a href="{% url 'account_login' %}"
+               class="block py-4 px-6 mx-auto w-full max-w-md text-xl font-semibold text-white bg-green-600 rounded-lg shadow hover:bg-green-700">
+                Sign In or Register
+            </a>
+        {% endif %}
 
         <div class="text-xl">version {{ app_version }}</div>
     </div>


### PR DESCRIPTION
Follow-up to #100/#104, per Jeff's direction.

- Widens the homepage card (`max-w-lg` → `max-w-3xl`).
- The two calls-to-action become equal side-by-side panels (stacked on mobile): **🙋 DjangoCon US Volunteers** and **✈️ Traveling to DjangoCon US** — each a full-panel link with an icon, title, and one-line description, so visitors pick one or the other.
- Below the panels, sign-in gets its own full-width row: anonymous visitors see a prominent "Sign In or Register" button (replacing the plain nav link they used to get); signed-in users see their "View my shifts" link and the regular nav groups as before.

Tests updated for the new layout.