### PR TITLE
Put GitHub and magic-link options first on the signup page

### DIFF
--- a/config/tests/test_signup_page.py
+++ b/config/tests/test_signup_page.py
@@ -1,0 +1,18 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_signup_page_puts_github_and_magic_link_before_password_form(client):
+    response = client.get(reverse("account_signup"))
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    github = content.index("Sign Up with GitHub")
+    magic_link = content.index(reverse("account_request_login_code"))
+    divider = content.index("or sign up with email")
+    password_form = content.index('action="' + reverse("account_signup"))
+
+    assert github < divider
+    assert magic_link < divider
+    assert divider < password_form

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -15,6 +15,24 @@
             </div>
         {% endif %}
 
+        <div class="space-y-3">
+            <a href="{% url 'github_login' %}"
+               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                🐙 Sign Up with GitHub
+            </a>
+
+            <a href="{% url 'account_request_login_code' %}"
+               class="block py-3 px-4 w-full text-lg font-semibold text-green-900 bg-yellow-300 rounded-lg hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                ✉️ Email Me a Sign-In Link
+            </a>
+        </div>
+
+        <div class="flex items-center gap-3 text-sm text-gray-400">
+            <div class="flex-1 border-t border-green-700"></div>
+            or sign up with email &amp; password
+            <div class="flex-1 border-t border-green-700"></div>
+        </div>
+
         <form method="POST" action="{% url 'account_signup' %}" class="space-y-4">
             {% csrf_token %}
 
@@ -74,17 +92,10 @@
             </button>
         </form>
 
-        <div class="pt-4 space-y-3 border-t border-green-700">
-            <a href="{% url 'github_login' %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
-                🐙 Sign Up with GitHub
+        <div class="pt-4 text-sm text-gray-400 border-t border-green-700">
+            <a href="{% url 'account_login' %}" class="text-yellow-300 underline hover:text-yellow-200">
+                Already have an account? Sign in
             </a>
-
-            <div class="text-sm text-gray-400">
-                <a href="{% url 'account_login' %}" class="text-yellow-300 underline hover:text-yellow-200">
-                    Already have an account? Sign in
-                </a>
-            </div>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Reorders the signup page so the low-friction options lead:

1. **🐙 Sign Up with GitHub** and **✉️ Email Me a Sign-In Link** buttons first
2. an "or sign up with email & password" divider
3. the email/password form below

The "Already have an account? Sign in" link stays at the bottom. Adds a test asserting the ordering.