### PR TITLE
Show role duties on the shift list and my shifts

### DIFF
--- a/volunteers/templates/volunteers/my_shifts.html
+++ b/volunteers/templates/volunteers/my_shifts.html
@@ -37,6 +37,12 @@
                             <time datetime="{{ signup.shift.starts_at|date:'c' }}">{{ signup.shift.starts_at|date:"l, F j," }} <span class="whitespace-nowrap">{{ signup.shift.starts_at|date:"g:i A" }}</span></time>–<time datetime="{{ signup.shift.ends_at|date:'c' }}" class="whitespace-nowrap">{{ signup.shift.ends_at|date:"g:i A" }}</time>
                             {% if signup.shift.location %} · {{ signup.shift.location }}{% endif %}
                         </p>
+                        {% if signup.shift.role.description %}
+                            <details class="mt-1 text-xs">
+                                <summary class="cursor-pointer text-yellow-300 select-none">What this role involves</summary>
+                                <p class="mt-1 text-sm whitespace-pre-line text-green-200">{{ signup.shift.role.description }}</p>
+                            </details>
+                        {% endif %}
                         {% if signup.shift.role.documentation_url %}
                             <p class="mt-1 text-xs">
                                 <a href="{{ signup.shift.role.documentation_url }}" target="_blank" rel="noopener" class="text-yellow-300 underline">

--- a/volunteers/templates/volunteers/shift_list.html
+++ b/volunteers/templates/volunteers/shift_list.html
@@ -121,6 +121,14 @@
                                                     {% if talk.talk_url %}<a href="{{ talk.talk_url }}" target="_blank" rel="noopener" class="text-yellow-300 underline">🔗 {{ talk.title }}</a>{% else %}{{ talk.title }}{% endif %}
                                                 </p>
                                             {% endfor %}
+                                            {% if shift.role.description %}
+                                                {# Collapsed by default: a role's duties repeat across every one of its
+                                                   shifts, so rendering them inline would swamp the list. #}
+                                                <details class="mt-1 text-xs">
+                                                    <summary class="cursor-pointer text-yellow-300 select-none">What this role involves</summary>
+                                                    <p class="mt-1 text-sm whitespace-pre-line text-green-200">{{ shift.role.description }}</p>
+                                                </details>
+                                            {% endif %}
                                             {% if shift.role.documentation_url %}
                                                 <p class="mt-1 text-xs">
                                                     <a href="{{ shift.role.documentation_url }}" target="_blank" rel="noopener" class="text-yellow-300 underline">

--- a/volunteers/tests/test_signups.py
+++ b/volunteers/tests/test_signups.py
@@ -137,6 +137,51 @@ def test_shift_list_shows_role_documentation(client, role):
     assert "https://docs.example.com/reg-desk/" in resp.content.decode()
 
 
+def test_shift_list_shows_role_description(client, role):
+    role.description = "Monitor public chat. Enforce the Code of Conduct."
+    role.save()
+    make_shift(role, title="Reg Desk")
+
+    body = client.get(reverse("volunteers:shifts")).content.decode()
+
+    assert "Monitor public chat. Enforce the Code of Conduct." in body
+
+
+def test_shift_list_role_description_is_collapsed(client, role):
+    """Duties repeat on every shift for a role, so they must not render inline
+    and swamp the list. Collapsed in a <details> keeps the overview compact."""
+    role.description = "Monitor public chat."
+    role.save()
+    make_shift(role, title="Reg Desk")
+
+    body = client.get(reverse("volunteers:shifts")).content.decode()
+
+    assert "<details" in body
+    assert "What this role involves" in body
+
+
+def test_shift_list_omits_description_block_when_role_has_none(client, role):
+    role.description = ""
+    role.save()
+    make_shift(role, title="Reg Desk")
+
+    body = client.get(reverse("volunteers:shifts")).content.decode()
+
+    assert "What this role involves" not in body
+
+
+def test_my_shifts_shows_role_description(auth_client, user, role):
+    role.description = "Monitor public chat."
+    role.save()
+    shift = make_shift(role, title="Reg Desk")
+    VolunteerSignup.objects.create(shift=shift, user=user)
+
+    body = auth_client.get(reverse("volunteers:my_shifts")).content.decode()
+
+    assert "Monitor public chat." in body
+    assert "<details" in body
+
+
 def test_shift_list_shows_talk_url(client, role):
     from volunteers.models import Talk
 


### PR DESCRIPTION
Follow-up from #93 — Rachell supplied a duty list for the Online Moderator role, which surfaced that role descriptions were never displayed at all.

## The problem

Every `Role` has a `description` field explaining what the job involves, and all five are populated:

| Role | description |
|---|---|
| Online Moderator | 317 chars |
| Registration Desk | 91 |
| Session Chair | 80 |
| Session Manager | 89 |
| Swag Bag Stuffing | 56 |

None of it reaches volunteers. Grepping the templates, only `shift.description` and `role.documentation_url` are rendered — `role.description` appears nowhere. So this is not a moderator-specific gap; it is five roles' worth of guidance that is stored and invisible.

## Why not `Shift.description`

The obvious alternative — copying duties onto each shift — is wrong here. That field already holds **imported talk abstracts**:

```
Session Chair 11/11 shifts have a description:
  "Presenter: Karen Tracey\n\nDjango 6.0 has multiple very exciting new features..."
```

and the template guards it with `{% if shift.description and not shift.covers_talks %}`, so duties would be suppressed on exactly the shifts that cover talks. It would also duplicate the same paragraph across 24 Online Moderator rows.

## The change

Render `role.description` in a `<details>`, collapsed by default, next to the existing documentation link — on both the shift list and my shifts.

Collapsed matters: a role's duties repeat on every one of its shifts, so rendering inline would swamp the overview. `<details>` is native, needs no JavaScript, and leaves the list exactly as compact as before until someone opens it.

## Tests

Four added:

- description appears on the shift list
- it is inside a `<details>` (pins the compact-overview property, so a later change cannot quietly inline it)
- no empty block when a role has no description
- description appears on my shifts

Verified the three positive tests **fail** without the template change.

## Rebased 2026-08-05

Rebased onto current `main` (past #122, which added the day jump-nav to `shift_list.html`). No conflicts — that change touched the page header and the day `<section>` tag, while this one touches the per-shift role block. Full suite re-run after the rebase: **271 passed** (the earlier "127 pass" figure predated tests added since).

## Note

`just lint` runs `rustywind` over every template and reformats 40 of them, reordering Tailwind classes *away* from what is currently committed — so the installed hook disagrees with the repo's present state. Still true on `main` today. I reverted all of it, including inside the two files I touched, so this diff is additions only. Worth fixing separately.
