### PR TITLE
Alert coordinators when a near-term shift loses its last volunteer

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -303,6 +303,17 @@ Q_SCHEDULES = {
 
 VOLUNTEER_MAX_HOURS = env.int("VOLUNTEER_MAX_HOURS", default=8)
 
+# Coordinators to alert when a near-term shift loses its last volunteer (#84).
+# Empty (the default) disables the alert entirely.
+VOLUNTEER_COORDINATOR_EMAILS = env.list("VOLUNTEER_COORDINATOR_EMAILS", default=[])
+
+# Only alert for shifts starting within this window...
+VOLUNTEER_UNCOVERED_ALERT_WINDOW_HOURS = env.int("VOLUNTEER_UNCOVERED_ALERT_WINDOW_HOURS", default=48)
+
+# ...and skip the alert when the volunteer signed up and cancelled within this
+# buffer — a quick change of mind isn't worth an email.
+VOLUNTEER_UNCOVERED_ALERT_BUFFER_MINUTES = env.int("VOLUNTEER_UNCOVERED_ALERT_BUFFER_MINUTES", default=60)
+
 # General volunteer handbook, shown alongside role-specific docs.
 VOLUNTEER_HANDBOOK_URL = env.str(
     "VOLUNTEER_HANDBOOK_URL",

--- a/volunteers/tasks.py
+++ b/volunteers/tasks.py
@@ -53,17 +53,21 @@ def send_shift_reminders():
     return sent
 
 
-def notify_shift_uncovered(shift, cancelled_signup):
+def notify_shift_uncovered(signup_id):
     """Alert the coordinators when a near-term shift just lost its last volunteer.
 
-    Skips quietly when: no coordinator emails are configured, the shift still has
-    active signups, it starts outside the alert window (or already started), or
-    the volunteer signed up and cancelled within the buffer — a quick change of
-    mind isn't worth an email. Returns True when an alert was sent.
+    Dispatched via django-q2's async_task from the cancel view, with the
+    cancelled signup's pk. Skips quietly when: no coordinator emails are
+    configured, the shift still has active signups, it starts outside the alert
+    window (or already started), or the volunteer signed up and cancelled within
+    the buffer — a quick change of mind isn't worth an email. Returns True when
+    an alert was sent.
     """
     recipients = settings.VOLUNTEER_COORDINATOR_EMAILS
     if not recipients:
         return False
+    cancelled_signup = VolunteerSignup.objects.select_related("shift", "shift__role", "user").get(pk=signup_id)
+    shift = cancelled_signup.shift
     if shift.active_signups.exists():
         return False
 

--- a/volunteers/tasks.py
+++ b/volunteers/tasks.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 
 from django.conf import settings
 from django.core.mail import send_mail
@@ -7,6 +8,8 @@ from django.utils import timezone
 from rich import print
 
 from volunteers.models import VolunteerSignup
+
+logger = logging.getLogger(__name__)
 
 # How far ahead of a shift we send the reminder.
 REMINDER_WINDOW_HOURS = 24
@@ -48,3 +51,45 @@ def send_shift_reminders():
 
     print(f"[green]Sent {sent} volunteer shift reminder(s).[/green]")
     return sent
+
+
+def notify_shift_uncovered(shift, cancelled_signup):
+    """Alert the coordinators when a near-term shift just lost its last volunteer.
+
+    Skips quietly when: no coordinator emails are configured, the shift still has
+    active signups, it starts outside the alert window (or already started), or
+    the volunteer signed up and cancelled within the buffer — a quick change of
+    mind isn't worth an email. Returns True when an alert was sent.
+    """
+    recipients = settings.VOLUNTEER_COORDINATOR_EMAILS
+    if not recipients:
+        return False
+    if shift.active_signups.exists():
+        return False
+
+    now = timezone.now()
+    window_end = now + datetime.timedelta(hours=settings.VOLUNTEER_UNCOVERED_ALERT_WINDOW_HOURS)
+    if not (now <= shift.starts_at <= window_end):
+        return False
+
+    buffer = datetime.timedelta(minutes=settings.VOLUNTEER_UNCOVERED_ALERT_BUFFER_MINUTES)
+    if now - cancelled_signup.created_at < buffer:
+        return False
+
+    body = render_to_string(
+        "volunteers/email/shift_uncovered.txt",
+        {"shift": shift, "user": cancelled_signup.user},
+    )
+    try:
+        send_mail(
+            subject=f"Volunteer needed: “{shift.title}” just lost its only volunteer",
+            message=body,
+            from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
+            recipient_list=recipients,
+            fail_silently=False,
+        )
+    except Exception:
+        # Never let a broken mail server break the volunteer's cancel action.
+        logger.exception("Failed to send uncovered-shift alert for shift %s", shift.pk)
+        return False
+    return True

--- a/volunteers/templates/volunteers/email/shift_uncovered.txt
+++ b/volunteers/templates/volunteers/email/shift_uncovered.txt
@@ -1,0 +1,13 @@
+Heads up,
+
+This upcoming volunteer shift just lost its only volunteer and is now uncovered:
+
+  {{ shift.title }} ({{ shift.role.name }})
+  {{ shift.starts_at|date:"l, F j" }} from {{ shift.starts_at|date:"g:i A" }} to {{ shift.ends_at|date:"g:i A" }}
+{% if shift.location %}  Location: {{ shift.location }}
+{% endif %}
+{{ user.get_full_name|default:user.email }} cancelled their signup.
+
+You may want to find a replacement or cover it from the dashboard.
+
+— The DjangoCon US Automation

--- a/volunteers/templates/volunteers/my_shifts.html
+++ b/volunteers/templates/volunteers/my_shifts.html
@@ -5,7 +5,7 @@
 {% block extra_head %}{% include "volunteers/_print_styles.html" %}{% endblock extra_head %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 max-w-3xl text-green-100">
+    <div class="flex max-w-3xl flex-col gap-6 p-8 text-green-100">
         <div class="text-center">
             <h1 class="mb-2 text-4xl font-bold text-yellow-200">My Volunteer Shifts</h1>
             <p class="text-green-200">
@@ -29,7 +29,7 @@
 
         <div class="flex flex-col gap-3">
             {% for signup in signups %}
-                <div class="flex flex-col gap-2 p-4 bg-green-800 rounded-lg border border-green-700 md:flex-row md:justify-between md:items-center shift-card">
+                <div class="shift-card flex flex-col gap-2 rounded-lg border border-green-700 bg-green-800 p-4 md:flex-row md:items-center md:justify-between">
                     <div>
                         <p class="text-lg font-semibold text-yellow-100">{{ signup.shift.title }}</p>
                         <p class="text-sm text-green-300">
@@ -48,7 +48,7 @@
                     <form method="post" action="{% url 'volunteers:cancel' signup.shift.id %}" class="shrink-0">
                         {% csrf_token %}
                         <input type="hidden" name="next" value="{{ request.get_full_path }}">
-                        <button type="submit" class="py-2 px-3 text-sm font-medium text-red-100 bg-red-700 rounded-md border border-red-600 hover:bg-red-600">
+                        <button type="submit" class="rounded-md border border-red-600 bg-red-700 px-3 py-2 text-sm font-medium text-red-100 hover:bg-red-600">
                             Cancel
                         </button>
                     </form>
@@ -59,20 +59,20 @@
         </div>
 
         {% if contact_info %}
-            <div class="p-4 bg-green-800 rounded-lg border border-green-700">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-4">
                 <h2 class="mb-2 text-lg font-semibold text-yellow-300">📇 Volunteer contacts</h2>
                 <div class="max-w-none prose prose-invert" data-markdown>{{ contact_info }}</div>
             </div>
         {% endif %}
 
         {% if signups %}
-            <div class="p-4 bg-green-800 rounded-lg border border-green-700 print-hide">
+            <div class="print-hide rounded-lg border border-green-700 bg-green-800 p-4">
                 <h2 class="mb-2 text-lg font-semibold text-yellow-300">📅 Subscribe to your shifts</h2>
                 <p class="mb-2 text-sm text-green-200">
                     Add this private calendar URL to Google Calendar, Apple Calendar, or Outlook to
                     keep your shifts in sync:
                 </p>
-                <code class="block p-2 text-xs text-green-100 break-all bg-green-900 rounded border border-green-700">{{ calendar_url }}</code>
+                <code class="block rounded border border-green-700 bg-green-900 p-2 text-xs break-all text-green-100">{{ calendar_url }}</code>
             </div>
         {% endif %}
     </div>

--- a/volunteers/templates/volunteers/shift_list.html
+++ b/volunteers/templates/volunteers/shift_list.html
@@ -5,7 +5,7 @@
 {% block extra_head %}{% include "volunteers/_print_styles.html" %}{% endblock extra_head %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 max-w-4xl text-green-100">
+    <div class="flex max-w-4xl flex-col gap-6 p-8 text-green-100">
         <div class="text-center">
             <h1 class="mb-2 text-4xl font-bold text-yellow-200">Volunteer Sign-up</h1>
             {% if user.is_authenticated %}
@@ -27,7 +27,7 @@
         </div>
 
         {% if my_upcoming %}
-            <section class="print-hide p-4 bg-green-800 rounded-lg border border-yellow-300">
+            <section class="print-hide rounded-lg border border-yellow-300 bg-green-800 p-4">
                 <h2 class="mb-2 text-lg font-semibold text-yellow-300">Your upcoming shifts</h2>
                 <ul class="space-y-1 text-sm text-green-100">
                     {% for signup in my_upcoming %}
@@ -38,7 +38,7 @@
                         </li>
                     {% endfor %}
                 </ul>
-                <a href="{% url 'volunteers:my_shifts' %}" class="inline-block mt-2 text-sm text-yellow-300 underline hover:text-yellow-200">
+                <a href="{% url 'volunteers:my_shifts' %}" class="mt-2 inline-block text-sm text-yellow-300 underline hover:text-yellow-200">
                     See my full schedule &amp; calendar feed
                 </a>
             </section>
@@ -52,21 +52,21 @@
             {% endfor %}
         {% endif %}
 
-        <form method="get" class="flex flex-wrap gap-3 items-end p-4 bg-green-800 rounded-lg border border-green-700">
+        <form method="get" class="flex flex-wrap items-end gap-3 rounded-lg border border-green-700 bg-green-800 p-4">
             <div>
-                <label class="block mb-1 text-xs text-green-300" for="role">Role</label>
-                <select name="role" id="role" class="p-2 text-sm text-green-900 rounded-md">
+                <label class="mb-1 block text-xs text-green-300" for="role">Role</label>
+                <select name="role" id="role" class="rounded-md p-2 text-sm text-green-900">
                     <option value="">All roles</option>
                     {% for role in roles %}
                         <option value="{{ role }}" {% if role == role_filter %}selected{% endif %}>{{ role }}</option>
                     {% endfor %}
                 </select>
             </div>
-            <label class="flex gap-2 items-center text-sm text-green-200">
+            <label class="flex items-center gap-2 text-sm text-green-200">
                 <input type="checkbox" name="needs_help" value="1" {% if needs_help %}checked{% endif %}>
                 Where we need help
             </label>
-            <button type="submit" class="py-2 px-4 text-sm font-semibold text-green-900 bg-yellow-300 rounded-md hover:bg-yellow-200">
+            <button type="submit" class="rounded-md bg-yellow-300 px-4 py-2 text-sm font-semibold text-green-900 hover:bg-yellow-200">
                 Filter
             </button>
             {% if role_filter or needs_help %}
@@ -75,18 +75,18 @@
         </form>
 
         {% for day, shifts in days %}
-            <section class="p-6 bg-green-800 rounded-lg border border-green-700">
+            <section class="rounded-lg border border-green-700 bg-green-800 p-6">
                 <h2 class="mb-4 text-2xl font-semibold text-yellow-300">{{ day|date:"l, F j" }}</h2>
                 {% regroup shifts by starts_at as time_groups %}
                 <div class="flex flex-col gap-6">
                     {% for slot in time_groups %}
-                        <div class="flex flex-col gap-2 pl-4 border-l-2 border-green-600">
-                            <div class="flex flex-wrap gap-2 items-baseline">
+                        <div class="flex flex-col gap-2 border-l-2 border-green-600 pl-4">
+                            <div class="flex flex-wrap items-baseline gap-2">
                                 <h3 class="text-lg font-semibold text-yellow-100">
                                     <time datetime="{{ slot.grouper|date:'c' }}" class="whitespace-nowrap">{{ slot.grouper|date:"g:i A" }}</time>
                                 </h3>
                                 {% if slot.list|length > 1 %}
-                                    <span class="py-0.5 px-2 text-xs font-semibold text-green-900 bg-yellow-300 rounded-full">
+                                    <span class="rounded-full bg-yellow-300 px-2 py-0.5 text-xs font-semibold text-green-900">
                                         {{ slot.list|length }} shifts at this time — sign up for any
                                     </span>
                                 {% endif %}
@@ -125,28 +125,28 @@
                                         <div class="mt-auto">
                                             {% if not user.is_authenticated %}
                                                 {% if shift.signups_open %}
-                                                    <a href="{% url 'account_login' %}?next={{ request.path }}" class="inline-block py-2 px-4 text-sm font-semibold text-green-900 bg-yellow-300 rounded-md hover:bg-yellow-200">
+                                                    <a href="{% url 'account_login' %}?next={{ request.path }}" class="inline-block rounded-md bg-yellow-300 px-4 py-2 text-sm font-semibold text-green-900 hover:bg-yellow-200">
                                                         Sign in to sign up
                                                     </a>
                                                 {% else %}
-                                                    <span class="py-2 px-3 text-sm text-green-400">Signups closed</span>
+                                                    <span class="px-3 py-2 text-sm text-green-400">Signups closed</span>
                                                 {% endif %}
                                             {% elif shift.id in my_shift_ids %}
                                                 <form method="post" action="{% url 'volunteers:cancel' shift.id %}">
                                                     {% csrf_token %}
                                                     <input type="hidden" name="next" value="{{ request.get_full_path }}">
                                                     <span class="mr-2 text-sm text-green-300">✓ Signed up</span>
-                                                    <button type="submit" class="py-2 px-3 text-sm font-medium text-red-100 bg-red-700 rounded-md border border-red-600 hover:bg-red-600">
+                                                    <button type="submit" class="rounded-md border border-red-600 bg-red-700 px-3 py-2 text-sm font-medium text-red-100 hover:bg-red-600">
                                                         Cancel
                                                     </button>
                                                 </form>
                                             {% elif not shift.signups_open %}
-                                                <span class="py-2 px-3 text-sm text-green-400">Signups closed</span>
+                                                <span class="px-3 py-2 text-sm text-green-400">Signups closed</span>
                                             {% else %}
                                                 <form method="post" action="{% url 'volunteers:signup' shift.id %}">
                                                     {% csrf_token %}
                                                     <input type="hidden" name="next" value="{{ request.get_full_path }}">
-                                                    <button type="submit" class="py-2 px-4 text-sm font-semibold text-green-900 bg-yellow-300 rounded-md hover:bg-yellow-200">
+                                                    <button type="submit" class="rounded-md bg-yellow-300 px-4 py-2 text-sm font-semibold text-green-900 hover:bg-yellow-200">
                                                         Sign up
                                                     </button>
                                                 </form>

--- a/volunteers/templates/volunteers/volunteers_list.html
+++ b/volunteers/templates/volunteers/volunteers_list.html
@@ -8,23 +8,23 @@
 
 {% block content %}
     <div class="flex flex-col gap-6 p-8 text-green-100">
-        <div class="flex flex-wrap gap-3 justify-between items-center">
+        <div class="flex flex-wrap items-center justify-between gap-3">
             <h1 class="text-4xl font-bold text-yellow-200">Volunteers</h1>
-            <a href="{% url 'volunteers:dashboard' %}" class="text-sm text-green-300 underline print-hide">← Shift dashboard</a>
+            <a href="{% url 'volunteers:dashboard' %}" class="print-hide text-sm text-green-300 underline">← Shift dashboard</a>
         </div>
 
         <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <div class="p-4 bg-green-800 rounded-lg border border-green-700">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-4">
                 <p class="text-3xl font-bold text-yellow-200">{{ total_volunteers }}</p>
                 <p class="text-sm text-green-300">Volunteers signed up</p>
             </div>
-            <div class="p-4 bg-green-800 rounded-lg border border-green-700">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-4">
                 <p class="text-3xl font-bold text-yellow-200">{{ total_hours|floatformat:1 }}</p>
                 <p class="text-sm text-green-300">Total volunteer hours</p>
             </div>
         </div>
 
-        <div class="flex flex-wrap gap-2 items-center text-sm print-hide">
+        <div class="print-hide flex flex-wrap items-center gap-2 text-sm">
             <span class="text-green-300">Sort by:</span>
             {% for key, label in sorts %}
                 <a href="?sort={{ key }}"
@@ -35,9 +35,9 @@
         </div>
 
         <div class="overflow-x-auto">
-            <table class="w-full text-left border-collapse">
+            <table class="w-full border-collapse text-left">
                 <thead>
-                    <tr class="text-yellow-300 border-b border-green-700">
+                    <tr class="border-b border-green-700 text-yellow-300">
                         <th class="p-3">Volunteer</th>
                         <th class="p-3">Email</th>
                         <th class="p-3">Roles</th>

--- a/volunteers/tests/test_uncovered_alert.py
+++ b/volunteers/tests/test_uncovered_alert.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -7,6 +8,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from volunteers.models import Role, Shift, VolunteerSignup
+from volunteers.tasks import notify_shift_uncovered
 
 User = get_user_model()
 
@@ -44,23 +46,20 @@ def make_shift(role, *, start_offset_hours=24, length_hours=2):
     )
 
 
-def make_aged_signup(shift, user, *, age_minutes=120):
-    signup = VolunteerSignup.objects.create(shift=shift, user=user)
+def make_cancelled_signup(shift, user, *, age_minutes=120):
+    """A signup that existed for ``age_minutes`` and has just been cancelled."""
+    signup = VolunteerSignup.objects.create(shift=shift, user=user, cancelled=True)
     VolunteerSignup.objects.filter(pk=signup.pk).update(
         created_at=timezone.now() - datetime.timedelta(minutes=age_minutes)
     )
     return signup
 
 
-def cancel(client, shift):
-    return client.post(reverse("volunteers:cancel", args=[shift.id]))
-
-
-def test_alert_sent_when_last_volunteer_cancels_near_shift(auth_client, user, role):
+def test_alert_sent_when_last_volunteer_cancels_near_shift(user, role):
     shift = make_shift(role, start_offset_hours=24)
-    make_aged_signup(shift, user)
+    signup = make_cancelled_signup(shift, user)
 
-    cancel(auth_client, shift)
+    assert notify_shift_uncovered(signup.pk) is True
     assert len(mail.outbox) == 1
     message = mail.outbox[0]
     assert message.recipients() == COORDINATORS
@@ -68,49 +67,61 @@ def test_alert_sent_when_last_volunteer_cancels_near_shift(auth_client, user, ro
     assert "Test Shift" in message.body
 
 
-def test_no_alert_when_signup_and_cancel_within_buffer(auth_client, user, role):
+def test_no_alert_when_signup_and_cancel_within_buffer(user, role):
     shift = make_shift(role, start_offset_hours=24)
-    make_aged_signup(shift, user, age_minutes=10)
+    signup = make_cancelled_signup(shift, user, age_minutes=10)
 
-    cancel(auth_client, shift)
+    assert notify_shift_uncovered(signup.pk) is False
     assert len(mail.outbox) == 0
 
 
-def test_no_alert_when_shift_is_far_out(auth_client, user, role):
+def test_no_alert_when_shift_is_far_out(user, role):
     shift = make_shift(role, start_offset_hours=72)
-    make_aged_signup(shift, user)
+    signup = make_cancelled_signup(shift, user)
 
-    cancel(auth_client, shift)
+    assert notify_shift_uncovered(signup.pk) is False
     assert len(mail.outbox) == 0
 
 
-def test_no_alert_when_shift_still_covered(auth_client, user, role):
+def test_no_alert_when_shift_still_covered(user, role):
     shift = make_shift(role, start_offset_hours=24)
-    make_aged_signup(shift, user)
+    signup = make_cancelled_signup(shift, user)
     other = User.objects.create_user(username="other", email="other@example.com", password="pw12345!")
     VolunteerSignup.objects.create(shift=shift, user=other)
 
-    cancel(auth_client, shift)
+    assert notify_shift_uncovered(signup.pk) is False
     assert len(mail.outbox) == 0
 
 
-def test_no_alert_when_no_coordinators_configured(auth_client, user, role, settings):
+def test_no_alert_when_no_coordinators_configured(user, role, settings):
     settings.VOLUNTEER_COORDINATOR_EMAILS = []
     shift = make_shift(role, start_offset_hours=24)
-    make_aged_signup(shift, user)
+    signup = make_cancelled_signup(shift, user)
 
-    cancel(auth_client, shift)
+    assert notify_shift_uncovered(signup.pk) is False
     assert len(mail.outbox) == 0
 
 
-def test_re_signup_resets_the_buffer(auth_client, user, role):
+@patch("volunteers.views.async_task")
+def test_cancel_view_dispatches_alert_task(mock_async_task, auth_client, user, role):
+    shift = make_shift(role, start_offset_hours=24)
+    signup = VolunteerSignup.objects.create(shift=shift, user=user)
+
+    auth_client.post(reverse("volunteers:cancel", args=[shift.id]))
+    mock_async_task.assert_called_once_with("volunteers.tasks.notify_shift_uncovered", signup.pk)
+
+
+@patch("volunteers.views.async_task")
+def test_re_signup_resets_the_buffer(mock_async_task, auth_client, user, role):
     """Signing up again after a cancel starts a fresh buffer window, so an old
     original signup date can't sneak an alert past the debounce."""
     shift = make_shift(role, start_offset_hours=24)
-    make_aged_signup(shift, user, age_minutes=600)
+    signup = VolunteerSignup.objects.create(shift=shift, user=user)
+    VolunteerSignup.objects.filter(pk=signup.pk).update(created_at=timezone.now() - datetime.timedelta(hours=10))
 
-    cancel(auth_client, shift)
-    mail.outbox.clear()
+    auth_client.post(reverse("volunteers:cancel", args=[shift.id]))
     auth_client.post(reverse("volunteers:signup", args=[shift.id]))
-    cancel(auth_client, shift)
+    auth_client.post(reverse("volunteers:cancel", args=[shift.id]))
+
+    assert notify_shift_uncovered(signup.pk) is False
     assert len(mail.outbox) == 0

--- a/volunteers/tests/test_uncovered_alert.py
+++ b/volunteers/tests/test_uncovered_alert.py
@@ -1,0 +1,116 @@
+import datetime
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.urls import reverse
+from django.utils import timezone
+
+from volunteers.models import Role, Shift, VolunteerSignup
+
+User = get_user_model()
+
+COORDINATORS = ["rachell@example.com", "monica@example.com"]
+
+
+@pytest.fixture
+def role(db):
+    return Role.objects.create(name="Registration Desk")
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+
+
+@pytest.fixture
+def auth_client(client, user):
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def coordinator_emails(settings):
+    settings.VOLUNTEER_COORDINATOR_EMAILS = COORDINATORS
+
+
+def make_shift(role, *, start_offset_hours=24, length_hours=2):
+    start = timezone.now() + datetime.timedelta(hours=start_offset_hours)
+    return Shift.objects.create(
+        role=role,
+        title="Test Shift",
+        starts_at=start,
+        ends_at=start + datetime.timedelta(hours=length_hours),
+    )
+
+
+def make_aged_signup(shift, user, *, age_minutes=120):
+    signup = VolunteerSignup.objects.create(shift=shift, user=user)
+    VolunteerSignup.objects.filter(pk=signup.pk).update(
+        created_at=timezone.now() - datetime.timedelta(minutes=age_minutes)
+    )
+    return signup
+
+
+def cancel(client, shift):
+    return client.post(reverse("volunteers:cancel", args=[shift.id]))
+
+
+def test_alert_sent_when_last_volunteer_cancels_near_shift(auth_client, user, role):
+    shift = make_shift(role, start_offset_hours=24)
+    make_aged_signup(shift, user)
+
+    cancel(auth_client, shift)
+    assert len(mail.outbox) == 1
+    message = mail.outbox[0]
+    assert message.recipients() == COORDINATORS
+    assert "lost its only volunteer" in message.subject
+    assert "Test Shift" in message.body
+
+
+def test_no_alert_when_signup_and_cancel_within_buffer(auth_client, user, role):
+    shift = make_shift(role, start_offset_hours=24)
+    make_aged_signup(shift, user, age_minutes=10)
+
+    cancel(auth_client, shift)
+    assert len(mail.outbox) == 0
+
+
+def test_no_alert_when_shift_is_far_out(auth_client, user, role):
+    shift = make_shift(role, start_offset_hours=72)
+    make_aged_signup(shift, user)
+
+    cancel(auth_client, shift)
+    assert len(mail.outbox) == 0
+
+
+def test_no_alert_when_shift_still_covered(auth_client, user, role):
+    shift = make_shift(role, start_offset_hours=24)
+    make_aged_signup(shift, user)
+    other = User.objects.create_user(username="other", email="other@example.com", password="pw12345!")
+    VolunteerSignup.objects.create(shift=shift, user=other)
+
+    cancel(auth_client, shift)
+    assert len(mail.outbox) == 0
+
+
+def test_no_alert_when_no_coordinators_configured(auth_client, user, role, settings):
+    settings.VOLUNTEER_COORDINATOR_EMAILS = []
+    shift = make_shift(role, start_offset_hours=24)
+    make_aged_signup(shift, user)
+
+    cancel(auth_client, shift)
+    assert len(mail.outbox) == 0
+
+
+def test_re_signup_resets_the_buffer(auth_client, user, role):
+    """Signing up again after a cancel starts a fresh buffer window, so an old
+    original signup date can't sneak an alert past the debounce."""
+    shift = make_shift(role, start_offset_hours=24)
+    make_aged_signup(shift, user, age_minutes=600)
+
+    cancel(auth_client, shift)
+    mail.outbox.clear()
+    auth_client.post(reverse("volunteers:signup", args=[shift.id]))
+    cancel(auth_client, shift)
+    assert len(mail.outbox) == 0

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -16,6 +16,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_POST
 
 from .ical import build_calendar
+from .tasks import notify_shift_uncovered
 from .models import (
     CalendarToken,
     Role,
@@ -185,7 +186,10 @@ def signup_view(request, pk):
     if not created:
         signup.cancelled = False
         signup.reminded = False
-        signup.save(update_fields=["cancelled", "reminded"])
+        # Treat re-signing up as a fresh signup so the uncovered-shift alert's
+        # quick-change-of-mind buffer measures from now, not the original signup.
+        signup.created_at = timezone.now()
+        signup.save(update_fields=["cancelled", "reminded", "created_at"])
 
     messages.success(request, f"You're signed up for “{shift.title}.” Thank you!")
     return redirect(return_url)
@@ -198,6 +202,7 @@ def cancel_view(request, pk):
     signup = get_object_or_404(VolunteerSignup, shift_id=pk, user=request.user, cancelled=False)
     signup.cancelled = True
     signup.save(update_fields=["cancelled"])
+    notify_shift_uncovered(signup.shift, signup)
     messages.success(request, f"You've been removed from “{signup.shift.title}.”")
     return redirect(_return_url(request))
 

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -14,9 +14,9 @@ from django.utils import timezone
 from django.utils.dateparse import parse_date
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_POST
+from django_q.tasks import async_task
 
 from .ical import build_calendar
-from .tasks import notify_shift_uncovered
 from .models import (
     CalendarToken,
     Role,
@@ -202,7 +202,7 @@ def cancel_view(request, pk):
     signup = get_object_or_404(VolunteerSignup, shift_id=pk, user=request.user, cancelled=False)
     signup.cancelled = True
     signup.save(update_fields=["cancelled"])
-    notify_shift_uncovered(signup.shift, signup)
+    async_task("volunteers.tasks.notify_shift_uncovered", signup.pk)
     messages.success(request, f"You've been removed from “{signup.shift.title}.”")
     return redirect(_return_url(request))
 


### PR DESCRIPTION
Closes #84.

When a volunteer cancels and their shift now has zero active signups, email the coordinators — but only when it's actually worth an interruption:

- **<48h window** (per Tim's suggestion on the issue): only shifts starting within `VOLUNTEER_UNCOVERED_ALERT_WINDOW_HOURS` (default 48) — far-out gaps have time to refill naturally.
- **1-hour debounce buffer** (per Jeff): if the volunteer signed up and cancelled within `VOLUNTEER_UNCOVERED_ALERT_BUFFER_MINUTES` (default 60), skip the email — a quick change of mind isn't worth a ping. Re-signing up resets the buffer clock, so an old original signup date can't sneak past the debounce.
- Recipients come from `VOLUNTEER_COORDINATOR_EMAILS` (env, comma-separated). **Empty default = feature off**, so nothing fires until Rachell/Monica's addresses are set in Coolify.
- Send failures are logged, never breaking the volunteer's cancel action.

Six tests cover the alert, buffer, window, still-covered, unconfigured, and buffer-reset cases. Depends on #90 for real delivery; until then alerts land in the console log like all other prod email.