### PR TITLE
Show discounts and net total per year on the sales dashboard

### DIFF
--- a/templates/titowebhooks/sales_dashboard.html
+++ b/templates/titowebhooks/sales_dashboard.html
@@ -193,7 +193,7 @@
                         </h2>
 
                         <div class="p-4 mb-3 bg-green-800 bg-opacity-50 rounded-lg">
-                            <div class="grid grid-cols-4 gap-4 text-center">
+                            <div class="grid grid-cols-3 gap-4 text-center lg:grid-cols-6">
                                 <div>
                                     <p class="text-2xl font-bold text-green-400">{{ event.total_sold }}</p>
                                     <p class="text-sm text-gray-300">Sold</p>
@@ -216,7 +216,30 @@
                                     <p class="text-2xl font-bold text-green-300">${{ event.total_revenue|floatformat:"0g" }}</p>
                                     <p class="text-sm text-gray-300">Raised</p>
                                 </div>
+                                <div>
+                                    {% if event.discount_total is not None %}
+                                        <p class="text-2xl font-bold text-yellow-300">&minus;${{ event.discount_total|floatformat:"0g" }}</p>
+                                    {% else %}
+                                        <p class="text-2xl font-bold text-gray-600">—</p>
+                                    {% endif %}
+                                    <p class="text-sm text-gray-300">Discounts</p>
+                                </div>
+                                <div>
+                                    {% if event.net_total is not None %}
+                                        <p class="text-2xl font-bold text-white">${{ event.net_total|floatformat:"0g" }}</p>
+                                    {% else %}
+                                        <p class="text-2xl font-bold text-gray-600">—</p>
+                                    {% endif %}
+                                    <p class="text-sm text-gray-300">
+                                        Total{% if event.totals_partial %}<span class="text-yellow-500" title="Only {{ event.discounted_ticket_count }} of {{ event.total_sold }} tickets synced, so discounts are understated">*</span>{% endif %}
+                                    </p>
+                                </div>
                             </div>
+                            {% if event.discount_total is None %}
+                                <p class="mt-3 text-xs text-gray-500">
+                                    Discounts need per-ticket detail &mdash; run <strong>Sync ticket history</strong> to fill them in.
+                                </p>
+                            {% endif %}
                             {% if event.last_synced %}
                                 <p class="mt-3 text-xs text-gray-500">Last synced {{ event.last_synced|date:"N j, Y H:i" }} UTC</p>
                             {% endif %}
@@ -364,6 +387,10 @@
                                     <span class="text-green-400">{{ event.total_sold }}</span>
                                     sold
                                     {% if event.total_revenue %}&middot; <span class="text-green-300">${{ event.total_revenue|floatformat:"0g" }}</span> raised{% endif %}
+                                    {% if event.discount_total is not None %}
+                                        &middot; <span class="text-yellow-300">&minus;${{ event.discount_total|floatformat:"0g" }}</span> discounts
+                                        &middot; <span class="font-semibold text-white">${{ event.net_total|floatformat:"0g" }}</span> total{% if event.totals_partial %}<span class="text-yellow-500" title="Only {{ event.discounted_ticket_count }} of {{ event.total_sold }} tickets synced, so discounts are understated">*</span>{% endif %}
+                                    {% endif %}
                                     {% if event.goal %}&middot; <span class="text-yellow-300">{{ event.percent_of_goal }}%</span> of goal{% endif %}
                                     &middot; {{ event.releases|length }} release{{ event.releases|length|pluralize }}
                                 </span>

--- a/titowebhooks/tests/test_event_totals.py
+++ b/titowebhooks/tests/test_event_totals.py
@@ -1,0 +1,134 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from titowebhooks.models import TitoHistoricalEvent, TitoTicket
+from titowebhooks.views import _annotate_event_totals
+
+User = get_user_model()
+
+URL = "/tito/sales/"
+
+
+def make_event(year=2026, sold=10, price="100.0", is_current=True):
+    return TitoHistoricalEvent.objects.create(
+        slug=f"djangocon-us-{year}",
+        year=year,
+        title=f"DjangoCon US {year}",
+        is_current=is_current,
+        releases=[{"title": "Individual", "tickets_count": sold, "price": price, "quantity": 100}],
+    )
+
+
+def make_ticket(slug, year=2026, release_price=100.0, price=100.0, voided=False):
+    return TitoTicket.objects.create(
+        ticket_slug=slug,
+        event_slug=f"djangocon-us-{year}",
+        year=year,
+        release_price=release_price,
+        price=price,
+        voided=voided,
+    )
+
+
+def annotated(events=None):
+    events = events if events is not None else list(TitoHistoricalEvent.objects.all())
+    _annotate_event_totals(events)
+    return {e.year: e for e in events}
+
+
+@pytest.mark.django_db
+def test_discounts_subtract_from_raised_to_give_the_total():
+    make_event(sold=3, price="100.0")
+    make_ticket("full", price=100.0)
+    make_ticket("half", price=50.0)
+    make_ticket("comp", price=0.0)
+
+    event = annotated()[2026]
+
+    assert event.total_revenue == 300.0  # face value, 3 x $100
+    assert event.discount_total == 150.0  # $50 off one, $100 off another
+    assert event.net_total == 150.0
+
+
+@pytest.mark.django_db
+def test_no_discounts_leaves_the_total_equal_to_raised():
+    make_event(sold=2, price="100.0")
+    make_ticket("a")
+    make_ticket("b")
+
+    event = annotated()[2026]
+
+    assert event.discount_total == 0.0
+    assert event.net_total == event.total_revenue
+
+
+@pytest.mark.django_db
+def test_year_without_ticket_detail_reports_none_not_zero():
+    make_event(sold=5)
+
+    event = annotated()[2026]
+
+    assert event.has_ticket_detail is False
+    assert event.discount_total is None
+    assert event.net_total is None
+    assert event.totals_partial is False
+
+
+@pytest.mark.django_db
+def test_voided_tickets_do_not_count_toward_discounts():
+    make_event(sold=1, price="100.0")
+    make_ticket("kept", price=0.0)
+    make_ticket("gone", price=0.0, voided=True)
+
+    assert annotated()[2026].discount_total == 100.0
+
+
+@pytest.mark.django_db
+def test_partial_sync_is_flagged():
+    make_event(sold=10, price="100.0")
+    make_ticket("only-one", price=0.0)
+
+    event = annotated()[2026]
+
+    assert event.totals_partial is True
+    assert event.discounted_ticket_count == 1
+
+
+@pytest.mark.django_db
+def test_fully_synced_year_is_not_flagged_as_partial():
+    make_event(sold=2, price="100.0")
+    make_ticket("a", price=0.0)
+    make_ticket("b", price=0.0)
+
+    assert annotated()[2026].totals_partial is False
+
+
+@pytest.mark.django_db
+def test_each_year_gets_its_own_totals():
+    make_event(year=2026, sold=1, price="100.0")
+    make_event(year=2024, sold=1, price="200.0", is_current=False)
+    make_ticket("new", year=2026, release_price=100.0, price=25.0)
+    make_ticket("old", year=2024, release_price=200.0, price=200.0)
+
+    events = annotated()
+
+    assert events[2026].discount_total == 75.0
+    assert events[2026].net_total == 25.0
+    assert events[2024].discount_total == 0.0
+    assert events[2024].net_total == 200.0
+
+
+@pytest.mark.django_db
+def test_dashboard_shows_discounts_and_total_for_current_and_past_years(client):
+    user = User.objects.create_superuser(username="root", email="r@example.com", password="pw12345!")
+    client.force_login(user)
+    make_event(year=2026, sold=2, price="100.0")
+    make_event(year=2024, sold=2, price="100.0", is_current=False)
+    make_ticket("now", year=2026, price=0.0)
+    make_ticket("then", year=2024, price=0.0)
+
+    body = client.get(URL).content.decode()
+
+    assert "Discounts" in body  # the current-event tile
+    assert "discounts" in body  # the per-year summary line
+    assert "Total" in body

--- a/titowebhooks/views.py
+++ b/titowebhooks/views.py
@@ -18,7 +18,7 @@ from django_q.tasks import async_task
 from rich import print
 
 from emailoctopus.models import Campaign
-from titowebhooks.models import TitoHistoricalEvent, TitoWebhookEvent
+from titowebhooks.models import TitoHistoricalEvent, TitoTicket, TitoWebhookEvent
 from titowebhooks.sales_curve import sales_curves
 from volunteers.models import VolunteerSignup
 
@@ -490,10 +490,40 @@ def _discount_breakdown(event_slug: str) -> dict:
     }
 
 
+def _annotate_event_totals(events: list[TitoHistoricalEvent]) -> None:
+    """Hang discount and net-revenue totals off each event, in place.
+
+    "Raised" on this page is face value - list price times count, straight from
+    Ti.to's release counts. Subtracting what the discount codes gave away turns it
+    into money we actually took in. Years with no per-ticket detail get None rather
+    than a zero, since "no discounts synced" and "no discounts given" look identical
+    at a glance and only one of them is good news.
+    """
+    totals: dict[int, dict] = {}
+    rows = TitoTicket.objects.filter(voided=False).values_list("year", "release_price", "price")
+
+    for year, release_price, price in rows:
+        entry = totals.setdefault(year, {"discount": 0.0, "paid": 0.0, "count": 0})
+        entry["discount"] += (release_price or 0.0) - (price or 0.0)
+        entry["paid"] += price or 0.0
+        entry["count"] += 1
+
+    for event in events:
+        entry = totals.get(event.year)
+        event.has_ticket_detail = entry is not None
+        event.discount_total = entry["discount"] if entry else None
+        event.net_total = (event.total_revenue - entry["discount"]) if entry else None
+        event.discounted_ticket_count = entry["count"] if entry else 0
+        # Discounts computed off a partial sync understate the giveaway, which quietly
+        # overstates the net. Flag it so the number isn't read as final.
+        event.totals_partial = bool(entry) and entry["count"] < (event.total_sold or 0)
+
+
 @superuser_required
 def tito_sales_dashboard_view(request: HttpRequest) -> HttpResponse:
-    events = TitoHistoricalEvent.objects.all()  # ordered by -year via Meta
-    never_synced = not events.exists()
+    events = list(TitoHistoricalEvent.objects.all())  # ordered by -year via Meta
+    never_synced = not events
+    _annotate_event_totals(events)
 
     context = {
         "events": events,


### PR DESCRIPTION
Follow-up to #114 and #115.

"Raised" on this page is face value — list price × count, straight from Ti.to's release counts — so it says nothing about what actually landed once speaker comps and discount codes come off. This adds that.

## Current event

The stat row goes from four tiles to six: **Sold · Goal · % of Goal · Raised · Discounts · Total**, where Total is Raised − Discounts. Grid is `grid-cols-3` on small screens, `lg:grid-cols-6` above.

## Each past year

The collapsed summary line gains the same two figures, so a season reads end to end without expanding it:

```
DjangoCon US 2024    420 sold · $231,000 raised · −$50,600 discounts · $180,400 total · 84% of goal · 1 release
```

## Why dashes instead of zeros

Totals come from `TitoTicket`, so a year with no per-ticket detail synced shows `—`, not `$0`. "No discounts synced" and "no discounts given" look identical at a glance and only one of them is good news. The current-event card also spells out how to fix it (run **Sync ticket history**).

A year synced short of its snapshot total gets a `*` next to Total, with a tooltip naming the counts — a partial sync understates the giveaway and therefore overstates the net, and that's exactly the kind of number worth not trusting silently.

## Tests

8 new cases in `test_event_totals.py`: discount subtraction, the no-discount case, `None` vs zero for unsynced years, voided tickets excluded, partial-sync flagging, the fully-synced case, per-year isolation, and dashboard rendering for both current and past sections. 160 pass overall, lint clean.