### PR TITLE
Restyle homepage panels as matching green cards

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -13,19 +13,19 @@
 
         <div class="grid gap-6 md:grid-cols-2">
             <a href="{% url 'volunteers:shifts' %}"
-               class="flex flex-col gap-3 justify-center p-8 text-green-900 bg-yellow-300 rounded-xl shadow hover:bg-yellow-200">
+               class="flex flex-col gap-3 justify-center p-8 bg-green-800 rounded-xl border border-green-700 shadow hover:border-yellow-300">
                 <span class="text-5xl">🙋</span>
-                <span class="text-2xl font-bold">DjangoCon US Volunteers</span>
-                <span class="text-sm">
+                <span class="text-2xl font-bold text-yellow-200">DjangoCon US Volunteers</span>
+                <span class="text-sm text-green-200">
                     Sign up for shifts, see your schedule, and pick up more times.
                 </span>
             </a>
 
             <a href="{% url 'travel_safety:register' %}"
-               class="flex flex-col gap-3 justify-center p-8 text-white bg-sky-700 rounded-xl shadow hover:bg-sky-600">
+               class="flex flex-col gap-3 justify-center p-8 bg-green-800 rounded-xl border border-green-700 shadow hover:border-yellow-300">
                 <span class="text-5xl">✈️</span>
-                <span class="text-2xl font-bold">Traveling to DjangoCon US</span>
-                <span class="text-sm">
+                <span class="text-2xl font-bold text-yellow-200">Traveling to DjangoCon US</span>
+                <span class="text-sm text-green-200">
                     Register your travel plans so we can check on your safe arrival.
                 </span>
             </a>


### PR DESCRIPTION
Per Jeff: the yellow + blue panel backgrounds were too loud. Both panels now use the site's card idiom — dark green background, green border, yellow heading, green body text — with the border brightening to yellow on hover. The emoji and titles carry the distinction between the two.