### PR TITLE
Bump ruff to v0.16.1 and lint everything

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         alias: autoformat
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/templates/_socialaccount/authentication_error.html
+++ b/templates/_socialaccount/authentication_error.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-md text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-md flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-red-400">
             ❌ Authentication Error
         </div>
@@ -12,7 +12,7 @@
             There was an error authenticating with GitHub. This could happen for several reasons.
         </div>
 
-        <div class="p-4 mb-6 text-red-200 bg-red-800 bg-opacity-30 rounded-lg">
+        <div class="bg-opacity-30 mb-6 rounded-lg bg-red-800 p-4 text-red-200">
             <div class="text-sm">
                 <strong>Common causes:</strong>
                 <ul class="mt-2 space-y-1 text-left">
@@ -26,17 +26,17 @@
 
         <div class="space-y-4">
             <a href="{% url 'github_login' %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+               class="block w-full rounded-lg bg-gray-800 px-4 py-3 text-lg font-semibold text-white hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 🐙 Try GitHub Again
             </a>
 
             <a href="{% url 'account_login' %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+               class="block w-full rounded-lg bg-green-600 px-4 py-3 text-lg font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 Use Email/Username Instead
             </a>
         </div>
 
-        <div class="pt-4 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4">
             <a href="{% url 'home' %}"
                class="text-sm text-yellow-300 underline hover:text-yellow-200">
                 ← Back to Home

--- a/templates/_socialaccount/login.html
+++ b/templates/_socialaccount/login.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-md text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-md flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-200">
             GitHub Sign In
         </div>
@@ -14,12 +14,12 @@
 
         <div class="space-y-4">
             <a href="{% url 'github_login' %}"
-               class="block py-4 px-6 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg transition-colors hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+               class="block w-full rounded-lg bg-gray-800 px-6 py-4 text-lg font-semibold text-white transition-colors hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 🐙 Continue with GitHub
             </a>
         </div>
 
-        <div class="pt-4 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4">
             <a href="{% url 'account_login' %}"
                class="text-sm text-yellow-300 underline hover:text-yellow-200">
                 ← Use email/username instead

--- a/templates/_socialaccount/login_cancelled.html
+++ b/templates/_socialaccount/login_cancelled.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-md text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-md flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-400">
             ⏹️ Sign In Cancelled
         </div>
@@ -14,17 +14,17 @@
 
         <div class="space-y-4">
             <a href="{% url 'github_login' %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+               class="block w-full rounded-lg bg-gray-800 px-4 py-3 text-lg font-semibold text-white hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 🐙 Try GitHub Again
             </a>
 
             <a href="{% url 'account_login' %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+               class="block w-full rounded-lg bg-green-600 px-4 py-3 text-lg font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 Use Email/Username Instead
             </a>
         </div>
 
-        <div class="pt-4 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4">
             <a href="{% url 'home' %}"
                class="text-sm text-yellow-300 underline hover:text-yellow-200">
                 ← Back to Home

--- a/templates/_socialaccount/providers/github/login.html
+++ b/templates/_socialaccount/providers/github/login.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-md text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-md flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-200">
             🐙 GitHub Sign In
         </div>
@@ -12,7 +12,7 @@
             You're about to sign in using your GitHub account. Click below to continue to GitHub's secure login.
         </div>
 
-        <div class="p-4 mb-6 text-gray-300 bg-gray-800 bg-opacity-30 rounded-lg">
+        <div class="bg-opacity-30 mb-6 rounded-lg bg-gray-800 p-4 text-gray-300">
             <div class="text-sm">
                 <strong>What happens next:</strong>
                 <ul class="mt-2 space-y-1 text-left">
@@ -25,11 +25,11 @@
         </div>
 
         <a href="{% url 'github_login' %}"
-           class="block py-4 px-6 w-full text-lg font-semibold text-center text-white bg-gray-800 rounded-lg transition-colors transform hover:bg-gray-700 hover:scale-105 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+           class="block w-full transform rounded-lg bg-gray-800 px-6 py-4 text-center text-lg font-semibold text-white transition-colors hover:scale-105 hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
             🐙 Continue to GitHub
         </a>
 
-        <div class="pt-4 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4">
             <a href="{% url 'account_login' %}"
                class="text-sm text-yellow-300 underline hover:text-yellow-200">
                 ← Use email/username instead

--- a/templates/_socialaccount/providers/github/signup.html
+++ b/templates/_socialaccount/providers/github/signup.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-md text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-md flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-200">
             🐙 Complete GitHub Sign Up
         </div>
@@ -13,7 +13,7 @@
         </div>
 
         {% if socialaccount %}
-            <div class="p-4 mb-6 text-gray-300 bg-gray-800 bg-opacity-30 rounded-lg">
+            <div class="bg-opacity-30 mb-6 rounded-lg bg-gray-800 p-4 text-gray-300">
                 <div class="text-sm">
                     <strong>GitHub Account:</strong> {{ socialaccount.extra_data.login }}<br>
                     <strong>Name:</strong> {{ socialaccount.extra_data.name|default:"Not provided" }}<br>
@@ -23,7 +23,7 @@
         {% endif %}
 
         {% if form.errors %}
-            <div class="p-4 text-red-200 bg-red-800 bg-opacity-50 rounded-lg">
+            <div class="bg-opacity-50 rounded-lg bg-red-800 p-4 text-red-200">
                 <div class="mb-2 text-sm font-medium">Please correct the following errors:</div>
                 {{ form.errors }}
             </div>
@@ -34,13 +34,13 @@
 
             {% if form.username %}
                 <div class="text-left">
-                    <label for="{{ form.username.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                    <label for="{{ form.username.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                         {{ form.username.label }}
                     </label>
                     <input type="text"
                            name="{{ form.username.name }}"
                            id="{{ form.username.id_for_label }}"
-                           class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                           class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                            {% if form.username.value %}value="{{ form.username.value }}"{% endif %}
                            placeholder="Choose a username">
                 </div>
@@ -48,13 +48,13 @@
 
             {% if form.email %}
                 <div class="text-left">
-                    <label for="{{ form.email.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                    <label for="{{ form.email.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                         {{ form.email.label }}
                     </label>
                     <input type="email"
                            name="{{ form.email.name }}"
                            id="{{ form.email.id_for_label }}"
-                           class="p-3 w-full text-gray-900 bg-gray-100 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                           class="w-full rounded-md border border-gray-300 bg-gray-100 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                            {% if form.email.value %}value="{{ form.email.value }}"{% endif %}
                            readonly>
                     <p class="mt-1 text-xs text-gray-400">Email from your GitHub account</p>
@@ -62,12 +62,12 @@
             {% endif %}
 
             <button type="submit"
-                    class="py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                    class="w-full rounded-lg bg-green-600 px-4 py-3 text-lg font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 🐙 Complete GitHub Sign Up
             </button>
         </form>
 
-        <div class="pt-4 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4">
             <a href="{% url 'account_login' %}"
                class="text-sm text-yellow-300 underline hover:text-yellow-200">
                 ← Cancel and use regular sign up

--- a/templates/_socialaccount/signup.html
+++ b/templates/_socialaccount/signup.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-md text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-md flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-200">
             Complete Sign Up
         </div>
@@ -13,7 +13,7 @@
         </div>
 
         {% if form.errors %}
-            <div class="p-4 text-red-200 bg-red-800 bg-opacity-50 rounded-lg">
+            <div class="bg-opacity-50 rounded-lg bg-red-800 p-4 text-red-200">
                 <div class="mb-2 text-sm font-medium">Please correct the following errors:</div>
                 {{ form.errors }}
             </div>
@@ -24,13 +24,13 @@
 
             {% if form.username %}
                 <div class="text-left">
-                    <label for="{{ form.username.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                    <label for="{{ form.username.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                         {{ form.username.label }}
                     </label>
                     <input type="text"
                            name="{{ form.username.name }}"
                            id="{{ form.username.id_for_label }}"
-                           class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                           class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                            {% if form.username.value %}value="{{ form.username.value }}"{% endif %}
                            placeholder="Choose a username">
                 </div>
@@ -38,20 +38,20 @@
 
             {% if form.email %}
                 <div class="text-left">
-                    <label for="{{ form.email.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                    <label for="{{ form.email.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                         {{ form.email.label }}
                     </label>
                     <input type="email"
                            name="{{ form.email.name }}"
                            id="{{ form.email.id_for_label }}"
-                           class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                           class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                            {% if form.email.value %}value="{{ form.email.value }}"{% endif %}
                            readonly>
                 </div>
             {% endif %}
 
             <button type="submit"
-                    class="py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                    class="w-full rounded-lg bg-green-600 px-4 py-3 text-lg font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 🐙 Complete GitHub Sign Up
             </button>
         </form>

--- a/templates/account/confirm_login_code.html
+++ b/templates/account/confirm_login_code.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-lg text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-lg flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-200">
             Enter Your Sign-In Code
         </div>
@@ -15,7 +15,7 @@
         </p>
 
         {% if form.errors %}
-            <div class="p-4 text-red-200 bg-red-800 bg-opacity-50 rounded-lg">
+            <div class="bg-opacity-50 rounded-lg bg-red-800 p-4 text-red-200">
                 <div class="mb-2 text-sm font-medium">Please correct the following errors:</div>
                 {{ form.errors }}
             </div>
@@ -25,13 +25,13 @@
             {% csrf_token %}
 
             <div class="text-left">
-                <label for="{{ form.code.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                <label for="{{ form.code.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                     Sign-in code
                 </label>
                 <input type="text"
                        name="{{ form.code.name }}"
                        id="{{ form.code.id_for_label }}"
-                       class="p-3 w-full font-mono text-xl tracking-widest text-center text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                       class="w-full rounded-md border border-gray-300 p-3 text-center font-mono text-xl tracking-widest text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                        value="{% if form.code.value %}{{ form.code.value }}{% elif request.GET.code %}{{ request.GET.code }}{% endif %}"
                        autocomplete="one-time-code"
                        autofocus
@@ -41,12 +41,12 @@
             {{ redirect_field }}
 
             <button type="submit"
-                    class="py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                    class="w-full rounded-lg bg-green-600 px-4 py-3 text-lg font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 Sign In
             </button>
         </form>
 
-        <div class="pt-4 text-sm text-gray-400 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4 text-sm text-gray-400">
             <a href="{% url 'account_request_login_code' %}" class="text-yellow-300 underline hover:text-yellow-200">
                 Send a new code
             </a>

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -3,13 +3,13 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-lg text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-lg flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-200">
             Sign In
         </div>
 
         {% if form.errors %}
-            <div class="p-4 text-red-200 bg-red-800 bg-opacity-50 rounded-lg">
+            <div class="bg-opacity-50 rounded-lg bg-red-800 p-4 text-red-200">
                 <div class="mb-2 text-sm font-medium">Please correct the following errors:</div>
                 {{ form.errors }}
             </div>
@@ -17,12 +17,12 @@
 
         <div class="space-y-3">
             <a href="{% url 'github_login' %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+               class="block w-full rounded-lg bg-gray-800 px-4 py-3 text-lg font-semibold text-white hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 🐙 Sign In with GitHub
             </a>
 
             <a href="{% url 'account_request_login_code' %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-green-900 bg-yellow-300 rounded-lg hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+               class="block w-full rounded-lg bg-yellow-300 px-4 py-3 text-lg font-semibold text-green-900 hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 ✉️ Email Me a Sign-In Link
             </a>
         </div>
@@ -37,25 +37,25 @@
             {% csrf_token %}
 
             <div class="text-left">
-                <label for="{{ form.login.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                <label for="{{ form.login.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                     {{ form.login.label }}
                 </label>
                 <input type="{{ form.login.field.widget.input_type }}"
                        name="{{ form.login.name }}"
                        id="{{ form.login.id_for_label }}"
-                       class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                       class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                        {% if form.login.value %}value="{{ form.login.value }}"{% endif %}
                        placeholder="Username or email">
             </div>
 
             <div class="text-left">
-                <label for="{{ form.password.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                <label for="{{ form.password.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                     {{ form.password.label }}
                 </label>
                 <input type="password"
                        name="{{ form.password.name }}"
                        id="{{ form.password.id_for_label }}"
-                       class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                       class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                        placeholder="Password">
             </div>
 
@@ -72,12 +72,12 @@
             {% endif %}
 
             <button type="submit"
-                    class="py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                    class="w-full rounded-lg bg-green-600 px-4 py-3 text-lg font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 Sign In
             </button>
         </form>
 
-        <div class="pt-4 text-sm text-gray-400 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4 text-sm text-gray-400">
             <a href="{% url 'account_signup' %}" class="text-yellow-300 underline hover:text-yellow-200">
                 Don't have an account? Sign up
             </a>

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-md text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-md flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-200">
             Sign Out
         </div>
@@ -16,7 +16,7 @@
             {% csrf_token %}
 
             <button type="submit"
-                    class="py-3 px-4 w-full text-lg font-semibold text-white bg-red-600 rounded-lg hover:bg-red-700 focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                    class="w-full rounded-lg bg-red-600 px-4 py-3 text-lg font-semibold text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 Yes, Sign Out
             </button>
         </form>

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-md text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-md flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-200">
             Reset Password
         </div>
@@ -13,7 +13,7 @@
         </div>
 
         {% if form.errors %}
-            <div class="p-4 text-red-200 bg-red-800 bg-opacity-50 rounded-lg">
+            <div class="bg-opacity-50 rounded-lg bg-red-800 p-4 text-red-200">
                 <div class="mb-2 text-sm font-medium">Please correct the following errors:</div>
                 {{ form.errors }}
             </div>
@@ -23,24 +23,24 @@
             {% csrf_token %}
 
             <div class="text-left">
-                <label for="{{ form.email.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                <label for="{{ form.email.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                     {{ form.email.label }}
                 </label>
                 <input type="email"
                        name="{{ form.email.name }}"
                        id="{{ form.email.id_for_label }}"
-                       class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                       class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                        {% if form.email.value %}value="{{ form.email.value }}"{% endif %}
                        placeholder="your.email@example.com">
             </div>
 
             <button type="submit"
-                    class="py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                    class="w-full rounded-lg bg-green-600 px-4 py-3 text-lg font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 Send Reset Email
             </button>
         </form>
 
-        <div class="pt-4 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4">
             <a href="{% url 'account_login' %}"
                class="text-sm text-yellow-300 underline hover:text-yellow-200">
                 ← Back to Sign In

--- a/templates/account/password_reset_done.html
+++ b/templates/account/password_reset_done.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-md text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-md flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-green-400">
             ✉️ Email Sent
         </div>
@@ -13,14 +13,14 @@
             Please check your inbox and follow the link in the email.
         </div>
 
-        <div class="p-4 text-blue-200 bg-blue-800 bg-opacity-30 rounded-lg">
+        <div class="bg-opacity-30 rounded-lg bg-blue-800 p-4 text-blue-200">
             <div class="text-sm">
                 <strong>Note:</strong> If you don't see the email, please check your spam folder.
                 The email should arrive within a few minutes.
             </div>
         </div>
 
-        <div class="pt-4 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4">
             <a href="{% url 'account_login' %}"
                class="text-sm text-yellow-300 underline hover:text-yellow-200">
                 ← Back to Sign In

--- a/templates/account/request_login_code.html
+++ b/templates/account/request_login_code.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-lg text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-lg flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-200">
             Email Me a Sign-In Link
         </div>
@@ -13,7 +13,7 @@
         </p>
 
         {% if form.errors %}
-            <div class="p-4 text-red-200 bg-red-800 bg-opacity-50 rounded-lg">
+            <div class="bg-opacity-50 rounded-lg bg-red-800 p-4 text-red-200">
                 <div class="mb-2 text-sm font-medium">Please correct the following errors:</div>
                 {{ form.errors }}
             </div>
@@ -23,13 +23,13 @@
             {% csrf_token %}
 
             <div class="text-left">
-                <label for="{{ form.email.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                <label for="{{ form.email.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                     Email
                 </label>
                 <input type="email"
                        name="{{ form.email.name }}"
                        id="{{ form.email.id_for_label }}"
-                       class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                       class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                        {% if form.email.value %}value="{{ form.email.value }}"{% endif %}
                        placeholder="you@example.com"
                        required>
@@ -38,12 +38,12 @@
             {{ redirect_field }}
 
             <button type="submit"
-                    class="py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                    class="w-full rounded-lg bg-green-600 px-4 py-3 text-lg font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 Send Sign-In Email
             </button>
         </form>
 
-        <div class="pt-4 text-sm text-gray-400 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4 text-sm text-gray-400">
             <a href="{% url 'account_login' %}" class="text-yellow-300 underline hover:text-yellow-200">
                 Other sign-in options
             </a>

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -3,13 +3,13 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 mx-auto max-w-md text-center text-green-200 bg-green-900 bg-opacity-80 rounded-xl shadow-inner">
+    <div class="bg-opacity-80 mx-auto flex max-w-md flex-col gap-6 rounded-xl bg-green-900 p-8 text-center text-green-200 shadow-inner">
         <div class="mb-4 text-4xl font-bold text-yellow-200">
             Sign Up
         </div>
 
         {% if form.errors %}
-            <div class="p-4 text-red-200 bg-red-800 bg-opacity-50 rounded-lg">
+            <div class="bg-opacity-50 rounded-lg bg-red-800 p-4 text-red-200">
                 <div class="mb-2 text-sm font-medium">Please correct the following errors:</div>
                 {{ form.errors }}
             </div>
@@ -17,12 +17,12 @@
 
         <div class="space-y-3">
             <a href="{% url 'github_login' %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+               class="block w-full rounded-lg bg-gray-800 px-4 py-3 text-lg font-semibold text-white hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 🐙 Sign Up with GitHub
             </a>
 
             <a href="{% url 'account_request_login_code' %}"
-               class="block py-3 px-4 w-full text-lg font-semibold text-green-900 bg-yellow-300 rounded-lg hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+               class="block w-full rounded-lg bg-yellow-300 px-4 py-3 text-lg font-semibold text-green-900 hover:bg-yellow-200 focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 ✉️ Email Me a Sign-In Link
             </a>
         </div>
@@ -38,13 +38,13 @@
 
             {% if form.username %}
                 <div class="text-left">
-                    <label for="{{ form.username.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                    <label for="{{ form.username.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                         {{ form.username.label }}
                     </label>
                     <input type="text"
                            name="{{ form.username.name }}"
                            id="{{ form.username.id_for_label }}"
-                           class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                           class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                            {% if form.username.value %}value="{{ form.username.value }}"{% endif %}
                            placeholder="Choose a username">
                 </div>
@@ -52,47 +52,47 @@
 
             {% if form.email %}
                 <div class="text-left">
-                    <label for="{{ form.email.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                    <label for="{{ form.email.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                         {{ form.email.label }}
                     </label>
                     <input type="email"
                            name="{{ form.email.name }}"
                            id="{{ form.email.id_for_label }}"
-                           class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                           class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                            {% if form.email.value %}value="{{ form.email.value }}"{% endif %}
                            placeholder="your.email@example.com">
                 </div>
             {% endif %}
 
             <div class="text-left">
-                <label for="{{ form.password1.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                <label for="{{ form.password1.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                     {{ form.password1.label }}
                 </label>
                 <input type="password"
                        name="{{ form.password1.name }}"
                        id="{{ form.password1.id_for_label }}"
-                       class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                       class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                        placeholder="Choose a secure password">
             </div>
 
             <div class="text-left">
-                <label for="{{ form.password2.id_for_label }}" class="block mb-1 text-sm font-medium text-gray-300">
+                <label for="{{ form.password2.id_for_label }}" class="mb-1 block text-sm font-medium text-gray-300">
                     {{ form.password2.label }}
                 </label>
                 <input type="password"
                        name="{{ form.password2.name }}"
                        id="{{ form.password2.id_for_label }}"
-                       class="p-3 w-full text-gray-900 rounded-md border border-gray-300 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                       class="w-full rounded-md border border-gray-300 p-3 text-gray-900 focus:ring-2 focus:ring-green-500 focus:outline-none"
                        placeholder="Confirm your password">
             </div>
 
             <button type="submit"
-                    class="py-3 px-4 w-full text-lg font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                    class="w-full rounded-lg bg-green-600 px-4 py-3 text-lg font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 Sign Up
             </button>
         </form>
 
-        <div class="pt-4 text-sm text-gray-400 border-t border-green-700">
+        <div class="border-t border-green-700 pt-4 text-sm text-gray-400">
             <a href="{% url 'account_login' %}" class="text-yellow-300 underline hover:text-yellow-200">
                 Already have an account? Sign in
             </a>

--- a/templates/allauth/layouts/base.html
+++ b/templates/allauth/layouts/base.html
@@ -6,7 +6,7 @@
 {% endblock title %}
 
 {% block content %}
-    <div class="p-8 mx-auto max-w-md rounded-lg shadow-lg bg-green-800/50">
+    <div class="mx-auto max-w-md rounded-lg bg-green-800/50 p-8 shadow-lg">
         {% if messages %}
             <div class="mb-4">
                 {% for message in messages %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,7 @@
             {% block content %}
             {% endblock content %}
         </main>
-        <footer class="py-6 text-sm text-center text-gray-400">
+        <footer class="py-6 text-center text-sm text-gray-400">
             <a href="/" class="hover:text-gray-200">Home</a>
             <span class="mx-1">&middot;</span>
             <a href="https://github.com/djangocon/djangoconus-automation/issues"

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -5,7 +5,7 @@
 {% block title %}DjangoCon US - Homepage{% endblock title %}
 
 {% block content %}
-    <div class="flex flex-col gap-8 p-12 mx-auto max-w-3xl text-center text-green-200 bg-green-900 rounded-xl shadow-inner">
+    <div class="mx-auto flex max-w-3xl flex-col gap-8 rounded-xl bg-green-900 p-12 text-center text-green-200 shadow-inner">
         <div class="text-6xl font-bold sm:tracking-tight">
             <div class="text-yellow-200">DjangoCon US</div>
             <div class="text-green-300">Automations</div>
@@ -13,7 +13,7 @@
 
         <div class="grid gap-6 md:grid-cols-2">
             <a href="{% url 'volunteers:shifts' %}"
-               class="flex flex-col gap-3 justify-center p-8 bg-green-800 rounded-xl border border-green-700 shadow hover:border-yellow-300">
+               class="flex flex-col justify-center gap-3 rounded-xl border border-green-700 bg-green-800 p-8 shadow hover:border-yellow-300">
                 <span class="text-5xl">🙋</span>
                 <span class="text-2xl font-bold text-yellow-200">DjangoCon US Volunteers</span>
                 <span class="text-sm text-green-200">
@@ -22,7 +22,7 @@
             </a>
 
             <a href="{% url 'travel_safety:register' %}"
-               class="flex flex-col gap-3 justify-center p-8 bg-green-800 rounded-xl border border-green-700 shadow hover:border-yellow-300">
+               class="flex flex-col justify-center gap-3 rounded-xl border border-green-700 bg-green-800 p-8 shadow hover:border-yellow-300">
                 <span class="text-5xl">✈️</span>
                 <span class="text-2xl font-bold text-yellow-200">Traveling to DjangoCon US</span>
                 <span class="text-sm text-green-200">
@@ -39,7 +39,7 @@
             {% django_simple_nav "config.nav.MainNav" %}
         {% else %}
             <a href="{% url 'account_login' %}"
-               class="block py-4 px-6 mx-auto w-full max-w-md text-xl font-semibold text-white bg-green-600 rounded-lg shadow hover:bg-green-700">
+               class="mx-auto block w-full max-w-md rounded-lg bg-green-600 px-6 py-4 text-xl font-semibold text-white shadow hover:bg-green-700">
                 Sign In or Register
             </a>
         {% endif %}

--- a/templates/socialaccount/login.html
+++ b/templates/socialaccount/login.html
@@ -4,7 +4,7 @@
 {% block title %}Sign In - DjangoCon US{% endblock title %}
 
 {% block content %}
-    <div class="p-8 mx-auto max-w-md rounded-lg shadow-lg bg-green-800/50">
+    <div class="mx-auto max-w-md rounded-lg bg-green-800/50 p-8 shadow-lg">
         {% if process == "connect" %}
             <h1 class="mb-4 text-2xl font-bold">
                 {% blocktrans with provider.name as provider %}Connect {{ provider }}{% endblocktrans %}
@@ -22,7 +22,7 @@
         {% endif %}
         <form method="post">
             {% csrf_token %}
-            <button type="submit" class="py-3 px-6 w-full font-bold text-white bg-green-600 rounded-lg transition duration-200 hover:bg-green-500">
+            <button type="submit" class="w-full rounded-lg bg-green-600 px-6 py-3 font-bold text-white transition duration-200 hover:bg-green-500">
                 {% trans "Continue" %}
             </button>
         </form>

--- a/templates/thunderdome/_submission_content.html
+++ b/templates/thunderdome/_submission_content.html
@@ -12,28 +12,28 @@
 {% if submission.abstract %}
     <div class="mb-4">
         <h3 class="mb-1 text-sm font-semibold text-gray-400 uppercase">Abstract</h3>
-        <div class="max-w-none text-gray-200 prose prose-invert prose-sm markdown-content">{{ submission.abstract }}</div>
+        <div class="markdown-content max-w-none prose prose-sm prose-invert text-gray-200">{{ submission.abstract }}</div>
     </div>
 {% endif %}
 
 {% if submission.description %}
     <div class="mb-4">
         <h3 class="mb-1 text-sm font-semibold text-gray-400 uppercase">Description</h3>
-        <div class="max-w-none text-gray-200 prose prose-invert prose-sm markdown-content">{{ submission.description }}</div>
+        <div class="markdown-content max-w-none prose prose-sm prose-invert text-gray-200">{{ submission.description }}</div>
     </div>
 {% endif %}
 
 {% if submission.notes %}
     <div class="mb-4">
         <h3 class="mb-1 text-sm font-semibold text-gray-400 uppercase">Speaker Notes</h3>
-        <div class="max-w-none text-gray-200 prose prose-invert prose-sm markdown-content">{{ submission.notes }}</div>
+        <div class="markdown-content max-w-none prose prose-sm prose-invert text-gray-200">{{ submission.notes }}</div>
     </div>
 {% endif %}
 
 {% if submission.internal_notes %}
     <div class="mb-4">
         <h3 class="mb-1 text-sm font-semibold text-gray-400 uppercase">Internal Notes</h3>
-        <div class="max-w-none text-gray-200 prose prose-invert prose-sm markdown-content">{{ submission.internal_notes }}</div>
+        <div class="markdown-content max-w-none prose prose-sm prose-invert text-gray-200">{{ submission.internal_notes }}</div>
     </div>
 {% endif %}
 
@@ -42,7 +42,7 @@
         <h3 class="mb-1 text-sm font-semibold text-gray-400 uppercase">Tags</h3>
         <div class="flex flex-wrap gap-2">
             {% for tag in submission.tags.all %}
-                <span class="inline-flex py-1 px-2 text-xs bg-green-800 rounded-full">{{ tag.name }}</span>
+                <span class="inline-flex rounded-full bg-green-800 px-2 py-1 text-xs">{{ tag.name }}</span>
             {% endfor %}
         </div>
     </div>
@@ -58,26 +58,26 @@
         {% endif %}
     </h3>
     {% if submission.reviews.all %}
-        <table class="overflow-hidden w-full bg-green-800 bg-opacity-30 rounded-lg">
-            <thead class="bg-green-700 bg-opacity-50">
+        <table class="bg-opacity-30 w-full overflow-hidden rounded-lg bg-green-800">
+            <thead class="bg-opacity-50 bg-green-700">
                 <tr>
-                    <th class="py-2 px-4 text-xs font-medium tracking-wider text-left uppercase">Reviewer</th>
-                    <th class="py-2 px-4 text-xs font-medium tracking-wider text-center uppercase">Score</th>
-                    <th class="py-2 px-4 text-xs font-medium tracking-wider text-left uppercase">Notes</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium tracking-wider uppercase">Reviewer</th>
+                    <th class="px-4 py-2 text-center text-xs font-medium tracking-wider uppercase">Score</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium tracking-wider uppercase">Notes</th>
                 </tr>
             </thead>
             <tbody class="divide-y divide-green-700">
                 {% for review in submission.reviews.all %}
                     <tr>
-                        <td class="py-2 px-4 text-sm">{{ review.display_name }}</td>
-                        <td class="py-2 px-4 text-sm text-center">
+                        <td class="px-4 py-2 text-sm">{{ review.display_name }}</td>
+                        <td class="px-4 py-2 text-center text-sm">
                             {% if review.score is not None %}
                                 {{ review.score }}
                             {% else %}
                                 <span class="text-gray-500">-</span>
                             {% endif %}
                         </td>
-                        <td class="py-2 px-4 text-sm">{{ review.notes }}</td>
+                        <td class="px-4 py-2 text-sm">{{ review.notes }}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/templates/thunderdome/_submission_detail.html
+++ b/templates/thunderdome/_submission_detail.html
@@ -1,14 +1,14 @@
-<div class="flex justify-center items-center p-4 min-h-screen bg-black bg-opacity-70">
-    <div class="overflow-y-auto relative p-6 w-full max-w-3xl bg-green-900 rounded-lg shadow-xl max-h-[90vh]">
+<div class="bg-opacity-70 flex min-h-screen items-center justify-center bg-black p-4">
+    <div class="relative max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-lg bg-green-900 p-6 shadow-xl">
         <button class="absolute top-4 right-4 text-2xl text-gray-400 hover:text-white"
                 onclick="document.getElementById('detail-modal').classList.add('hidden');document.getElementById('detail-modal').innerHTML=''">
             &times;
         </button>
 
-        <div class="flex justify-between items-start mb-1">
+        <div class="mb-1 flex items-start justify-between">
             <h2 class="text-xl font-bold">{{ submission.title }}</h2>
             <a href="{% url 'thunderdome_submission_page' submission.pretalx_id %}"
-               class="ml-4 text-xs text-blue-300 underline whitespace-nowrap hover:text-blue-200">
+               class="ml-4 text-xs whitespace-nowrap text-blue-300 underline hover:text-blue-200">
                 Full page &rarr;
             </a>
         </div>

--- a/templates/thunderdome/_submission_row.html
+++ b/templates/thunderdome/_submission_row.html
@@ -1,66 +1,66 @@
-<tr id="submission-{{ submission.pk }}" class="transition-colors hover:bg-green-700 hover:bg-opacity-30">
-    <td class="py-3 px-3 w-8">
-        <input type="checkbox" class="rounded row-select" data-pk="{{ submission.pk }}" onchange="updateSelectedCount();">
+<tr id="submission-{{ submission.pk }}" class="transition-colors hover:bg-opacity-30 hover:bg-green-700">
+    <td class="w-8 px-3 py-3">
+        <input type="checkbox" class="row-select rounded" data-pk="{{ submission.pk }}" onchange="updateSelectedCount();">
     </td>
-    <td class="py-3 px-4 text-sm whitespace-nowrap">
+    <td class="px-4 py-3 text-sm whitespace-nowrap">
         <a href="https://pretalx.com/djangocon-us-2026/talk/{{ submission.pretalx_id }}/"
            target="_blank"
            class="text-blue-300 underline hover:text-blue-200">
             {{ submission.pretalx_id }}
         </a>
     </td>
-    <td class="py-3 px-4 text-sm">
+    <td class="px-4 py-3 text-sm">
         <a href="{% url 'thunderdome_submission_page' submission.pretalx_id %}"
            class="text-blue-300 underline hover:text-blue-200">
             {{ submission.title }}
         </a>
     </td>
-    <td class="py-3 px-4 text-sm">
+    <td class="px-4 py-3 text-sm">
         {% for speaker in submission.speakers.all %}
             {{ speaker.name }}{% if not forloop.last %}, {% endif %}
         {% endfor %}
     </td>
-    <td class="py-3 px-4 text-sm text-center whitespace-nowrap">
+    <td class="px-4 py-3 text-center text-sm whitespace-nowrap">
         {% if submission.duration %}{{ submission.duration }} min{% else %}-{% endif %}
     </td>
-    <td class="py-3 px-4 text-sm text-center">
+    <td class="px-4 py-3 text-center text-sm">
         <a href="{% url 'thunderdome_submission_page' submission.pretalx_id %}"
            class="text-blue-300 underline hover:text-blue-200">
             {{ submission.annotated_review_count }}
         </a>
     </td>
-    <td class="py-3 px-4 text-sm text-center">
+    <td class="px-4 py-3 text-center text-sm">
         {% if submission.annotated_review_mean is not None %}
             {{ submission.annotated_review_mean|floatformat:1 }}
         {% else %}
             -
         {% endif %}
     </td>
-    <td class="py-3 px-4 text-sm">
+    <td class="px-4 py-3 text-sm">
         <div class="flex flex-wrap gap-1">
             {% for tag in submission.tags.all %}
-                <span class="inline-flex py-0.5 px-2 text-xs bg-green-800 rounded-full">{{ tag.name }}</span>
+                <span class="inline-flex rounded-full bg-green-800 px-2 py-0.5 text-xs">{{ tag.name }}</span>
             {% endfor %}
         </div>
     </td>
-    <td class="py-3 px-4 text-sm text-center whitespace-nowrap">
+    <td class="px-4 py-3 text-center text-sm whitespace-nowrap">
         {% if submission.has_grant_applicant %}
             <span title="At least one speaker has applied for a grant"
-                  class="inline-flex py-1 px-2 text-xs text-yellow-100 bg-yellow-700 rounded-full">
+                  class="inline-flex rounded-full bg-yellow-700 px-2 py-1 text-xs text-yellow-100">
                 $
             </span>
         {% else %}
             <span class="text-gray-500">-</span>
         {% endif %}
     </td>
-    <td class="py-3 px-4 text-sm text-center whitespace-nowrap">
+    <td class="px-4 py-3 text-center text-sm whitespace-nowrap">
         <span class="inline-flex py-1 px-2 text-xs rounded-full {% if submission.pretalx_state == 'withdrawn' %}bg-gray-700 text-gray-300{% elif submission.pretalx_state == 'accepted' %}bg-green-800 text-green-200{% elif submission.pretalx_state == 'rejected' %}bg-red-800 text-red-200{% elif submission.pretalx_state == 'confirmed' %}bg-blue-800 text-blue-200{% else %}bg-gray-600 text-gray-200{% endif %}">
             {{ submission.get_pretalx_state_display }}
         </span>
     </td>
-    <td class="py-3 px-4 text-sm text-center whitespace-nowrap">
+    <td class="px-4 py-3 text-center text-sm whitespace-nowrap">
         <select name="state"
-                class="py-1 px-1 text-xs text-gray-900 rounded border border-gray-300"
+                class="rounded border border-gray-300 px-1 py-1 text-xs text-gray-900"
                 hx-post="{% url 'thunderdome_submission_set_state' submission.pk %}"
                 hx-target="#submission-{{ submission.pk }}"
                 hx-swap="outerHTML"

--- a/templates/thunderdome/_submissions_table.html
+++ b/templates/thunderdome/_submissions_table.html
@@ -1,17 +1,17 @@
 {% if submissions %}
-    <div class="flex gap-3 items-center mb-3">
+    <div class="mb-3 flex items-center gap-3">
         <form id="bulk-action-form" method="post" action="{% url 'thunderdome_bulk_state' %}"
               onsubmit="collectSelectedPks(this)">
             {% csrf_token %}
-            <div class="flex gap-3 items-center">
-                <select name="bulk_state" class="py-1 px-2 text-sm text-gray-900 rounded border border-gray-300">
+            <div class="flex items-center gap-3">
+                <select name="bulk_state" class="rounded border border-gray-300 px-2 py-1 text-sm text-gray-900">
                     <option value="">-- Set decision --</option>
                     {% for value, label in states %}
                         <option value="{{ value }}">{{ label }}</option>
                     {% endfor %}
                 </select>
                 <button type="submit"
-                        class="py-1 px-3 text-sm font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                        class="rounded-lg bg-green-600 px-3 py-1 text-sm font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                     Apply
                 </button>
                 <span class="text-sm text-gray-400" id="selected-count"></span>
@@ -20,43 +20,43 @@
     </div>
 
     <div class="overflow-x-auto">
-        <table class="overflow-hidden w-full bg-green-800 bg-opacity-30 rounded-lg">
-            <thead class="bg-green-700 bg-opacity-50">
+        <table class="bg-opacity-30 w-full overflow-hidden rounded-lg bg-green-800">
+            <thead class="bg-opacity-50 bg-green-700">
                 <tr>
-                    <th class="py-3 px-3 w-8">
+                    <th class="w-8 px-3 py-3">
                         <input type="checkbox" id="select-all" class="rounded"
                                onchange="document.querySelectorAll('input.row-select').forEach(c => c.checked = this.checked); updateSelectedCount();">
                     </th>
-                    <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">
+                    <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">
                         <a href="#" class="text-gray-200 hover:text-white" onclick="setSort('{% if current_sort == 'id' %}-id{% else %}id{% endif %}'); return false;">
                             ID{% if current_sort == 'id' %} &#9650;{% elif current_sort == '-id' %} &#9660;{% endif %}
                         </a>
                     </th>
-                    <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">
+                    <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">
                         <a href="#" class="text-gray-200 hover:text-white" onclick="setSort('{% if current_sort == 'title' %}-title{% else %}title{% endif %}'); return false;">
                             Title{% if current_sort == 'title' %} &#9650;{% elif current_sort == '-title' %} &#9660;{% endif %}
                         </a>
                     </th>
-                    <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Speakers</th>
-                    <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase">
+                    <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">Speakers</th>
+                    <th class="px-4 py-3 text-center text-xs font-medium tracking-wider uppercase">
                         <a href="#" class="text-gray-200 hover:text-white" onclick="setSort('{% if current_sort == '-duration' %}duration{% else %}-duration{% endif %}'); return false;">
                             Duration{% if current_sort == 'duration' %} &#9650;{% elif current_sort == '-duration' %} &#9660;{% endif %}
                         </a>
                     </th>
-                    <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase">
+                    <th class="px-4 py-3 text-center text-xs font-medium tracking-wider uppercase">
                         <a href="#" class="text-gray-200 hover:text-white" onclick="setSort('{% if current_sort == '-reviews' %}reviews{% else %}-reviews{% endif %}'); return false;">
                             Reviews{% if current_sort == 'reviews' %} &#9650;{% elif current_sort == '-reviews' %} &#9660;{% endif %}
                         </a>
                     </th>
-                    <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase">
+                    <th class="px-4 py-3 text-center text-xs font-medium tracking-wider uppercase">
                         <a href="#" class="text-gray-200 hover:text-white" onclick="setSort('{% if current_sort == '-mean' %}mean{% else %}-mean{% endif %}'); return false;">
                             Mean{% if current_sort == 'mean' %} &#9650;{% elif current_sort == '-mean' %} &#9660;{% endif %}
                         </a>
                     </th>
-                    <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Tags</th>
-                    <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase">Grant</th>
-                    <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase">Pretalx</th>
-                    <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase">Decision</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">Tags</th>
+                    <th class="px-4 py-3 text-center text-xs font-medium tracking-wider uppercase">Grant</th>
+                    <th class="px-4 py-3 text-center text-xs font-medium tracking-wider uppercase">Pretalx</th>
+                    <th class="px-4 py-3 text-center text-xs font-medium tracking-wider uppercase">Decision</th>
                 </tr>
             </thead>
             <tbody class="divide-y divide-green-700">
@@ -67,7 +67,7 @@
         </table>
     </div>
 {% else %}
-    <div class="py-12 text-center bg-green-800 bg-opacity-30 rounded-lg">
+    <div class="bg-opacity-30 rounded-lg bg-green-800 py-12 text-center">
         <p class="text-xl text-gray-300">No submissions found.</p>
     </div>
 {% endif %}

--- a/templates/thunderdome/grants.html
+++ b/templates/thunderdome/grants.html
@@ -6,7 +6,7 @@
 {% block title %}Grant Applicants - Thunderdome{% endblock %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-4xl">
+    <div class="mx-auto max-w-4xl p-6">
         <div class="mb-4">
             <a href="/" class="text-sm text-gray-400 hover:text-gray-200">Home</a>
             <span class="text-sm text-gray-500">/</span>
@@ -32,35 +32,35 @@
             </div>
         {% endif %}
 
-        <form method="post" class="p-4 mb-6 bg-green-800 bg-opacity-50 rounded-lg">
+        <form method="post" class="bg-opacity-50 mb-6 rounded-lg bg-green-800 p-4">
             {% csrf_token %}
-            <label for="emails" class="block mb-2 text-xs font-medium text-gray-300 uppercase">
+            <label for="emails" class="mb-2 block text-xs font-medium text-gray-300 uppercase">
                 Email Addresses
             </label>
             <textarea name="emails"
                       id="emails"
                       rows="10"
                       placeholder="alice@example.com&#10;bob@example.com"
-                      class="p-2 w-full font-mono text-sm text-gray-900 rounded border border-gray-300">{{ raw_emails }}</textarea>
-            <div class="flex gap-3 mt-3">
+                      class="w-full rounded border border-gray-300 p-2 font-mono text-sm text-gray-900">{{ raw_emails }}</textarea>
+            <div class="mt-3 flex gap-3">
                 <button type="submit"
                         name="action"
                         value="mark"
-                        class="py-2 px-4 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700">
+                        class="rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700">
                     Mark as Applied
                 </button>
                 <button type="submit"
                         name="action"
                         value="unmark"
-                        class="py-2 px-4 font-semibold text-white bg-gray-600 rounded-lg hover:bg-gray-700">
+                        class="rounded-lg bg-gray-600 px-4 py-2 font-semibold text-white hover:bg-gray-700">
                     Unmark
                 </button>
             </div>
         </form>
 
         {% if matched or unmatched %}
-            <div class="grid grid-cols-1 gap-4 mb-6 md:grid-cols-2">
-                <div class="p-4 bg-green-800 bg-opacity-50 rounded-lg">
+            <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div class="bg-opacity-50 rounded-lg bg-green-800 p-4">
                     <h2 class="mb-2 text-lg font-semibold">Matched ({{ matched|length }})</h2>
                     {% if matched %}
                         <ul class="space-y-1 text-sm">
@@ -75,7 +75,7 @@
                         <p class="text-sm text-gray-300">No matches.</p>
                     {% endif %}
                 </div>
-                <div class="p-4 bg-red-900 bg-opacity-50 rounded-lg">
+                <div class="bg-opacity-50 rounded-lg bg-red-900 p-4">
                     <h2 class="mb-2 text-lg font-semibold">Unmatched ({{ unmatched|length }})</h2>
                     {% if unmatched %}
                         <ul class="space-y-1 font-mono text-sm">
@@ -88,7 +88,7 @@
             </div>
         {% endif %}
 
-        <div class="p-4 bg-green-800 bg-opacity-50 rounded-lg">
+        <div class="bg-opacity-50 rounded-lg bg-green-800 p-4">
             <h2 class="mb-2 text-lg font-semibold">
                 Currently Flagged ({{ applied_speakers.count }})
             </h2>

--- a/templates/thunderdome/submission_page.html
+++ b/templates/thunderdome/submission_page.html
@@ -20,7 +20,7 @@
 {% endblock extra_head %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-4xl">
+    <div class="mx-auto max-w-4xl p-6">
         <div class="mb-4">
             <a href="/" class="text-sm text-gray-400 hover:text-gray-200">Home</a>
             <span class="text-sm text-gray-500">/</span>
@@ -30,13 +30,13 @@
             </a>
         </div>
 
-        <div class="flex justify-between items-start mb-2">
+        <div class="mb-2 flex items-start justify-between">
             <h1 class="text-3xl font-bold">{{ submission.title }}</h1>
         </div>
 
-        <div class="grid grid-cols-4 gap-4 p-4 mb-6 text-sm text-gray-300 bg-green-800 bg-opacity-50 rounded-lg">
+        <div class="bg-opacity-50 mb-6 grid grid-cols-4 gap-4 rounded-lg bg-green-800 p-4 text-sm text-gray-300">
             <div>
-                <span class="block mb-2 text-xs font-medium text-gray-400 uppercase">ID</span>
+                <span class="mb-2 block text-xs font-medium text-gray-400 uppercase">ID</span>
                 <a href="https://pretalx.com/djangocon-us-2026/talk/{{ submission.pretalx_id }}/"
                    target="_blank"
                    class="text-blue-300 underline hover:text-blue-200">
@@ -44,19 +44,19 @@
                 </a>
             </div>
             <div>
-                <span class="block mb-2 text-xs font-medium text-gray-400 uppercase">Duration</span>
+                <span class="mb-2 block text-xs font-medium text-gray-400 uppercase">Duration</span>
                 {% if submission.duration %}{{ submission.duration }} min{% else %}-{% endif %}
             </div>
             <div>
-                <span class="block mb-2 text-xs font-medium text-gray-400 uppercase">Pretalx Status</span>
+                <span class="mb-2 block text-xs font-medium text-gray-400 uppercase">Pretalx Status</span>
                 <span class="inline-flex py-1 px-2 text-xs rounded-full {% if submission.pretalx_state == 'withdrawn' %}bg-gray-700 text-gray-300{% elif submission.pretalx_state == 'accepted' %}bg-green-800 text-green-200{% elif submission.pretalx_state == 'rejected' %}bg-red-800 text-red-200{% elif submission.pretalx_state == 'confirmed' %}bg-blue-800 text-blue-200{% else %}bg-gray-600 text-gray-200{% endif %}">
                     {{ submission.get_pretalx_state_display }}
                 </span>
             </div>
             <div>
-                <span class="block mb-2 text-xs font-medium text-gray-400 uppercase">Decision</span>
+                <span class="mb-2 block text-xs font-medium text-gray-400 uppercase">Decision</span>
                 <select name="state"
-                        class="py-1 px-2 text-sm text-gray-900 rounded border border-gray-300"
+                        class="rounded border border-gray-300 px-2 py-1 text-sm text-gray-900"
                         hx-post="{% url 'thunderdome_submission_set_state' submission.pk %}"
                         hx-swap="none"
                         hx-include="this">

--- a/templates/thunderdome/submissions.html
+++ b/templates/thunderdome/submissions.html
@@ -63,21 +63,21 @@
 {% endblock extra_head %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-7xl">
-        <div class="flex justify-between items-center mb-6">
+    <div class="mx-auto max-w-7xl p-6">
+        <div class="mb-6 flex items-center justify-between">
             <div>
                 <a href="/" class="text-sm text-gray-400 hover:text-gray-200">&larr; Home</a>
                 <h1 class="text-3xl font-bold">Thunderdome</h1>
             </div>
-            <div class="flex gap-2 items-center">
+            <div class="flex items-center gap-2">
                 <a href="{% url 'thunderdome_grants' %}"
-                   class="py-2 px-4 font-semibold text-white bg-green-700 rounded-lg hover:bg-green-600 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                   class="rounded-lg bg-green-700 px-4 py-2 font-semibold text-white hover:bg-green-600 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                     Grant Applicants
                 </a>
                 <form method="post" action="{% url 'thunderdome_sync' %}">
                     {% csrf_token %}
                     <button type="submit"
-                            class="py-2 px-4 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                            class="rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                         Sync from Pretalx
                     </button>
                 </form>
@@ -94,7 +94,7 @@
             </div>
         {% endif %}
 
-        <div class="p-4 mb-6 bg-green-800 bg-opacity-50 rounded-lg">
+        <div class="bg-opacity-50 mb-6 rounded-lg bg-green-800 p-4">
             <div class="grid grid-cols-7 gap-4 text-center">
                 <div>
                     <p class="text-2xl font-bold">{{ total_count }}</p>
@@ -112,34 +112,34 @@
         </div>
 
         <form id="filter-form"
-              class="flex flex-wrap gap-4 items-end p-4 mb-6 bg-green-800 bg-opacity-50 rounded-lg"
+              class="bg-opacity-50 mb-6 flex flex-wrap items-end gap-4 rounded-lg bg-green-800 p-4"
               hx-get="{% url 'thunderdome_submissions' %}"
               hx-target="#submissions-table"
               hx-trigger="change, keyup changed delay:300ms from:#q"
               hx-push-url="true">
             <input type="hidden" name="sort" id="sort-input" value="{{ current_sort }}">
             <div class="flex-grow">
-                <label class="block mb-1 text-xs text-gray-300 uppercase" for="q">Search</label>
+                <label class="mb-1 block text-xs text-gray-300 uppercase" for="q">Search</label>
                 <input type="text"
                        name="q"
                        id="q"
                        value="{{ current_search }}"
                        placeholder="Search title or speaker..."
-                       class="py-1 px-2 w-full text-sm text-gray-900 rounded border border-gray-300">
+                       class="w-full rounded border border-gray-300 px-2 py-1 text-sm text-gray-900">
             </div>
             <div>
-                <label class="block mb-1 text-xs text-gray-300 uppercase" for="duration">Duration</label>
+                <label class="mb-1 block text-xs text-gray-300 uppercase" for="duration">Duration</label>
                 <select name="duration" id="duration"
-                        class="py-1 px-2 text-sm text-gray-900 rounded border border-gray-300">
+                        class="rounded border border-gray-300 px-2 py-1 text-sm text-gray-900">
                     <option value="">All</option>
                     <option value="25" {% if current_duration == "25" %}selected{% endif %}>25 min</option>
                     <option value="45" {% if current_duration == "45" %}selected{% endif %}>45 min</option>
                 </select>
             </div>
             <div>
-                <label class="block mb-1 text-xs text-gray-300 uppercase" for="pretalx_state">Pretalx</label>
+                <label class="mb-1 block text-xs text-gray-300 uppercase" for="pretalx_state">Pretalx</label>
                 <select name="pretalx_state" id="pretalx_state"
-                        class="py-1 px-2 text-sm text-gray-900 rounded border border-gray-300">
+                        class="rounded border border-gray-300 px-2 py-1 text-sm text-gray-900">
                     <option value="">All (excl. withdrawn)</option>
                     {% for value, label in pretalx_states %}
                         <option value="{{ value }}" {% if current_pretalx_state == value %}selected{% endif %}>
@@ -149,10 +149,10 @@
                 </select>
             </div>
             <div class="relative" id="tag-dropdown-container">
-                <label class="block mb-1 text-xs text-gray-300 uppercase">Tags</label>
+                <label class="mb-1 block text-xs text-gray-300 uppercase">Tags</label>
                 <button type="button" id="tag-dropdown-btn"
                         onclick="toggleTagDropdown()"
-                        class="py-1 px-2 text-sm text-left text-gray-900 bg-white rounded border border-gray-300 truncate"
+                        class="truncate rounded border border-gray-300 bg-white px-2 py-1 text-left text-sm text-gray-900"
                         style="min-width: 140px; max-width: 200px;">
                     {% if current_tags %}
                         {% for tag in tags %}{% if tag.pk in current_tags %}{{ tag.name }}{% if not forloop.last %}, {% endif %}{% endif %}{% endfor %}
@@ -161,24 +161,24 @@
                     {% endif %}
                 </button>
                 <div id="tag-dropdown"
-                     class="hidden overflow-y-auto absolute z-50 py-1 mt-1 w-56 bg-white rounded border border-gray-300 shadow-lg"
+                     class="absolute z-50 mt-1 hidden w-56 overflow-y-auto rounded border border-gray-300 bg-white py-1 shadow-lg"
                      style="max-height: 250px;">
                     {% for tag in tags %}
-                        <label class="flex items-center py-1.5 px-3 cursor-pointer hover:bg-gray-100">
+                        <label class="flex cursor-pointer items-center px-3 py-1.5 hover:bg-gray-100">
                             <input type="checkbox" name="tags" value="{{ tag.pk }}"
                                    data-name="{{ tag.name }}"
                                    {% if tag.pk in current_tags %}checked{% endif %}
                                    onchange="updateTagLabel()"
-                                   class="mr-2 text-green-600 rounded">
+                                   class="mr-2 rounded text-green-600">
                             <span class="text-sm text-gray-900">{{ tag.name }}</span>
                         </label>
                     {% endfor %}
                 </div>
             </div>
             <div>
-                <label class="block mb-1 text-xs text-gray-300 uppercase" for="state">Decision</label>
+                <label class="mb-1 block text-xs text-gray-300 uppercase" for="state">Decision</label>
                 <select name="state" id="state"
-                        class="py-1 px-2 text-sm text-gray-900 rounded border border-gray-300">
+                        class="rounded border border-gray-300 px-2 py-1 text-sm text-gray-900">
                     <option value="">All Decisions</option>
                     {% for value, label in states %}
                         <option value="{{ value }}" {% if current_state == value %}selected{% endif %}>

--- a/templates/tickets/claim.html
+++ b/templates/tickets/claim.html
@@ -3,7 +3,7 @@
 {% block title %}Claim Your Ticket - DjangoCon US{% endblock %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-2xl">
+    <div class="mx-auto max-w-2xl p-6">
         <div class="mb-8 text-center">
             <h1 class="mb-4 text-4xl font-bold">Claim Your Ticket</h1>
             <p class="text-lg text-gray-300">Enter your email address to claim a ticket or retrieve your existing one.</p>
@@ -19,12 +19,12 @@
             </div>
         {% endif %}
 
-        <div class="p-8 bg-green-800 bg-opacity-30 rounded-lg">
+        <div class="bg-opacity-30 rounded-lg bg-green-800 p-8">
             <form method="post" class="space-y-6">
                 {% csrf_token %}
 
                 <div>
-                    <label for="{{ form.email.id_for_label }}" class="block mb-3 text-lg font-medium">
+                    <label for="{{ form.email.id_for_label }}" class="mb-3 block text-lg font-medium">
                         {{ form.email.label }}
                     </label>
 
@@ -45,7 +45,7 @@
 
                 <div class="pt-4">
                     <button type="submit"
-                            class="py-3 px-6 w-full text-lg font-semibold text-white bg-green-600 rounded-lg transition-colors hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                            class="w-full rounded-lg bg-green-600 px-6 py-3 text-lg font-semibold text-white transition-colors hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                         Get My Ticket
                     </button>
                 </div>

--- a/templates/tickets/claim_result.html
+++ b/templates/tickets/claim_result.html
@@ -3,7 +3,7 @@
 {% block title %}Your Ticket - DjangoCon US{% endblock %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-3xl">
+    <div class="mx-auto max-w-3xl p-6">
         <div class="mb-8 text-center">
             {% if is_existing %}
                 <h1 class="mb-4 text-4xl font-bold text-green-400">Welcome Back!</h1>
@@ -14,9 +14,9 @@
             {% endif %}
         </div>
 
-        <div class="p-8 bg-green-800 bg-opacity-50 rounded-lg shadow-lg">
+        <div class="bg-opacity-50 rounded-lg bg-green-800 p-8 shadow-lg">
             <div class="space-y-6">
-                <div class="pb-6 border-b border-green-600">
+                <div class="border-b border-green-600 pb-6">
                     <h2 class="mb-4 text-2xl font-semibold">Your Ticket Information</h2>
 
                     <div class="space-y-4">
@@ -27,7 +27,7 @@
 
                         <div>
                             <p class="mb-1 text-sm text-gray-400">Ticket URL</p>
-                            <div class="p-3 bg-green-900 bg-opacity-50 rounded-md">
+                            <div class="bg-opacity-50 rounded-md bg-green-900 p-3">
                                 <p class="font-mono text-lg break-all">{{ ticket_link.link }}</p>
                             </div>
                         </div>
@@ -47,7 +47,7 @@
                             <div>
                                 <p class="mb-1 text-sm text-gray-400">Status</p>
                                 <p class="text-md">
-                                    <span class="inline-flex py-1 px-3 text-sm font-semibold text-green-200 bg-green-800 rounded-full">
+                                    <span class="inline-flex rounded-full bg-green-800 px-3 py-1 text-sm font-semibold text-green-200">
                                         Ready to Use
                                     </span>
                                 </p>
@@ -59,7 +59,7 @@
                 <div class="space-y-4">
                     <a href="{{ ticket_link.link }}"
                        target="_blank"
-                       class="block py-3 px-6 w-full text-lg font-semibold text-center text-white bg-green-600 rounded-lg transition-colors hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                       class="block w-full rounded-lg bg-green-600 px-6 py-3 text-center text-lg font-semibold text-white transition-colors hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                         Access Your Ticket →
                     </a>
 
@@ -73,7 +73,7 @@
             </div>
         </div>
 
-        <div class="p-4 mt-8 bg-yellow-800 bg-opacity-30 rounded-lg">
+        <div class="bg-opacity-30 mt-8 rounded-lg bg-yellow-800 p-4">
             <p class="text-sm text-yellow-200">
                 <strong>Important:</strong> Save this page or bookmark your ticket URL.
                 You can always retrieve it again using your email address.

--- a/templates/tickets/create.html
+++ b/templates/tickets/create.html
@@ -6,7 +6,7 @@
 {% block title %}Create Tickets - DjangoCon US Automation{% endblock %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-4xl">
+    <div class="mx-auto max-w-4xl p-6">
         <a href="/" class="text-sm text-gray-400 hover:text-gray-200">&larr; Home</a>
         <h1 class="mb-6 text-3xl font-bold">Create Ticket Links</h1>
 
@@ -24,7 +24,7 @@
             {% csrf_token %}
 
             <div>
-                <label for="{{ form.urls.id_for_label }}" class="block mb-2 text-lg font-medium">
+                <label for="{{ form.urls.id_for_label }}" class="mb-2 block text-lg font-medium">
                     {{ form.urls.label }}
                 </label>
 
@@ -45,12 +45,12 @@
 
             <div class="flex gap-4">
                 <button type="submit"
-                        class="py-3 px-6 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                        class="rounded-lg bg-green-600 px-6 py-3 font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                     Create Tickets
                 </button>
 
                 <a href="{% url 'tickets_list' %}"
-                   class="py-3 px-6 font-semibold text-white bg-gray-600 rounded-lg hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                   class="rounded-lg bg-gray-600 px-6 py-3 font-semibold text-white hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                     View All Tickets
                 </a>
             </div>

--- a/templates/tickets/info.html
+++ b/templates/tickets/info.html
@@ -3,7 +3,7 @@
 {% block title %}DjangoCon US - Tickets{% endblock title %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-3xl">
+    <div class="mx-auto max-w-3xl p-6">
         <div class="mb-8 text-center">
             <h1 class="mb-4 text-4xl font-bold text-yellow-200">DjangoCon US Tickets</h1>
             <p class="text-lg text-gray-300">Enter your email address to claim your ticket to Venueless</p>
@@ -21,7 +21,7 @@
 
         {% if ticket_link %}
             <!-- Show claimed ticket -->
-            <div class="p-8 bg-green-800 bg-opacity-50 rounded-lg shadow-lg">
+            <div class="bg-opacity-50 rounded-lg bg-green-800 p-8 shadow-lg">
                 <div class="mb-6 text-center">
                     {% if is_existing %}
                         <h2 class="mb-2 text-3xl font-bold text-green-400">Welcome Back!</h2>
@@ -36,14 +36,14 @@
                     <div class="text-center">
                         <a href="{{ ticket_link.link }}"
                            target="_blank"
-                           class="inline-block py-4 px-8 text-xl font-bold text-green-900 bg-yellow-500 rounded-lg transition-colors duration-300 transform hover:bg-yellow-400 hover:scale-105">
+                           class="inline-block transform rounded-lg bg-yellow-500 px-8 py-4 text-xl font-bold text-green-900 transition-colors duration-300 hover:scale-105 hover:bg-yellow-400">
                             🎫 Access Venueless
                         </a>
                     </div>
 
-                    <div class="p-4 bg-green-900 bg-opacity-50 rounded-md">
+                    <div class="bg-opacity-50 rounded-md bg-green-900 p-4">
                         <p class="mb-1 text-sm text-gray-400">Your Ticket URL:</p>
-                        <p class="font-mono text-sm text-gray-300 break-all">{{ ticket_link.link }}</p>
+                        <p class="font-mono text-sm break-all text-gray-300">{{ ticket_link.link }}</p>
                     </div>
 
                 </div>
@@ -59,13 +59,13 @@
 
         {% else %}
             <!-- Show claim form -->
-            <div class="p-8 bg-green-800 bg-opacity-30 rounded-lg">
+            <div class="bg-opacity-30 rounded-lg bg-green-800 p-8">
                 {% if tickets_available %}
                     <form method="post" class="space-y-6">
                         {% csrf_token %}
 
                         <div>
-                            <label for="{{ form.email.id_for_label }}" class="block mb-3 text-lg font-medium">
+                            <label for="{{ form.email.id_for_label }}" class="mb-3 block text-lg font-medium">
                                 {{ form.email.label }}
                             </label>
 
@@ -86,7 +86,7 @@
 
                         <div class="pt-4">
                             <button type="submit"
-                                    class="py-3 px-6 w-full text-lg font-semibold text-white bg-green-600 rounded-lg transition-colors hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                                    class="w-full rounded-lg bg-green-600 px-6 py-3 text-lg font-semibold text-white transition-colors hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                                 Get My Ticket
                             </button>
                         </div>
@@ -98,13 +98,13 @@
                             If you've already claimed a ticket, enter your email to retrieve it.
                         </p>
 
-                        <div class="p-4 bg-blue-800 bg-opacity-30 rounded-lg">
+                        <div class="bg-opacity-30 rounded-lg bg-blue-800 p-4">
                             <p class="text-sm text-blue-200">
                                 <strong>Already registered?</strong> You can go directly to:
                             </p>
                             <a href="https://dcus25.venueless.events"
                                target="_blank"
-                               class="inline-block py-2 px-4 mt-2 text-sm font-semibold text-green-900 bg-yellow-500 rounded-lg transition-colors duration-300 hover:bg-yellow-400">
+                               class="mt-2 inline-block rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-green-900 transition-colors duration-300 hover:bg-yellow-400">
                                 dcus25.venueless.events
                             </a>
                         </div>
@@ -119,7 +119,7 @@
                             If you believe this is an error or need assistance, please reach out to us:
                         </p>
                         <a href="mailto:hello@djangocon.us"
-                           class="inline-block py-3 px-6 font-semibold text-green-900 bg-yellow-500 rounded-lg transition-colors duration-300 hover:bg-yellow-400">
+                           class="inline-block rounded-lg bg-yellow-500 px-6 py-3 font-semibold text-green-900 transition-colors duration-300 hover:bg-yellow-400">
                             hello@djangocon.us
                         </a>
                     </div>

--- a/templates/tickets/list.html
+++ b/templates/tickets/list.html
@@ -6,14 +6,14 @@
 {% block title %}All Tickets - DjangoCon US Automation{% endblock %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-6xl">
-        <div class="flex justify-between items-center mb-6">
+    <div class="mx-auto max-w-6xl p-6">
+        <div class="mb-6 flex items-center justify-between">
             <div>
                 <a href="/" class="text-sm text-gray-400 hover:text-gray-200">&larr; Home</a>
                 <h1 class="text-3xl font-bold">All Ticket Links</h1>
             </div>
             <a href="{% url 'create_tickets' %}"
-               class="py-2 px-4 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+               class="rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                 Create New Tickets
             </a>
         </div>
@@ -28,7 +28,7 @@
             </div>
         {% endif %}
 
-        <div class="p-4 mb-6 bg-green-800 bg-opacity-50 rounded-lg">
+        <div class="bg-opacity-50 mb-6 rounded-lg bg-green-800 p-4">
             <div class="grid grid-cols-3 gap-4 text-center">
                 <div>
                     <p class="text-2xl font-bold">{{ total_count }}</p>
@@ -47,53 +47,53 @@
 
         {% if tickets %}
             <div class="overflow-x-auto">
-                <table class="overflow-hidden w-full bg-green-800 bg-opacity-30 rounded-lg">
-                    <thead class="bg-green-700 bg-opacity-50">
+                <table class="bg-opacity-30 w-full overflow-hidden rounded-lg bg-green-800">
+                    <thead class="bg-opacity-50 bg-green-700">
                         <tr>
-                            <th class="py-3 px-6 text-xs font-medium tracking-wider text-left uppercase">
+                            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider uppercase">
                                 Ticket URL
                             </th>
-                            <th class="py-3 px-6 text-xs font-medium tracking-wider text-left uppercase">
+                            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider uppercase">
                                 Assigned To
                             </th>
-                            <th class="py-3 px-6 text-xs font-medium tracking-wider text-left uppercase">
+                            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider uppercase">
                                 Assigned On
                             </th>
-                            <th class="py-3 px-6 text-xs font-medium tracking-wider text-center uppercase">
+                            <th class="px-6 py-3 text-center text-xs font-medium tracking-wider uppercase">
                                 Status
                             </th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-green-700">
                         {% for ticket in tickets %}
-                            <tr class="transition-colors hover:bg-green-700 hover:bg-opacity-30">
-                                <td class="py-4 px-6 whitespace-nowrap">
-                                    <span class="block max-w-md text-gray-300 truncate"
+                            <tr class="transition-colors hover:bg-opacity-30 hover:bg-green-700">
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    <span class="block max-w-md truncate text-gray-300"
                                           title="{{ ticket.link }}">
                                         {{ ticket.link|truncatechars:60 }}
                                     </span>
                                 </td>
-                                <td class="py-4 px-6 text-sm whitespace-nowrap">
+                                <td class="px-6 py-4 text-sm whitespace-nowrap">
                                     {% if ticket.attendee_email %}
                                         <span class="text-blue-300">{{ ticket.attendee_email }}</span>
                                     {% else %}
                                         <span class="text-gray-500">Unassigned</span>
                                     {% endif %}
                                 </td>
-                                <td class="py-4 px-6 text-sm whitespace-nowrap">
+                                <td class="px-6 py-4 text-sm whitespace-nowrap">
                                     {% if ticket.date_link_assigned %}
                                         {{ ticket.date_link_assigned|date:"M d, Y g:i A" }}
                                     {% else %}
                                         <span class="text-gray-400">Not assigned</span>
                                     {% endif %}
                                 </td>
-                                <td class="py-4 px-6 text-center whitespace-nowrap">
+                                <td class="px-6 py-4 text-center whitespace-nowrap">
                                     {% if ticket.attendee_email %}
-                                        <span class="inline-flex py-1 px-3 text-xs font-semibold leading-5 text-red-200 bg-red-800 rounded-full">
+                                        <span class="inline-flex rounded-full bg-red-800 px-3 py-1 text-xs leading-5 font-semibold text-red-200">
                                             Assigned
                                         </span>
                                     {% else %}
-                                        <span class="inline-flex py-1 px-3 text-xs font-semibold leading-5 text-green-200 bg-green-800 rounded-full">
+                                        <span class="inline-flex rounded-full bg-green-800 px-3 py-1 text-xs leading-5 font-semibold text-green-200">
                                             Available
                                         </span>
                                     {% endif %}
@@ -104,10 +104,10 @@
                 </table>
             </div>
         {% else %}
-            <div class="py-12 text-center bg-green-800 bg-opacity-30 rounded-lg">
+            <div class="bg-opacity-30 rounded-lg bg-green-800 py-12 text-center">
                 <p class="mb-4 text-xl text-gray-300">No tickets have been created yet.</p>
                 <a href="{% url 'create_tickets' %}"
-                   class="inline-block py-3 px-6 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                   class="inline-block rounded-lg bg-green-600 px-6 py-3 font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                     Create Your First Tickets
                 </a>
             </div>

--- a/templates/titowebhooks/sales_dashboard.html
+++ b/templates/titowebhooks/sales_dashboard.html
@@ -6,8 +6,8 @@
 {% block title %}Ticket Sales - DjangoCon US Automation{% endblock %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-7xl">
-        <div class="flex justify-between items-center mb-6">
+    <div class="mx-auto max-w-7xl p-6">
+        <div class="mb-6 flex items-center justify-between">
             <div>
                 <a href="/" class="text-sm text-gray-400 hover:text-gray-200">&larr; Home</a>
                 <h1 class="text-3xl font-bold">Ticket Sales</h1>
@@ -15,7 +15,7 @@
             <form method="post" action="{% url 'tito_sync' %}">
                 {% csrf_token %}
                 <button type="submit"
-                        class="py-2 px-4 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                        class="rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                     Sync from Tito
                 </button>
             </form>
@@ -32,7 +32,7 @@
         {% endif %}
 
         {% if never_synced %}
-            <div class="p-6 text-center bg-green-800 bg-opacity-30 rounded-lg">
+            <div class="bg-opacity-30 rounded-lg bg-green-800 p-6 text-center">
                 <p class="mb-4 text-gray-300">No data yet. Click <strong>Sync from Tito</strong> to load ticket sales.</p>
             </div>
         {% else %}
@@ -44,7 +44,7 @@
                             <span class="ml-2 text-sm font-normal text-green-400">current</span>
                         </h2>
 
-                        <div class="p-4 mb-3 bg-green-800 bg-opacity-50 rounded-lg">
+                        <div class="bg-opacity-50 mb-3 rounded-lg bg-green-800 p-4">
                             <div class="grid grid-cols-4 gap-4 text-center">
                                 <div>
                                     <p class="text-2xl font-bold text-green-400">{{ event.total_sold }}</p>
@@ -76,13 +76,13 @@
 
                         {% if event.activities %}
                             <h3 class="mt-4 mb-2 text-sm font-semibold tracking-wider text-gray-400 uppercase">Activities</h3>
-                            <div class="overflow-hidden mb-4 bg-green-800 bg-opacity-30 rounded-lg">
+                            <div class="bg-opacity-30 mb-4 overflow-hidden rounded-lg bg-green-800">
                                 <table class="w-full">
                                     <tbody class="divide-y divide-green-700">
                                         {% for activity in event.activities %}
-                                            <tr class="transition-colors hover:bg-green-700 hover:bg-opacity-20">
-                                                <td class="py-2 px-4 text-sm">{{ activity.name }}</td>
-                                                <td class="py-2 px-4 font-mono text-sm text-right">
+                                            <tr class="transition-colors hover:bg-opacity-20 hover:bg-green-700">
+                                                <td class="px-4 py-2 text-sm">{{ activity.name }}</td>
+                                                <td class="px-4 py-2 text-right font-mono text-sm">
                                                     <span class="{% if activity.allocation_count %}text-green-400{% else %}text-gray-500{% endif %}">{{ activity.allocation_count|default:0 }}</span>
                                                     <span class="text-gray-600">/</span>
                                                     <span class="text-gray-300">{% if activity.capacity %}{{ activity.capacity }}{% else %}&infin;{% endif %}</span>
@@ -96,36 +96,36 @@
 
                         {% if event.releases_by_activity %}
                             <h3 class="mb-2 text-sm font-semibold tracking-wider text-gray-400 uppercase">Tickets</h3>
-                            <div class="overflow-hidden bg-green-800 bg-opacity-30 rounded-lg">
+                            <div class="bg-opacity-30 overflow-hidden rounded-lg bg-green-800">
                                 <table class="w-full">
-                                    <thead class="bg-green-700 bg-opacity-50">
+                                    <thead class="bg-opacity-50 bg-green-700">
                                         <tr>
-                                            <th class="py-2 px-4 text-xs font-medium tracking-wider text-left uppercase">Release</th>
-                                            <th class="py-2 px-4 text-xs font-medium tracking-wider text-center uppercase">State</th>
-                                            <th class="py-2 px-4 text-xs font-medium tracking-wider text-right uppercase">Price</th>
-                                            <th class="py-2 px-4 text-xs font-medium tracking-wider text-right uppercase">Sold / Cap</th>
-                                            <th class="py-2 px-4 text-xs font-medium tracking-wider text-right uppercase">Total</th>
+                                            <th class="px-4 py-2 text-left text-xs font-medium tracking-wider uppercase">Release</th>
+                                            <th class="px-4 py-2 text-center text-xs font-medium tracking-wider uppercase">State</th>
+                                            <th class="px-4 py-2 text-right text-xs font-medium tracking-wider uppercase">Price</th>
+                                            <th class="px-4 py-2 text-right text-xs font-medium tracking-wider uppercase">Sold / Cap</th>
+                                            <th class="px-4 py-2 text-right text-xs font-medium tracking-wider uppercase">Total</th>
                                         </tr>
                                     </thead>
                                     <tbody class="divide-y divide-green-700">
                                         {% for group in event.releases_by_activity %}
-                                            <tr class="bg-green-900 bg-opacity-60">
-                                                <td class="py-1 px-4 text-xs font-semibold tracking-wider text-green-300 uppercase">{{ group.name }}</td>
-                                                <td class="py-1 px-4 text-xs text-center text-gray-500"></td>
-                                                <td class="py-1 px-4 text-xs text-right text-gray-500"></td>
-                                                <td class="py-1 px-4 font-mono text-xs text-right text-gray-400">
+                                            <tr class="bg-opacity-60 bg-green-900">
+                                                <td class="px-4 py-1 text-xs font-semibold tracking-wider text-green-300 uppercase">{{ group.name }}</td>
+                                                <td class="px-4 py-1 text-center text-xs text-gray-500"></td>
+                                                <td class="px-4 py-1 text-right text-xs text-gray-500"></td>
+                                                <td class="px-4 py-1 text-right font-mono text-xs text-gray-400">
                                                     <span class="{% if group.total_sold %}text-green-300{% else %}text-gray-600{% endif %}">{{ group.total_sold }}</span>
                                                     <span class="text-gray-600">/</span>
                                                     <span>{% if group.total_capacity %}{{ group.total_capacity }}{% else %}&infin;{% endif %}</span>
                                                 </td>
-                                                <td class="py-1 px-4 font-mono text-xs text-right">
+                                                <td class="px-4 py-1 text-right font-mono text-xs">
                                                     <span class="{% if group.total_revenue %}text-green-300{% else %}text-gray-600{% endif %}">${{ group.total_revenue|floatformat:"0g" }}</span>
                                                 </td>
                                             </tr>
                                             {% for release in group.releases %}
-                                                <tr class="transition-colors hover:bg-green-700 hover:bg-opacity-20">
-                                                    <td class="py-2 px-4 pl-6 text-sm">{{ release.title }}</td>
-                                                    <td class="py-2 px-4 text-sm text-center">
+                                                <tr class="transition-colors hover:bg-opacity-20 hover:bg-green-700">
+                                                    <td class="px-4 py-2 pl-6 text-sm">{{ release.title }}</td>
+                                                    <td class="px-4 py-2 text-center text-sm">
                                                         <span class="inline-flex py-0.5 px-2 text-xs rounded-full
                                                                      {% if release.state_name == 'on_sale' %}bg-green-800 text-green-200
                                                                      {% elif release.state_name == 'paused' %}bg-yellow-800 text-yellow-200
@@ -133,24 +133,24 @@
                                                             {{ release.state_name|default:"—" }}
                                                         </span>
                                                     </td>
-                                                    <td class="py-2 px-4 font-mono text-sm text-right">
+                                                    <td class="px-4 py-2 text-right font-mono text-sm">
                                                         {% if release.price %}<span class="text-gray-300">${{ release.price|floatformat:"0g" }}</span>{% else %}<span class="text-gray-600">—</span>{% endif %}
                                                     </td>
-                                                    <td class="py-2 px-4 font-mono text-sm text-right">
+                                                    <td class="px-4 py-2 text-right font-mono text-sm">
                                                         <span class="{% if release.tickets_count %}text-green-400{% else %}text-gray-500{% endif %}">{{ release.tickets_count|default:0 }}</span>
                                                         <span class="text-gray-600">/</span>
                                                         <span class="text-gray-300">{% if release.quantity %}{{ release.quantity }}{% else %}&infin;{% endif %}</span>
                                                     </td>
-                                                    <td class="py-2 px-4 font-mono text-sm text-right">
+                                                    <td class="px-4 py-2 text-right font-mono text-sm">
                                                         {% if release.revenue %}<span class="text-green-400">${{ release.revenue|floatformat:"0g" }}</span>{% else %}<span class="text-gray-600">—</span>{% endif %}
                                                     </td>
                                                 </tr>
                                             {% endfor %}
                                         {% endfor %}
-                                        <tr class="bg-green-700 bg-opacity-40">
-                                            <td class="py-2 px-4 text-xs font-semibold tracking-wider text-green-200 uppercase" colspan="3">Total raised</td>
-                                            <td class="py-2 px-4 font-mono text-xs text-right text-gray-300">{{ event.total_sold }}</td>
-                                            <td class="py-2 px-4 font-mono text-sm text-right text-green-300">${{ event.total_revenue|floatformat:"0g" }}</td>
+                                        <tr class="bg-opacity-40 bg-green-700">
+                                            <td class="px-4 py-2 text-xs font-semibold tracking-wider text-green-200 uppercase" colspan="3">Total raised</td>
+                                            <td class="px-4 py-2 text-right font-mono text-xs text-gray-300">{{ event.total_sold }}</td>
+                                            <td class="px-4 py-2 text-right font-mono text-sm text-green-300">${{ event.total_revenue|floatformat:"0g" }}</td>
                                         </tr>
                                     </tbody>
                                 </table>
@@ -158,8 +158,8 @@
                         {% endif %}
 
                     {% else %}
-                        <details class="overflow-hidden bg-green-800 bg-opacity-20 rounded-lg">
-                            <summary class="flex justify-between items-center py-3 px-4 cursor-pointer hover:bg-green-700 hover:bg-opacity-20">
+                        <details class="bg-opacity-20 overflow-hidden rounded-lg bg-green-800">
+                            <summary class="flex cursor-pointer items-center justify-between px-4 py-3 hover:bg-opacity-20 hover:bg-green-700">
                                 <span class="font-semibold">{{ event.title }}</span>
                                 <span class="font-mono text-sm text-gray-300">
                                     <span class="text-green-400">{{ event.total_sold }}</span>
@@ -170,13 +170,13 @@
                                 </span>
                             </summary>
                             {% if event.activities %}
-                                <p class="py-2 px-4 text-xs font-semibold tracking-wider text-gray-500 uppercase border-t border-green-700">Activities</p>
+                                <p class="border-t border-green-700 px-4 py-2 text-xs font-semibold tracking-wider text-gray-500 uppercase">Activities</p>
                                 <table class="w-full">
                                     <tbody class="divide-y divide-green-800">
                                         {% for activity in event.activities %}
-                                            <tr class="transition-colors hover:bg-green-700 hover:bg-opacity-10">
-                                                <td class="py-2 px-4 text-sm">{{ activity.name }}</td>
-                                                <td class="py-2 px-4 font-mono text-sm text-right">
+                                            <tr class="transition-colors hover:bg-opacity-10 hover:bg-green-700">
+                                                <td class="px-4 py-2 text-sm">{{ activity.name }}</td>
+                                                <td class="px-4 py-2 text-right font-mono text-sm">
                                                     <span class="{% if activity.allocation_count %}text-green-400{% else %}text-gray-500{% endif %}">{{ activity.allocation_count|default:0 }}</span>
                                                     <span class="text-gray-600">/</span>
                                                     <span class="text-gray-300">{% if activity.capacity %}{{ activity.capacity }}{% else %}&infin;{% endif %}</span>
@@ -187,39 +187,39 @@
                                 </table>
                             {% endif %}
                             {% if event.releases_by_activity %}
-                                <p class="py-2 px-4 text-xs font-semibold tracking-wider text-gray-500 uppercase border-t border-green-700">Tickets</p>
+                                <p class="border-t border-green-700 px-4 py-2 text-xs font-semibold tracking-wider text-gray-500 uppercase">Tickets</p>
                                 <table class="w-full">
                                     <tbody class="divide-y divide-green-800">
                                         {% for group in event.releases_by_activity %}
-                                            <tr class="bg-green-900 bg-opacity-40">
-                                                <td class="py-1 px-4 text-xs font-semibold tracking-wider text-green-400 uppercase">{{ group.name }}</td>
-                                                <td class="py-1 px-4 font-mono text-xs text-right text-gray-400">
+                                            <tr class="bg-opacity-40 bg-green-900">
+                                                <td class="px-4 py-1 text-xs font-semibold tracking-wider text-green-400 uppercase">{{ group.name }}</td>
+                                                <td class="px-4 py-1 text-right font-mono text-xs text-gray-400">
                                                     <span class="{% if group.total_sold %}text-green-300{% else %}text-gray-600{% endif %}">{{ group.total_sold }}</span>
                                                     <span class="text-gray-600">/</span>
                                                     <span>{% if group.total_capacity %}{{ group.total_capacity }}{% else %}&infin;{% endif %}</span>
                                                 </td>
-                                                <td class="py-1 px-4 font-mono text-xs text-right">
+                                                <td class="px-4 py-1 text-right font-mono text-xs">
                                                     <span class="{% if group.total_revenue %}text-green-300{% else %}text-gray-600{% endif %}">${{ group.total_revenue|floatformat:"0g" }}</span>
                                                 </td>
                                             </tr>
                                             {% for release in group.releases %}
-                                                <tr class="transition-colors hover:bg-green-700 hover:bg-opacity-10">
-                                                    <td class="py-2 px-4 pl-6 text-sm">{{ release.title }}</td>
-                                                    <td class="py-2 px-4 font-mono text-sm text-right">
+                                                <tr class="transition-colors hover:bg-opacity-10 hover:bg-green-700">
+                                                    <td class="px-4 py-2 pl-6 text-sm">{{ release.title }}</td>
+                                                    <td class="px-4 py-2 text-right font-mono text-sm">
                                                         <span class="{% if release.tickets_count %}text-green-400{% else %}text-gray-500{% endif %}">{{ release.tickets_count|default:0 }}</span>
                                                         <span class="text-gray-600">/</span>
                                                         <span class="text-gray-300">{% if release.quantity %}{{ release.quantity }}{% else %}&infin;{% endif %}</span>
                                                     </td>
-                                                    <td class="py-2 px-4 font-mono text-sm text-right">
+                                                    <td class="px-4 py-2 text-right font-mono text-sm">
                                                         {% if release.revenue %}<span class="text-green-400">${{ release.revenue|floatformat:"0g" }}</span>{% else %}<span class="text-gray-600">—</span>{% endif %}
                                                     </td>
                                                 </tr>
                                             {% endfor %}
                                         {% endfor %}
-                                        <tr class="bg-green-700 bg-opacity-30">
-                                            <td class="py-2 px-4 text-xs font-semibold tracking-wider text-green-200 uppercase">Total raised</td>
-                                            <td class="py-2 px-4 font-mono text-xs text-right text-gray-300">{{ event.total_sold }}</td>
-                                            <td class="py-2 px-4 font-mono text-sm text-right text-green-300">${{ event.total_revenue|floatformat:"0g" }}</td>
+                                        <tr class="bg-opacity-30 bg-green-700">
+                                            <td class="px-4 py-2 text-xs font-semibold tracking-wider text-green-200 uppercase">Total raised</td>
+                                            <td class="px-4 py-2 text-right font-mono text-xs text-gray-300">{{ event.total_sold }}</td>
+                                            <td class="px-4 py-2 text-right font-mono text-sm text-green-300">${{ event.total_revenue|floatformat:"0g" }}</td>
                                         </tr>
                                     </tbody>
                                 </table>

--- a/templates/titowebhooks/sprint_tickets.html
+++ b/templates/titowebhooks/sprint_tickets.html
@@ -6,8 +6,8 @@
 {% block title %}Sprint Tickets - DjangoCon US Automation{% endblock %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-7xl">
-        <div class="flex justify-between items-center mb-6">
+    <div class="mx-auto max-w-7xl p-6">
+        <div class="mb-6 flex items-center justify-between">
             <div>
                 <a href="/" class="text-sm text-gray-400 hover:text-gray-200">&larr; Home</a>
                 <h1 class="text-3xl font-bold">Sprint Tickets</h1>
@@ -15,28 +15,28 @@
             <div class="flex gap-2">
                 {% if include_online %}
                     <a href="?"
-                       class="py-2 px-4 font-semibold text-white bg-gray-700 rounded-lg hover:bg-gray-600 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                       class="rounded-lg bg-gray-700 px-4 py-2 font-semibold text-white hover:bg-gray-600 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                         Hide online
                     </a>
                 {% else %}
                     <a href="?include_online=1"
-                       class="py-2 px-4 font-semibold text-white bg-gray-700 rounded-lg hover:bg-gray-600 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                       class="rounded-lg bg-gray-700 px-4 py-2 font-semibold text-white hover:bg-gray-600 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                         Show online too
                     </a>
                 {% endif %}
                 <a href="?format=csv{% if include_online %}&include_online=1{% endif %}"
-                   class="py-2 px-4 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                   class="rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                     Download CSV
                 </a>
                 <a href="?scope=historical&format=csv{% if include_online %}&include_online=1{% endif %}"
                    title="In-person sprint attendees across the last {{ historical_years }} conference years"
-                   class="py-2 px-4 font-semibold text-white bg-green-700 rounded-lg hover:bg-green-800 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
+                   class="rounded-lg bg-green-700 px-4 py-2 font-semibold text-white hover:bg-green-800 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">
                     Download Historical
                 </a>
             </div>
         </div>
 
-        <div class="p-4 mb-6 bg-green-800 bg-opacity-50 rounded-lg">
+        <div class="bg-opacity-50 mb-6 rounded-lg bg-green-800 p-4">
             <div class="grid {% if include_online %}grid-cols-6{% else %}grid-cols-5{% endif %} gap-4 text-center">
                 <div>
                     <p class="text-2xl font-bold">{{ total_count }}</p>
@@ -69,53 +69,53 @@
 
         {% if sprint_tickets %}
             <div class="overflow-x-auto">
-                <table class="overflow-hidden w-full bg-green-800 bg-opacity-30 rounded-lg">
-                    <thead class="bg-green-700 bg-opacity-50">
+                <table class="bg-opacity-30 w-full overflow-hidden rounded-lg bg-green-800">
+                    <thead class="bg-opacity-50 bg-green-700">
                         <tr>
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">
+                            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">
                                 Name
                             </th>
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">
+                            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">
                                 Email
                             </th>
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase" colspan="2">
+                            <th class="px-4 py-3 text-center text-xs font-medium tracking-wider uppercase" colspan="2">
                                 Thursday
                             </th>
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase" colspan="2">
+                            <th class="px-4 py-3 text-center text-xs font-medium tracking-wider uppercase" colspan="2">
                                 Friday
                             </th>
                             {% if include_online %}
-                                <th class="py-3 px-4 text-xs font-medium tracking-wider text-center uppercase">
+                                <th class="px-4 py-3 text-center text-xs font-medium tracking-wider uppercase">
                                     Online
                                 </th>
                             {% endif %}
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">
+                            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">
                                 Ticket Date
                             </th>
                         </tr>
-                        <tr class="bg-green-700 bg-opacity-30">
+                        <tr class="bg-opacity-30 bg-green-700">
                             <th colspan="2"></th>
-                            <th class="py-1 px-4 text-xs font-medium tracking-wider text-center text-gray-400 uppercase">Leading</th>
-                            <th class="py-1 px-4 text-xs font-medium tracking-wider text-center text-gray-400 uppercase">Joining</th>
-                            <th class="py-1 px-4 text-xs font-medium tracking-wider text-center text-gray-400 uppercase">Leading</th>
-                            <th class="py-1 px-4 text-xs font-medium tracking-wider text-center text-gray-400 uppercase">Joining</th>
+                            <th class="px-4 py-1 text-center text-xs font-medium tracking-wider text-gray-400 uppercase">Leading</th>
+                            <th class="px-4 py-1 text-center text-xs font-medium tracking-wider text-gray-400 uppercase">Joining</th>
+                            <th class="px-4 py-1 text-center text-xs font-medium tracking-wider text-gray-400 uppercase">Leading</th>
+                            <th class="px-4 py-1 text-center text-xs font-medium tracking-wider text-gray-400 uppercase">Joining</th>
                             {% if include_online %}<th></th>{% endif %}
                             <th></th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-green-700">
                         {% for ticket in sprint_tickets %}
-                            <tr class="transition-colors hover:bg-green-700 hover:bg-opacity-30">
-                                <td class="py-3 px-4 whitespace-nowrap">
+                            <tr class="transition-colors hover:bg-opacity-30 hover:bg-green-700">
+                                <td class="px-4 py-3 whitespace-nowrap">
                                     {{ ticket.name }}
                                 </td>
-                                <td class="py-3 px-4 text-sm whitespace-nowrap">
+                                <td class="px-4 py-3 text-sm whitespace-nowrap">
                                     <span class="text-blue-300">{{ ticket.email }}</span>
                                 </td>
-                                <td class="py-3 px-4 text-center whitespace-nowrap">
+                                <td class="px-4 py-3 text-center whitespace-nowrap">
                                     {% if ticket.thursday %}
                                         {% if ticket.thursday_leading == "Yes" %}
-                                            <span class="inline-flex py-1 px-3 text-xs font-semibold leading-5 text-yellow-200 bg-yellow-800 rounded-full">Yes</span>
+                                            <span class="inline-flex rounded-full bg-yellow-800 px-3 py-1 text-xs leading-5 font-semibold text-yellow-200">Yes</span>
                                         {% else %}
                                             <span class="text-gray-500">No</span>
                                         {% endif %}
@@ -123,10 +123,10 @@
                                         <span class="text-gray-600">-</span>
                                     {% endif %}
                                 </td>
-                                <td class="py-3 px-4 text-center whitespace-nowrap">
+                                <td class="px-4 py-3 text-center whitespace-nowrap">
                                     {% if ticket.thursday %}
                                         {% if ticket.thursday_joining == "Yes" %}
-                                            <span class="inline-flex py-1 px-3 text-xs font-semibold leading-5 text-blue-200 bg-blue-800 rounded-full">Yes</span>
+                                            <span class="inline-flex rounded-full bg-blue-800 px-3 py-1 text-xs leading-5 font-semibold text-blue-200">Yes</span>
                                         {% else %}
                                             <span class="text-gray-500">No</span>
                                         {% endif %}
@@ -134,10 +134,10 @@
                                         <span class="text-gray-600">-</span>
                                     {% endif %}
                                 </td>
-                                <td class="py-3 px-4 text-center whitespace-nowrap">
+                                <td class="px-4 py-3 text-center whitespace-nowrap">
                                     {% if ticket.friday %}
                                         {% if ticket.friday_leading == "Yes" %}
-                                            <span class="inline-flex py-1 px-3 text-xs font-semibold leading-5 text-yellow-200 bg-yellow-800 rounded-full">Yes</span>
+                                            <span class="inline-flex rounded-full bg-yellow-800 px-3 py-1 text-xs leading-5 font-semibold text-yellow-200">Yes</span>
                                         {% else %}
                                             <span class="text-gray-500">No</span>
                                         {% endif %}
@@ -145,10 +145,10 @@
                                         <span class="text-gray-600">-</span>
                                     {% endif %}
                                 </td>
-                                <td class="py-3 px-4 text-center whitespace-nowrap">
+                                <td class="px-4 py-3 text-center whitespace-nowrap">
                                     {% if ticket.friday %}
                                         {% if ticket.friday_joining == "Yes" %}
-                                            <span class="inline-flex py-1 px-3 text-xs font-semibold leading-5 text-blue-200 bg-blue-800 rounded-full">Yes</span>
+                                            <span class="inline-flex rounded-full bg-blue-800 px-3 py-1 text-xs leading-5 font-semibold text-blue-200">Yes</span>
                                         {% else %}
                                             <span class="text-gray-500">No</span>
                                         {% endif %}
@@ -157,15 +157,15 @@
                                     {% endif %}
                                 </td>
                                 {% if include_online %}
-                                    <td class="py-3 px-4 text-center whitespace-nowrap">
+                                    <td class="px-4 py-3 text-center whitespace-nowrap">
                                         {% if ticket.online %}
-                                            <span class="inline-flex py-1 px-3 text-xs font-semibold leading-5 text-purple-200 bg-purple-800 rounded-full">Yes</span>
+                                            <span class="inline-flex rounded-full bg-purple-800 px-3 py-1 text-xs leading-5 font-semibold text-purple-200">Yes</span>
                                         {% else %}
                                             <span class="text-gray-600">-</span>
                                         {% endif %}
                                     </td>
                                 {% endif %}
-                                <td class="py-3 px-4 text-sm whitespace-nowrap">
+                                <td class="px-4 py-3 text-sm whitespace-nowrap">
                                     {{ ticket.created_at|date:"Y-m-d H:i" }}
                                 </td>
                             </tr>
@@ -174,7 +174,7 @@
                 </table>
             </div>
         {% else %}
-            <div class="py-12 text-center bg-green-800 bg-opacity-30 rounded-lg">
+            <div class="bg-opacity-30 rounded-lg bg-green-800 py-12 text-center">
                 <p class="text-xl text-gray-300">No sprint tickets found.</p>
             </div>
         {% endif %}

--- a/templates/titowebhooks/volunteer_interest.html
+++ b/templates/titowebhooks/volunteer_interest.html
@@ -7,8 +7,8 @@
 {% block title %}Volunteer Interest - DjangoCon US Automation{% endblock %}
 
 {% block content %}
-    <div class="p-6 mx-auto max-w-7xl">
-        <div class="flex justify-between items-center mb-6">
+    <div class="mx-auto max-w-7xl p-6">
+        <div class="mb-6 flex items-center justify-between">
             <div>
                 <a href="/" class="text-sm text-gray-400 hover:text-gray-200">&larr; Home</a>
                 <h1 class="text-3xl font-bold">Volunteer Interest</h1>
@@ -18,11 +18,11 @@
             </div>
             <div class="flex gap-2">
                 <a href="?format=csv"
-                   class="py-2 px-4 font-semibold text-white bg-green-600 rounded-lg hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">Download CSV</a>
+                   class="rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-green-900 focus:outline-none">Download CSV</a>
             </div>
         </div>
 
-        <div class="p-4 mb-6 bg-green-800 bg-opacity-50 rounded-lg">
+        <div class="bg-opacity-50 mb-6 rounded-lg bg-green-800 p-4">
             <div class="grid grid-cols-3 gap-4 text-center">
                 <div>
                     <p class="text-2xl font-bold text-green-400">{{ total_count }}</p>
@@ -41,29 +41,29 @@
 
         {% if people %}
             <div class="overflow-x-auto">
-                <table class="overflow-hidden w-full bg-green-800 bg-opacity-30 rounded-lg">
-                    <thead class="bg-green-700 bg-opacity-50">
+                <table class="bg-opacity-30 w-full overflow-hidden rounded-lg bg-green-800">
+                    <thead class="bg-opacity-50 bg-green-700">
                         <tr>
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Name</th>
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Email</th>
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Company</th>
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Ticket</th>
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Date</th>
-                            <th class="py-3 px-4 text-xs font-medium tracking-wider text-left uppercase">Signed Up</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">Name</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">Email</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">Company</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">Ticket</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">Date</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider uppercase">Signed Up</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-green-700">
                         {% for person in people %}
-                            <tr class="transition-colors hover:bg-green-700 hover:bg-opacity-20">
-                                <td class="py-2 px-4 text-sm">{{ person.name }}</td>
-                                <td class="py-2 px-4 text-sm">
+                            <tr class="transition-colors hover:bg-opacity-20 hover:bg-green-700">
+                                <td class="px-4 py-2 text-sm">{{ person.name }}</td>
+                                <td class="px-4 py-2 text-sm">
                                     <a href="mailto:{{ person.email }}"
                                        class="text-yellow-300 underline hover:text-yellow-200">{{ person.email }}</a>
                                 </td>
-                                <td class="py-2 px-4 text-sm">{{ person.company_name }}</td>
-                                <td class="py-2 px-4 text-sm">{{ person.release_title }}</td>
-                                <td class="py-2 px-4 text-sm">{{ person.created_at|date:"Y-m-d" }}</td>
-                                <td class="py-2 px-4 text-sm">
+                                <td class="px-4 py-2 text-sm">{{ person.company_name }}</td>
+                                <td class="px-4 py-2 text-sm">{{ person.release_title }}</td>
+                                <td class="px-4 py-2 text-sm">{{ person.created_at|date:"Y-m-d" }}</td>
+                                <td class="px-4 py-2 text-sm">
                                     {% if person.has_signed_up %}
                                         <span class="text-green-400">Yes</span>
                                     {% else %}
@@ -76,7 +76,7 @@
                 </table>
             </div>
         {% else %}
-            <div class="p-6 text-center bg-green-800 bg-opacity-30 rounded-lg">
+            <div class="bg-opacity-30 rounded-lg bg-green-800 p-6 text-center">
                 <p class="text-gray-300">No attendees have answered &ldquo;Yes!&rdquo; to volunteering yet.</p>
             </div>
         {% endif %}

--- a/titowebhooks/tests/test_views.py
+++ b/titowebhooks/tests/test_views.py
@@ -119,9 +119,7 @@ def _sprint_payload(*, email, release_title, created_at, leading="No", joining="
 class TestSprintTicketsView(TestCase):
     def setUp(self):
         User = get_user_model()
-        self.staff = User.objects.create_user(
-            username="staff", password="x", email="staff@example.com", is_staff=True
-        )
+        self.staff = User.objects.create_user(username="staff", password="x", email="staff@example.com", is_staff=True)
         self.client.force_login(self.staff)
 
     def _create_event(self, payload):
@@ -271,9 +269,7 @@ def _historical_payload(*, email, release_title, created_at, year, leading="No",
 class TestHistoricalSprintTicketsCsv(TestCase):
     def setUp(self):
         User = get_user_model()
-        self.staff = User.objects.create_user(
-            username="staff", password="x", email="staff@example.com", is_staff=True
-        )
+        self.staff = User.objects.create_user(username="staff", password="x", email="staff@example.com", is_staff=True)
         self.client.force_login(self.staff)
 
     def _create_event(self, payload):

--- a/travel_safety/templates/travel_safety/register.html
+++ b/travel_safety/templates/travel_safety/register.html
@@ -3,13 +3,13 @@
 {% block title %}{{ page_title }}{% endblock title %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 max-w-4xl text-green-200 bg-green-900 rounded-xl shadow-inner">
+    <div class="flex max-w-4xl flex-col gap-6 rounded-xl bg-green-900 p-8 text-green-200 shadow-inner">
         <div class="mb-8 text-center">
             <h1 class="mb-6 text-4xl font-bold text-yellow-200">DjangoCon US 2026 Travel Safety Registration</h1>
         </div>
 
     <!-- Introduction Text -->
-        <div class="p-6 mb-8 bg-gray-100 rounded-lg border border-blue-600">
+        <div class="mb-8 rounded-lg border border-blue-600 bg-gray-100 p-6">
             <div class="space-y-4 text-sm leading-relaxed text-green-900">
                 <p>
                     We recognize that international travel to the United States has become more concerning this year, and we want to acknowledge those valid worries. The organizers of DjangoCon US 2026 are committed to ensuring all our international attendees have the support they need for a safe experience entering and leaving the United States.
@@ -39,13 +39,13 @@
             {% csrf_token %}
 
         <!-- Personal Information Section -->
-            <div class="p-6 bg-green-800 rounded-lg border border-green-700">
-                <h2 class="flex items-center mb-4 text-2xl font-semibold text-yellow-300">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-6">
+                <h2 class="mb-4 flex items-center text-2xl font-semibold text-yellow-300">
                     👤 Personal Information
                 </h2>
                 <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.name.label }}
                             <span class="text-red-400">*</span>
                         </label>
@@ -57,7 +57,7 @@
                         {% endif %}
                     </div>
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.email.label }}
                             <span class="text-red-400">*</span>
                         </label>
@@ -69,7 +69,7 @@
                         {% endif %}
                     </div>
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.phone.label }}
                             <span class="text-red-400">*</span>
                         </label>
@@ -81,7 +81,7 @@
                         {% endif %}
                     </div>
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.preferred_contact.label }}
                         </label>
                         {{ form.preferred_contact }}
@@ -95,13 +95,13 @@
             </div>
 
         <!-- Arrival Flight Information Section -->
-            <div class="p-6 bg-green-800 rounded-lg border border-green-700">
-                <h2 class="flex items-center mb-4 text-2xl font-semibold text-yellow-300">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-6">
+                <h2 class="mb-4 flex items-center text-2xl font-semibold text-yellow-300">
                     ✈️ Arrival Flight Information
                 </h2>
                 <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.arrival_airline.label }}
                             <span class="text-red-400">*</span>
                         </label>
@@ -113,7 +113,7 @@
                         {% endif %}
                     </div>
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.arrival_flight_number.label }}
                             <span class="text-red-400">*</span>
                         </label>
@@ -125,7 +125,7 @@
                         {% endif %}
                     </div>
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.arrival_time.label }}
                             <span class="text-red-400">*</span>
                         </label>
@@ -138,7 +138,7 @@
                         <p class="mt-1 text-xs text-green-300">Time zone: US/Chicago (Central Time)</p>
                     </div>
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.arrival_airport.label }}
                             <span class="text-red-400">*</span>
                         </label>
@@ -153,12 +153,12 @@
             </div>
 
         <!-- Accommodation Information Section (Optional) -->
-            <div class="p-6 bg-green-800 rounded-lg border border-green-700">
-                <h2 class="flex items-center mb-4 text-2xl font-semibold text-yellow-300">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-6">
+                <h2 class="mb-4 flex items-center text-2xl font-semibold text-yellow-300">
                     🏨 Accommodation Information <span class="ml-2 text-sm text-green-300">(Optional)</span>
                 </h2>
                 <div>
-                    <label class="block mb-1 text-sm font-medium text-green-200">
+                    <label class="mb-1 block text-sm font-medium text-green-200">
                         {{ form.accommodation.label }}
                     </label>
                     {{ form.accommodation }}
@@ -171,13 +171,13 @@
             </div>
 
         <!-- Departure Flight Information Section (Optional) -->
-            <div class="p-6 bg-green-800 rounded-lg border border-green-700">
-                <h2 class="flex items-center mb-4 text-2xl font-semibold text-yellow-300">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-6">
+                <h2 class="mb-4 flex items-center text-2xl font-semibold text-yellow-300">
                     🛫 Departure Flight Information <span class="ml-2 text-sm text-green-300">(Optional)</span>
                 </h2>
                 <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.departure_airline.label }}
                         </label>
                         {{ form.departure_airline }}
@@ -188,7 +188,7 @@
                         {% endif %}
                     </div>
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.departure_flight_number.label }}
                         </label>
                         {{ form.departure_flight_number }}
@@ -199,7 +199,7 @@
                         {% endif %}
                     </div>
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.departure_time.label }}
                         </label>
                         {{ form.departure_time }}
@@ -211,7 +211,7 @@
                         <p class="mt-1 text-xs text-green-300">Time zone: US/Chicago (Central Time)</p>
                     </div>
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.departure_airport.label }}
                         </label>
                         {{ form.departure_airport }}
@@ -222,7 +222,7 @@
                         {% endif %}
                     </div>
                     <div class="md:col-span-2">
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.departure_destination.label }}
                         </label>
                         {{ form.departure_destination }}
@@ -236,13 +236,13 @@
             </div>
 
         <!-- Emergency Contact Section -->
-            <div class="p-6 bg-green-800 rounded-lg border border-green-700">
-                <h2 class="flex items-center mb-4 text-2xl font-semibold text-yellow-300">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-6">
+                <h2 class="mb-4 flex items-center text-2xl font-semibold text-yellow-300">
                     🚨 Emergency Contact Information
                 </h2>
                 <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.emergency_contact_name.label }}
                             <span class="text-red-400">*</span>
                         </label>
@@ -254,7 +254,7 @@
                         {% endif %}
                     </div>
                     <div>
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.emergency_contact_phone.label }}
                             <span class="text-red-400">*</span>
                         </label>
@@ -266,7 +266,7 @@
                         {% endif %}
                     </div>
                     <div class="md:col-span-2">
-                        <label class="block mb-1 text-sm font-medium text-green-200">
+                        <label class="mb-1 block text-sm font-medium text-green-200">
                             {{ form.emergency_contact_relationship.label }}
                         </label>
                         {{ form.emergency_contact_relationship }}
@@ -280,12 +280,12 @@
             </div>
 
         <!-- Additional Information Section (Optional) -->
-            <div class="p-6 bg-green-800 rounded-lg border border-green-700">
-                <h2 class="flex items-center mb-4 text-2xl font-semibold text-yellow-300">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-6">
+                <h2 class="mb-4 flex items-center text-2xl font-semibold text-yellow-300">
                     📝 Additional Information <span class="ml-2 text-sm text-green-300">(Optional)</span>
                 </h2>
                 <div>
-                    <label class="block mb-1 text-sm font-medium text-green-200">
+                    <label class="mb-1 block text-sm font-medium text-green-200">
                         {{ form.user_notes.label }}
                     </label>
                     {{ form.user_notes }}
@@ -298,7 +298,7 @@
             </div>
 
         <!-- Data Retention Policy Notice -->
-            <div class="p-4 bg-yellow-900 rounded-lg border border-yellow-600">
+            <div class="rounded-lg border border-yellow-600 bg-yellow-900 p-4">
                 <h3 class="mb-2 text-lg font-semibold text-yellow-200">📋 Data Retention Policy</h3>
                 <p class="text-sm text-yellow-100">
                     Your travel safety information will be securely stored for monitoring purposes during DjangoCon US.
@@ -309,7 +309,7 @@
 
         <!-- Form Errors -->
             {% if form.non_field_errors %}
-                <div class="p-4 bg-red-700 rounded-md border border-red-600">
+                <div class="rounded-md border border-red-600 bg-red-700 p-4">
                     {% for error in form.non_field_errors %}
                         <p class="text-red-100">{{ error }}</p>
                     {% endfor %}
@@ -318,14 +318,14 @@
 
         <!-- Submit Button -->
             <div class="text-center">
-                <button type="submit" class="py-3 px-8 font-semibold text-yellow-900 bg-yellow-600 rounded-lg shadow-lg transition duration-200 hover:bg-yellow-500">
+                <button type="submit" class="rounded-lg bg-yellow-600 px-8 py-3 font-semibold text-yellow-900 shadow-lg transition duration-200 hover:bg-yellow-500">
                     Register Travel Information
                 </button>
             </div>
         </form>
 
     <!-- Back to Home -->
-        <div class="pt-4 text-center border-t border-green-700">
+        <div class="border-t border-green-700 pt-4 text-center">
             <a href="{% url 'home' %}" class="text-yellow-300 underline hover:text-yellow-200">
                 ← Back to Home
             </a>

--- a/travel_safety/templates/travel_safety/success.html
+++ b/travel_safety/templates/travel_safety/success.html
@@ -3,7 +3,7 @@
 {% block title %}{{ page_title }}{% endblock title %}
 
 {% block content %}
-    <div class="flex flex-col gap-6 p-8 max-w-3xl text-green-200 bg-green-900 rounded-xl shadow-inner">
+    <div class="flex max-w-3xl flex-col gap-6 rounded-xl bg-green-900 p-8 text-green-200 shadow-inner">
         <div class="text-center">
             <div class="mb-4 text-6xl">✅</div>
             <h1 class="mb-2 text-4xl font-bold text-yellow-200">Registration Successful!</h1>
@@ -11,7 +11,7 @@
         </div>
 
         {% if registration %}
-            <div class="p-6 bg-green-800 rounded-lg border border-green-700">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-6">
                 <h2 class="mb-4 text-2xl font-semibold text-yellow-300">Registration Summary</h2>
 
                 <div class="space-y-4">
@@ -86,10 +86,10 @@
                     {% endif %}
 
                 <!-- Status -->
-                    <div class="pt-4 border-t border-green-700">
+                    <div class="border-t border-green-700 pt-4">
                         <div class="text-sm">
                             <span class="text-green-300">Status:</span>
-                            <span class="py-1 px-2 text-xs text-blue-100 bg-blue-700 rounded">{{ registration.get_status_display }}</span>
+                            <span class="rounded bg-blue-700 px-2 py-1 text-xs text-blue-100">{{ registration.get_status_display }}</span>
                         </div>
                         <div class="mt-1 text-xs text-green-400">
                             Registered: {{ registration.created_at|date:"M j, Y g:i A T" }}
@@ -100,7 +100,7 @@
         {% endif %}
 
     <!-- Important Information -->
-        <div class="p-6 bg-yellow-900 rounded-lg border border-yellow-600">
+        <div class="rounded-lg border border-yellow-600 bg-yellow-900 p-6">
             <h3 class="mb-4 text-xl font-semibold text-yellow-200">📋 What's Next?</h3>
             <div class="space-y-3 text-yellow-100">
                 <p class="flex items-start">
@@ -123,7 +123,7 @@
         </div>
 
     <!-- Contact Information -->
-        <div class="p-6 bg-blue-900 rounded-lg border border-blue-600">
+        <div class="rounded-lg border border-blue-600 bg-blue-900 p-6">
             <h3 class="mb-4 text-xl font-semibold text-blue-200">📞 Organizer Contact</h3>
             <div class="space-y-2 text-blue-100">
                 <p>If you need to update your information or have questions about travel safety:</p>
@@ -135,7 +135,7 @@
         </div>
 
     <!-- Navigation Links -->
-        <div class="pt-4 space-y-2 text-center border-t border-green-700">
+        <div class="space-y-2 border-t border-green-700 pt-4 text-center">
             <div>
                 <a href="{% url 'travel_safety:register' %}" class="text-yellow-300 underline hover:text-yellow-200">
                     Register Another Person →

--- a/volunteers/templates/volunteers/dashboard.html
+++ b/volunteers/templates/volunteers/dashboard.html
@@ -8,20 +8,20 @@
 
 {% block content %}
     <div class="flex flex-col gap-6 p-8 text-green-100">
-        <div class="flex flex-wrap gap-3 justify-between items-center">
+        <div class="flex flex-wrap items-center justify-between gap-3">
             <h1 class="text-4xl font-bold text-yellow-200">Volunteer Dashboard</h1>
             <div class="flex gap-2">
                 <form method="post" action="{% url 'volunteers:sync_schedule' %}">
                     {% csrf_token %}
                     <input type="hidden" name="dry_run" value="1">
-                    <button type="submit" class="py-2 px-3 text-sm font-medium text-green-100 bg-green-700 rounded-md border border-green-600 hover:bg-green-600">
+                    <button type="submit" class="rounded-md border border-green-600 bg-green-700 px-3 py-2 text-sm font-medium text-green-100 hover:bg-green-600">
                         Preview schedule sync
                     </button>
                 </form>
                 <form method="post" action="{% url 'volunteers:sync_schedule' %}"
                       onsubmit="return confirm('Sync shifts from the conference schedule? Existing slots and signups are kept.');">
                     {% csrf_token %}
-                    <button type="submit" class="py-2 px-3 text-sm font-semibold text-green-900 bg-yellow-300 rounded-md hover:bg-yellow-200">
+                    <button type="submit" class="rounded-md bg-yellow-300 px-3 py-2 text-sm font-semibold text-green-900 hover:bg-yellow-200">
                         Sync schedule now
                     </button>
                 </form>
@@ -36,14 +36,14 @@
             {% endfor %}
         {% endif %}
 
-        <details class="p-4 bg-green-800 rounded-lg border border-green-700 print-hide">
-            <summary class="text-lg font-semibold text-yellow-300 cursor-pointer">📇 Volunteer contact info (shown to all volunteers)</summary>
+        <details class="print-hide rounded-lg border border-green-700 bg-green-800 p-4">
+            <summary class="cursor-pointer text-lg font-semibold text-yellow-300">📇 Volunteer contact info (shown to all volunteers)</summary>
             <p class="mt-2 mb-3 text-sm text-green-200">
                 How volunteers can reach the coordinators — email, Slack, etc. Markdown supported;
                 appears on every volunteer's page.
             </p>
             {% if contact_info %}
-                <div class="p-3 mb-3 max-w-none bg-green-900 rounded border border-green-700 prose prose-invert"
+                <div class="mb-3 max-w-none rounded border border-green-700 bg-green-900 p-3 prose prose-invert"
                      data-markdown>{{ contact_info }}</div>
             {% endif %}
             <form method="post" action="{% url 'volunteers:update_contact' %}" class="flex flex-col gap-2">
@@ -51,19 +51,19 @@
                 <input type="hidden" name="next" value="{{ request.get_full_path }}">
                 <textarea name="contact_info" rows="4"
                           placeholder="e.g. **Volunteer chairs:** Rachell & Monica · **Slack:** #volunteers"
-                          class="p-2 w-full text-sm text-green-900 rounded-md">{{ contact_info }}</textarea>
+                          class="w-full rounded-md p-2 text-sm text-green-900">{{ contact_info }}</textarea>
                 <div>
-                    <button type="submit" class="py-2 px-4 text-sm font-semibold text-green-900 bg-yellow-300 rounded-md hover:bg-yellow-200">
+                    <button type="submit" class="rounded-md bg-yellow-300 px-4 py-2 text-sm font-semibold text-green-900 hover:bg-yellow-200">
                         Save contact info
                     </button>
                 </div>
             </form>
         </details>
 
-        <form method="get" class="flex flex-wrap gap-3 items-end p-4 bg-green-800 rounded-lg border border-green-700">
+        <form method="get" class="flex flex-wrap items-end gap-3 rounded-lg border border-green-700 bg-green-800 p-4">
             <div>
-                <label class="block mb-1 text-xs text-green-300" for="date">Day</label>
-                <select name="date" id="date" class="p-2 text-sm text-green-900 rounded-md">
+                <label class="mb-1 block text-xs text-green-300" for="date">Day</label>
+                <select name="date" id="date" class="rounded-md p-2 text-sm text-green-900">
                     <option value="">All days</option>
                     {% for d in dates %}
                         <option value="{{ d|date:'Y-m-d' }}" {% if d == selected_date %}selected{% endif %}>{{ d|date:"l, M j" }}</option>
@@ -71,8 +71,8 @@
                 </select>
             </div>
             <div>
-                <label class="block mb-1 text-xs text-green-300" for="role">Role</label>
-                <select name="role" id="role" class="p-2 text-sm text-green-900 rounded-md">
+                <label class="mb-1 block text-xs text-green-300" for="role">Role</label>
+                <select name="role" id="role" class="rounded-md p-2 text-sm text-green-900">
                     <option value="">All roles</option>
                     {% for role in roles %}
                         <option value="{{ role }}" {% if role == role_filter %}selected{% endif %}>{{ role }}</option>
@@ -80,23 +80,23 @@
                 </select>
             </div>
             <div>
-                <label class="block mb-1 text-xs text-green-300" for="location">Room / location</label>
-                <select name="location" id="location" class="p-2 text-sm text-green-900 rounded-md">
+                <label class="mb-1 block text-xs text-green-300" for="location">Room / location</label>
+                <select name="location" id="location" class="rounded-md p-2 text-sm text-green-900">
                     <option value="">All locations</option>
                     {% for location in locations %}
                         <option value="{{ location }}" {% if location == location_filter %}selected{% endif %}>{{ location }}</option>
                     {% endfor %}
                 </select>
             </div>
-            <label class="flex gap-2 items-center text-sm text-green-200">
+            <label class="flex items-center gap-2 text-sm text-green-200">
                 <input type="checkbox" name="open_only" value="1" {% if open_only %}checked{% endif %}>
                 Only unstaffed shifts
             </label>
-            <label class="flex gap-2 items-center text-sm text-green-200">
+            <label class="flex items-center gap-2 text-sm text-green-200">
                 <input type="checkbox" name="show_past" value="1" {% if show_past %}checked{% endif %}>
                 Include past shifts
             </label>
-            <button type="submit" class="py-2 px-4 text-sm font-semibold text-green-900 bg-yellow-300 rounded-md hover:bg-yellow-200">
+            <button type="submit" class="rounded-md bg-yellow-300 px-4 py-2 text-sm font-semibold text-green-900 hover:bg-yellow-200">
                 Filter
             </button>
             {% if role_filter or location_filter or date_filter or open_only or show_past %}
@@ -112,25 +112,25 @@
         </p>
 
         <div class="grid grid-cols-1 gap-4 md:grid-cols-4">
-            <div class="p-4 bg-green-800 rounded-lg border border-green-700">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-4">
                 <p class="text-3xl font-bold text-yellow-200">{{ total_filled }}</p>
                 <p class="text-sm text-green-300">Roles filled</p>
             </div>
-            <div class="p-4 bg-green-800 rounded-lg border border-green-700">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-4">
                 <p class="text-3xl font-bold text-yellow-200">{{ total_open }}</p>
                 <p class="text-sm text-green-300">Still needed</p>
             </div>
-            <div class="p-4 bg-green-800 rounded-lg border border-green-700">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-4">
                 <p class="text-3xl font-bold text-yellow-200">{{ total_capacity }}</p>
                 <p class="text-sm text-green-300">Total capacity</p>
             </div>
-            <div class="p-4 bg-green-800 rounded-lg border border-green-700">
+            <div class="rounded-lg border border-green-700 bg-green-800 p-4">
                 <p class="text-3xl font-bold text-yellow-200">{{ coverage|floatformat:0 }}%</p>
                 <p class="text-sm text-green-300">Coverage</p>
             </div>
         </div>
 
-        <form id="merge-form" method="post" action="{% url 'volunteers:merge_shifts' %}" class="flex flex-wrap gap-3 items-center p-4 bg-green-800 rounded-lg border border-green-700 print-hide">
+        <form id="merge-form" method="post" action="{% url 'volunteers:merge_shifts' %}" class="print-hide flex flex-wrap items-center gap-3 rounded-lg border border-green-700 bg-green-800 p-4">
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ request.get_full_path }}">
             <span class="text-sm text-green-200">
@@ -138,7 +138,7 @@
                 tick the <span class="text-yellow-200">Merge</span> box on two or more shifts with the same role,
                 in the same room, that run back-to-back, then
             </span>
-            <button type="submit" class="py-2 px-4 text-sm font-semibold text-green-900 bg-yellow-300 rounded-md hover:bg-yellow-200">
+            <button type="submit" class="rounded-md bg-yellow-300 px-4 py-2 text-sm font-semibold text-green-900 hover:bg-yellow-200">
                 Merge selected into a block
             </button>
         </form>
@@ -147,30 +147,30 @@
             <section class="flex flex-col gap-2">
                 <h2 class="text-2xl font-semibold text-yellow-300">{{ day|date:"l, F j" }}</h2>
                 <div class="overflow-x-auto">
-                    <table class="w-full text-left border-collapse">
+                    <table class="w-full border-collapse text-left">
                         <thead>
-                            <tr class="text-yellow-300 border-b border-green-700">
-                                <th class="p-3 text-xs print-hide">Merge</th>
+                            <tr class="border-b border-green-700 text-yellow-300">
+                                <th class="print-hide p-3 text-xs">Merge</th>
                                 <th class="p-3">Shift</th>
                                 <th class="p-3">Role</th>
                                 <th class="p-3">When</th>
                                 <th class="p-3">Filled</th>
                                 <th class="p-3">Volunteers</th>
-                                <th class="p-3 print-hide"></th>
+                                <th class="print-hide p-3"></th>
                             </tr>
                         </thead>
                         <tbody>
                             {% for shift in day_shifts %}
                                 <tr class="border-b border-green-800 {% if shift.filled_count < shift.capacity %}bg-green-900/40{% endif %}">
-                                    <td class="p-3 text-center print-hide">
-                                        <input type="checkbox" name="shift" value="{{ shift.id }}" form="merge-form" class="w-4 h-4 align-middle accent-yellow-400">
+                                    <td class="print-hide p-3 text-center">
+                                        <input type="checkbox" name="shift" value="{{ shift.id }}" form="merge-form" class="h-4 w-4 align-middle accent-yellow-400">
                                     </td>
                                     <td class="p-3 font-medium text-yellow-100">
                                         {{ shift.title }}
-                                        {% if shift.is_block %}<span class="inline-block py-0.5 px-2 ml-1 text-xs text-green-900 bg-yellow-300 rounded-full">block</span>{% endif %}
+                                        {% if shift.is_block %}<span class="ml-1 inline-block rounded-full bg-yellow-300 px-2 py-0.5 text-xs text-green-900">block</span>{% endif %}
                                         {% if shift.location %}<span class="block text-xs text-green-400">{{ shift.location }}</span>{% endif %}
                                         {% if shift.is_block %}
-                                            <ul class="mt-1 ml-1 text-xs list-disc list-inside text-green-300">
+                                            <ul class="mt-1 ml-1 list-inside list-disc text-xs text-green-300">
                                                 {% for talk in shift.covered_talks %}
                                                     <li>
                                                         <time datetime="{{ talk.starts_at|date:'c' }}" class="whitespace-nowrap">{{ talk.starts_at|date:"g:i A" }}</time>
@@ -194,20 +194,20 @@
                                             <span class="text-green-500">— open —</span>
                                         {% endfor %}
                                     </td>
-                                    <td class="p-3 print-hide">
+                                    <td class="print-hide p-3">
                                         <div class="flex gap-1">
                                             {% if shift.is_block %}
                                                 <form method="post" action="{% url 'volunteers:split_shift' shift.id %}">
                                                     {% csrf_token %}
                                                     <input type="hidden" name="next" value="{{ request.get_full_path }}">
-                                                    <button type="submit" class="py-1 px-2 text-xs text-green-100 bg-green-700 rounded border border-green-600 hover:bg-green-600">Split</button>
+                                                    <button type="submit" class="rounded border border-green-600 bg-green-700 px-2 py-1 text-xs text-green-100 hover:bg-green-600">Split</button>
                                                 </form>
                                             {% endif %}
                                             <form method="post" action="{% url 'volunteers:delete_shift' shift.id %}"
                                                   onsubmit="return confirm('Delete “{{ shift.title|escapejs }}”? Any sign-ups on it are removed.');">
                                                 {% csrf_token %}
                                                 <input type="hidden" name="next" value="{{ request.get_full_path }}">
-                                                <button type="submit" class="py-1 px-2 text-xs text-red-100 bg-red-700 rounded border border-red-600 hover:bg-red-600">Delete</button>
+                                                <button type="submit" class="rounded border border-red-600 bg-red-700 px-2 py-1 text-xs text-red-100 hover:bg-red-600">Delete</button>
                                             </form>
                                         </div>
                                     </td>


### PR DESCRIPTION
- Bumps the ruff pre-commit hook from v0.12.11 to the latest release (v0.16.1).
- Runs `just lint` across the repo and commits the result: one small ruff-format change (`titowebhooks/tests/test_views.py`) plus a large batch of DjHTML/rustywind template normalizations that had drifted (36 templates, whitespace/attribute-order only).
- `just lint` now passes clean on a second run, and the full test suite (123 tests) passes.