### PR TITLE
Drop 2021 from sales curves and flag partly-synced years

### DIFF
--- a/templates/titowebhooks/sales_dashboard.html
+++ b/templates/titowebhooks/sales_dashboard.html
@@ -44,8 +44,22 @@
             <h2 class="mb-3 text-xl font-semibold">Sales pace by year</h2>
             <p class="mb-3 text-sm text-gray-400">
                 Cumulative sales at each point before the conference, so you can compare seasons at the same distance out.
-                Left edge is a year out, right edge is day one.
+                Left edge is a year out, right edge is day one. Revenue is what attendees actually paid, after discount
+                codes and comps, for every year shown.
             </p>
+
+            {% if curves.partial %}
+                <div class="p-4 mb-4 bg-yellow-900 bg-opacity-40 rounded-lg border border-yellow-700">
+                    <p class="text-sm text-yellow-200">
+                        <strong>Not an even comparison yet.</strong>
+                        {% for s in curves.partial %}
+                            {{ s.year }} has {{ s.synced_tickets }} of {{ s.snapshot_sold }} tickets synced ({{ s.coverage_percent }}%){% if not forloop.last %};{% endif %}
+                        {% endfor %}.
+                        Those curves sit lower than the season really was. Run <strong>Sync ticket history</strong> to fill
+                        them in before reading anything into the gaps.
+                    </p>
+                </div>
+            {% endif %}
 
             <div class="grid grid-cols-1 gap-4 mb-3 lg:grid-cols-2">
                 {% for chart in curves.charts %}
@@ -106,6 +120,12 @@
                         <span class="font-mono text-xs text-gray-500">
                             {{ s.final_tickets }} &middot; ${{ s.final_revenue|floatformat:"0g" }}
                         </span>
+                        {% if s.partial %}
+                            <span class="font-mono text-xs text-yellow-500"
+                                  title="Only {{ s.synced_tickets }} of {{ s.snapshot_sold }} tickets synced, so this curve reads low">
+                                {{ s.coverage_percent }}% synced
+                            </span>
+                        {% endif %}
                     </span>
                 {% endfor %}
             </div>

--- a/titowebhooks/sales_curve.py
+++ b/titowebhooks/sales_curve.py
@@ -11,6 +11,14 @@ from titowebhooks.models import TitoHistoricalEvent, TitoTicket
 # Days before the conference start date, furthest out first.
 CHECKPOINTS = [365, 330, 300, 270, 240, 210, 180, 150, 120, 90, 60, 30, 21, 14, 7, 3, 0]
 
+# 2021 was the COVID year - the sales pattern says nothing useful about a normal
+# season, so it would only distort a year-over-year read.
+EXCLUDED_YEARS = {2021}
+
+# A year whose synced tickets fall this far short of its snapshot total is only
+# partially covered, so its curve sits below where that season really was.
+COVERAGE_THRESHOLD = 0.95
+
 # Distinct enough to tell apart on a dark background, oldest year to newest.
 SERIES_COLORS = [
     "#f87171",
@@ -71,6 +79,16 @@ def _series_for_event(event: TitoHistoricalEvent) -> dict | None:
 
     ticket_counts, revenue = _cumulative_at_checkpoints(days_out_values)
 
+    # How much of the season we actually hold. The snapshot totals come straight from
+    # Ti.to's release counts, so a shortfall means tickets we never synced - and a
+    # curve that sits low for reasons that have nothing to do with how sales went.
+    snapshot_sold = event.total_sold or 0
+    synced = len(days_out_values)
+    coverage = (synced / snapshot_sold) if snapshot_sold else None
+    sources = sorted(
+        TitoTicket.objects.filter(year=event.year, voided=False).values_list("source", flat=True).distinct()
+    )
+
     return {
         "year": event.year,
         "title": event.title,
@@ -80,6 +98,12 @@ def _series_for_event(event: TitoHistoricalEvent) -> dict | None:
         "revenue": revenue,
         "final_tickets": ticket_counts[-1],
         "final_revenue": revenue[-1],
+        "synced_tickets": synced,
+        "snapshot_sold": snapshot_sold,
+        "coverage": coverage,
+        "coverage_percent": round(coverage * 100) if coverage is not None else None,
+        "partial": coverage is not None and coverage < COVERAGE_THRESHOLD,
+        "sources": sources,
     }
 
 
@@ -116,8 +140,7 @@ def _chart(series: list[dict], key: str, width: float = 720, height: float = 260
     ]
 
     gridlines = [
-        {"y": height - (height * fraction), "value": axis_max * fraction}
-        for fraction in (0, 0.25, 0.5, 0.75, 1.0)
+        {"y": height - (height * fraction), "value": axis_max * fraction} for fraction in (0, 0.25, 0.5, 0.75, 1.0)
     ]
 
     x_step = width / (len(CHECKPOINTS) - 1) if len(CHECKPOINTS) > 1 else width
@@ -140,19 +163,25 @@ def _chart(series: list[dict], key: str, width: float = 720, height: float = 260
 
 def sales_curves() -> dict:
     """Days-out ticket and revenue curves for every year we can chart."""
-    events = TitoHistoricalEvent.objects.all().order_by("year")
+    events = list(TitoHistoricalEvent.objects.all().order_by("year"))
+    chartable = [e for e in events if e.year not in EXCLUDED_YEARS]
 
-    series = [s for s in (_series_for_event(e) for e in events) if s]
+    series = [s for s in (_series_for_event(e) for e in chartable) if s]
     for index, s in enumerate(series):
         s["color"] = SERIES_COLORS[index % len(SERIES_COLORS)]
 
     # Skipped years are worth naming - an empty chart otherwise looks like a bug.
     charted_years = {s["year"] for s in series}
-    missing = [
-        {"year": e.year, "reason": "no start date" if not e.start_date else "no ticket detail synced"}
-        for e in events
-        if e.year not in charted_years
-    ]
+
+    def _reason(event):
+        if event.year in EXCLUDED_YEARS:
+            return "excluded, COVID year"
+        if not event.start_date:
+            return "no start date"
+        return "no ticket detail synced"
+
+    missing = [{"year": e.year, "reason": _reason(e)} for e in events if e.year not in charted_years]
+    partial = [s for s in series if s["partial"]]
 
     return {
         "has_data": bool(series),
@@ -162,6 +191,10 @@ def sales_curves() -> dict:
         "columns": [{"year": s["year"], "color": s["color"]} for s in series],
         "checkpoint_labels": CHECKPOINT_LABELS,
         "checkpoints": CHECKPOINTS,
+        # Any year charted off incomplete data makes the comparison misleading, so
+        # say so on the page rather than letting a low curve read as slow sales.
+        "partial": sorted(partial, key=lambda s: -s["year"]),
+        "excluded_years": sorted(EXCLUDED_YEARS),
         "charts": (
             [
                 {"title": "Tickets sold", "is_money": False, **_chart(series, "tickets")},
@@ -175,9 +208,7 @@ def sales_curves() -> dict:
             {
                 "label": label,
                 "days_out": CHECKPOINTS[i],
-                "cells": [
-                    {"year": s["year"], "tickets": s["tickets"][i], "revenue": s["revenue"][i]} for s in series
-                ],
+                "cells": [{"year": s["year"], "tickets": s["tickets"][i], "revenue": s["revenue"][i]} for s in series],
             }
             for i, label in enumerate(CHECKPOINT_LABELS)
         ],

--- a/titowebhooks/tests/test_sales_curve.py
+++ b/titowebhooks/tests/test_sales_curve.py
@@ -4,7 +4,7 @@ import pytest
 from django.contrib.auth import get_user_model
 
 from titowebhooks.models import TitoHistoricalEvent, TitoTicket
-from titowebhooks.sales_curve import CHECKPOINTS, sales_curves
+from titowebhooks.sales_curve import CHECKPOINTS, EXCLUDED_YEARS, sales_curves
 
 User = get_user_model()
 
@@ -192,6 +192,100 @@ def test_table_rows_line_up_with_the_checkpoints():
     assert len(curves["table_rows"]) == len(CHECKPOINTS)
     assert curves["table_rows"][-1]["label"] == "Event"
     assert curves["table_rows"][-1]["cells"] == [{"year": 2026, "tickets": 1, "revenue": 100.0}]
+
+
+@pytest.mark.django_db
+def test_covid_year_is_excluded_but_named():
+    assert 2021 in EXCLUDED_YEARS
+
+    make_event(year=2026)
+    make_ticket("new", days_out=30)
+    make_event(year=2021, start_date=datetime.date(2021, 9, 22), is_current=False)
+    make_ticket("covid", year=2021, created_at=datetime.datetime(2021, 8, 23, tzinfo=datetime.timezone.utc))
+
+    curves = sales_curves()
+
+    assert [s["year"] for s in curves["series"]] == [2026]
+    assert {"year": 2021, "reason": "excluded, COVID year"} in curves["missing"]
+    assert curves["excluded_years"] == [2021]
+
+
+@pytest.mark.django_db
+def test_excluded_year_does_not_consume_a_series_color():
+    make_event(year=2021, start_date=datetime.date(2021, 9, 22), is_current=False)
+    make_ticket("covid", year=2021, created_at=datetime.datetime(2021, 8, 23, tzinfo=datetime.timezone.utc))
+    make_event(year=2026)
+    make_ticket("new", days_out=30)
+
+    assert sales_curves()["series"][0]["color"] == "#f87171"  # the first color, not the second
+
+
+@pytest.mark.django_db
+def test_coverage_compares_synced_tickets_against_the_snapshot_total():
+    make_event(releases=[{"tickets_count": 10, "price": "100.0"}])
+    for i in range(10):
+        make_ticket(f"t{i}", days_out=30)
+
+    series = sales_curves()["series"][0]
+
+    assert series["synced_tickets"] == 10
+    assert series["snapshot_sold"] == 10
+    assert series["coverage_percent"] == 100
+    assert series["partial"] is False
+    assert sales_curves()["partial"] == []
+
+
+@pytest.mark.django_db
+def test_partially_synced_year_is_flagged():
+    make_event(releases=[{"tickets_count": 100, "price": "100.0"}])
+    for i in range(40):
+        make_ticket(f"t{i}", days_out=30)
+
+    curves = sales_curves()
+    series = curves["series"][0]
+
+    assert series["coverage_percent"] == 40
+    assert series["partial"] is True
+    assert [s["year"] for s in curves["partial"]] == [2026]
+
+
+@pytest.mark.django_db
+def test_year_without_a_snapshot_total_is_not_flagged_as_partial():
+    make_event()  # no releases, so there's nothing to compare against
+    make_ticket("a", days_out=30)
+
+    series = sales_curves()["series"][0]
+
+    assert series["coverage"] is None
+    assert series["partial"] is False
+
+
+@pytest.mark.django_db
+def test_revenue_is_discount_aware_for_every_year_not_just_the_current_one():
+    make_event(year=2026)
+    make_event(year=2024, start_date=datetime.date(2024, 9, 22), is_current=False)
+    make_ticket("now-comp", year=2026, days_out=30, price=0.0)
+    make_ticket("now-paid", year=2026, days_out=30, price=500.0)
+    old = datetime.datetime(2024, 8, 23, tzinfo=datetime.timezone.utc)
+    make_ticket("then-comp", year=2024, price=0.0, created_at=old)
+    make_ticket("then-paid", year=2024, price=400.0, created_at=old)
+
+    by_year = {s["year"]: s for s in sales_curves()["series"]}
+
+    assert by_year[2026]["final_revenue"] == 500.0
+    assert by_year[2024]["final_revenue"] == 400.0
+
+
+@pytest.mark.django_db
+def test_dashboard_warns_when_a_year_is_only_partly_synced(client):
+    user = User.objects.create_superuser(username="root2", email="r2@example.com", password="pw12345!")
+    client.force_login(user)
+    make_event(releases=[{"tickets_count": 100, "price": "100.0"}])
+    make_ticket("a", days_out=30)
+
+    response = client.get(URL)
+
+    assert "Not an even comparison yet" in response.content.decode()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Follow-up to #114, aimed at making the year-over-year read trustworthy.

## 2021 is out

The COVID year's sales pattern says nothing useful about a normal season, so it's excluded from the charts. It still shows up in the "Not charted" line as `2021 (excluded, COVID year)` rather than silently vanishing, and it no longer consumes a series color.

Controlled by `EXCLUDED_YEARS` in `sales_curve.py` if another year ever needs the same treatment.

## Discounts across years

Worth stating plainly since it came up: the curves have always been discount-aware for **every** year, not just the current one. `_series_for_event` sums `TitoTicket.price` — what the attendee actually paid — so comps land as $0 and code-discounted tickets land at their real amount, uniformly across seasons. The note above the charts now says this out loud.

(The face-value figure is the `total_revenue` on the sales table further down the page, which is still list price × count. Different number, different purpose.)

## The real comparability risk

Uniform pricing math doesn't make the comparison fair if the *coverage* is uneven. A year whose tickets were never fully synced draws a curve sitting well below where that season actually was — which reads as a slow year rather than as missing data.

Each series now carries `synced_tickets` vs `snapshot_sold` (the latter from Ti.to's own release counts), and any year under 95% coverage gets:

- a `NN% synced` marker next to its legend entry
- a banner above the charts naming each affected year and its numbers, pointing at **Sync ticket history**

A year with no snapshot total to compare against isn't flagged, since there's nothing to measure the shortfall against.

## Tests

7 new cases: 2021 excluded and named, color assignment unaffected, coverage at 100%, partial-year flagging, the no-snapshot case, discount-aware revenue across two different years, and the banner rendering. 152 pass overall, lint clean.