### PR TITLE
Put GitHub and magic-link options first on the login page

### DIFF
--- a/config/tests/test_login_page.py
+++ b/config/tests/test_login_page.py
@@ -1,0 +1,18 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_login_page_puts_github_and_magic_link_before_password_form(client):
+    response = client.get(reverse("account_login"))
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    github = content.index("Sign In with GitHub")
+    magic_link = content.index(reverse("account_request_login_code"))
+    divider = content.index("or sign in with email")
+    password_form = content.index('action="' + reverse("account_login"))
+
+    assert github < divider
+    assert magic_link < divider
+    assert divider < password_form

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -15,6 +15,24 @@
             </div>
         {% endif %}
 
+        <div class="space-y-3">
+            <a href="{% url 'github_login' %}"
+               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                🐙 Sign In with GitHub
+            </a>
+
+            <a href="{% url 'account_request_login_code' %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}"
+               class="block py-3 px-4 w-full text-lg font-semibold text-green-900 bg-yellow-300 rounded-lg hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                ✉️ Email Me a Sign-In Link
+            </a>
+        </div>
+
+        <div class="flex items-center gap-3 text-sm text-gray-400">
+            <div class="flex-1 border-t border-green-700"></div>
+            or sign in with email &amp; password
+            <div class="flex-1 border-t border-green-700"></div>
+        </div>
+
         <form method="POST" action="{% url 'account_login' %}" class="space-y-4">
             {% csrf_token %}
 
@@ -59,22 +77,10 @@
             </button>
         </form>
 
-        <div class="pt-4 space-y-3 border-t border-green-700">
-            <a href="{% url 'github_login' %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
-                🐙 Sign In with GitHub
+        <div class="pt-4 text-sm text-gray-400 border-t border-green-700">
+            <a href="{% url 'account_signup' %}" class="text-yellow-300 underline hover:text-yellow-200">
+                Don't have an account? Sign up
             </a>
-
-            <a href="{% url 'account_request_login_code' %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-green-900 bg-yellow-300 rounded-lg hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
-                ✉️ Email Me a Sign-In Link
-            </a>
-
-            <div class="text-sm text-gray-400">
-                <a href="{% url 'account_signup' %}" class="text-yellow-300 underline hover:text-yellow-200">
-                    Don't have an account? Sign up
-                </a>
-            </div>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Same treatment as #106, for the login page: 🐙 GitHub and ✉️ magic-link buttons lead, then an "or sign in with email & password" divider, then the password form, with the sign-up link at the bottom. Ordering test included.