### PR TITLE
Make email sending configurable via EMAIL_URL

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,6 +1,11 @@
 ALLOWED_HOSTS=*
 DATABASE_URL=postgres://postgres@db/postgres
 DJANGO_DEBUG=true
+# Email: leave EMAIL_URL unset to print emails to the console (dev default).
+# Production example: EMAIL_URL=submission://USER:PASSWORD@smtp.example.com:587
+# EMAIL_URL=
+# DEFAULT_FROM_EMAIL=DjangoCon US <automation@defna.org>
+# SERVER_EMAIL=automation@defna.org
 SLACK_OAUTH_TOKEN=
 SLACK_CHANNEL_ID=
 TITO_SECURITY_TOKEN=

--- a/config/settings.py
+++ b/config/settings.py
@@ -233,6 +233,27 @@ LOGGING = {
     },
 }
 
+# Email sending (#90). Configure entirely via EMAIL_URL, e.g.:
+#   submission://USER:PASSWORD@smtp.example.com:587   (STARTTLS)
+#   smtp://USER:PASSWORD@smtp.example.com:465?ssl=True (implicit TLS)
+# The default is the console backend, so environments without EMAIL_URL print
+# emails to stdout instead of dying with ConnectionRefusedError on localhost:25.
+# An unrecognized scheme fails at startup with KeyError("EMAIL_BACKEND") — loud
+# beats silently sending nothing.
+
+email = env.dj_email_url("EMAIL_URL", default="console://")
+EMAIL_BACKEND = email["EMAIL_BACKEND"]
+EMAIL_HOST = email["EMAIL_HOST"]
+EMAIL_PORT = email["EMAIL_PORT"]
+EMAIL_HOST_USER = email["EMAIL_HOST_USER"]
+EMAIL_HOST_PASSWORD = email["EMAIL_HOST_PASSWORD"]
+EMAIL_USE_TLS = email["EMAIL_USE_TLS"]
+EMAIL_USE_SSL = email["EMAIL_USE_SSL"]
+EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", default=10)
+
+DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", default="DjangoCon US <automation@defna.org>")
+SERVER_EMAIL = env.str("SERVER_EMAIL", default="automation@defna.org")
+
 # Email Octopus API settings
 
 EMAILOCTOPUS_API_KEY = env("EMAILOCTOPUS_API_KEY", default="")

--- a/config/tests/test_email_settings.py
+++ b/config/tests/test_email_settings.py
@@ -1,0 +1,25 @@
+import environs
+from django.conf import settings
+
+
+def test_email_url_parses_smtp_tls(monkeypatch):
+    """Documents the EMAIL_URL format expected in production (Coolify env)."""
+    monkeypatch.setenv("EMAIL_URL", "submission://user:secret@smtp.example.com:587")
+    email = environs.Env().dj_email_url("EMAIL_URL")
+    assert email["EMAIL_BACKEND"] == "django.core.mail.backends.smtp.EmailBackend"
+    assert email["EMAIL_HOST"] == "smtp.example.com"
+    assert email["EMAIL_PORT"] == 587
+    assert email["EMAIL_HOST_USER"] == "user"
+    assert email["EMAIL_HOST_PASSWORD"] == "secret"
+    assert email["EMAIL_USE_TLS"] is True
+
+
+def test_unconfigured_email_defaults_to_console(monkeypatch):
+    monkeypatch.delenv("EMAIL_URL", raising=False)
+    email = environs.Env().dj_email_url("EMAIL_URL", default="console://")
+    assert email["EMAIL_BACKEND"] == "django.core.mail.backends.console.EmailBackend"
+
+
+def test_from_addresses_have_defaults():
+    assert settings.DEFAULT_FROM_EMAIL
+    assert settings.SERVER_EMAIL

--- a/config/tests/test_login_page.py
+++ b/config/tests/test_login_page.py
@@ -1,0 +1,18 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_login_page_puts_github_and_magic_link_before_password_form(client):
+    response = client.get(reverse("account_login"))
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    github = content.index("Sign In with GitHub")
+    magic_link = content.index(reverse("account_request_login_code"))
+    divider = content.index("or sign in with email")
+    password_form = content.index('action="' + reverse("account_login"))
+
+    assert github < divider
+    assert magic_link < divider
+    assert divider < password_form

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -15,6 +15,24 @@
             </div>
         {% endif %}
 
+        <div class="space-y-3">
+            <a href="{% url 'github_login' %}"
+               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                🐙 Sign In with GitHub
+            </a>
+
+            <a href="{% url 'account_request_login_code' %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}"
+               class="block py-3 px-4 w-full text-lg font-semibold text-green-900 bg-yellow-300 rounded-lg hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                ✉️ Email Me a Sign-In Link
+            </a>
+        </div>
+
+        <div class="flex items-center gap-3 text-sm text-gray-400">
+            <div class="flex-1 border-t border-green-700"></div>
+            or sign in with email &amp; password
+            <div class="flex-1 border-t border-green-700"></div>
+        </div>
+
         <form method="POST" action="{% url 'account_login' %}" class="space-y-4">
             {% csrf_token %}
 
@@ -59,22 +77,10 @@
             </button>
         </form>
 
-        <div class="pt-4 space-y-3 border-t border-green-700">
-            <a href="{% url 'github_login' %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
-                🐙 Sign In with GitHub
+        <div class="pt-4 text-sm text-gray-400 border-t border-green-700">
+            <a href="{% url 'account_signup' %}" class="text-yellow-300 underline hover:text-yellow-200">
+                Don't have an account? Sign up
             </a>
-
-            <a href="{% url 'account_request_login_code' %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-green-900 bg-yellow-300 rounded-lg hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
-                ✉️ Email Me a Sign-In Link
-            </a>
-
-            <div class="text-sm text-gray-400">
-                <a href="{% url 'account_signup' %}" class="text-yellow-300 underline hover:text-yellow-200">
-                    Don't have an account? Sign up
-                </a>
-            </div>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Groundwork for #90 — the app-side half of email configuration.

- Adds an `EMAIL_URL` env setting parsed with environs' `dj_email_url` (same pattern as `DATABASE_URL`): `submission://USER:PASSWORD@host:587` for STARTTLS, `smtp://…?ssl=True` for implicit TLS.
- **Default is the console backend**, so any environment without `EMAIL_URL` prints emails to stdout instead of 500ing with `ConnectionRefusedError` on `localhost:25` — this alone stops password reset and the new magic-link flow from crashing in prod before SMTP creds exist.
- An unrecognized scheme fails loudly at startup (`KeyError: EMAIL_BACKEND`) rather than silently not sending.
- Adds `EMAIL_TIMEOUT` (default 10s), `DEFAULT_FROM_EMAIL` (`DjangoCon US <automation@defna.org>`), and `SERVER_EMAIL` env settings, and documents everything in `.env-dist`.
- Tests document the expected URL formats and the console default.

What remains for #90 after this merges: set `EMAIL_URL` (and optionally `DEFAULT_FROM_EMAIL`/`SERVER_EMAIL`) in the Coolify UI, and set up the DNS records (SPF/DKIM/DMARC) for the sending domain.