### PR TITLE
Make discounts the gap between Raised and Revenue

### DIFF
--- a/templates/titowebhooks/sales_dashboard.html
+++ b/templates/titowebhooks/sales_dashboard.html
@@ -218,33 +218,31 @@
                                 </div>
                                 <div>
                                     {% if event.discount_total is not None %}
-                                        <p class="text-2xl font-bold text-yellow-300">&minus;${{ event.discount_total|floatformat:"0g" }}</p>
+                                        <p class="text-2xl font-bold text-yellow-300">${{ event.discount_total|floatformat:"0g" }}</p>
                                     {% else %}
                                         <p class="text-2xl font-bold text-gray-600">—</p>
                                     {% endif %}
-                                    <p class="text-sm text-gray-300">
-                                        Discounts{% if event.discounts_incomplete %}<span class="text-yellow-500" title="{{ event.priced_ticket_count }} of {{ event.discounted_ticket_count }} tickets belong to a release with a list price; the rest can't be compared">*</span>{% endif %}
-                                    </p>
+                                    <p class="text-sm text-gray-300">Discounts</p>
                                 </div>
                                 <div>
-                                    {% if event.collected_total is not None %}
-                                        <p class="text-2xl font-bold text-white">${{ event.collected_total|floatformat:"0g" }}</p>
+                                    {% if event.revenue_total is not None %}
+                                        <p class="text-2xl font-bold text-white">${{ event.revenue_total|floatformat:"0g" }}</p>
                                     {% else %}
                                         <p class="text-2xl font-bold text-gray-600">—</p>
                                     {% endif %}
                                     <p class="text-sm text-gray-300">
-                                        Collected{% if event.totals_partial %}<span class="text-yellow-500" title="Only {{ event.discounted_ticket_count }} of {{ event.total_sold }} tickets synced">*</span>{% endif %}
+                                        Revenue{% if event.totals_partial %}<span class="text-yellow-500" title="Only {{ event.ticket_detail_count }} of {{ event.total_sold }} tickets synced">*</span>{% endif %}
                                     </p>
                                 </div>
                             </div>
-                            {% if event.collected_total is None %}
+                            {% if event.revenue_total is None %}
                                 <p class="mt-3 text-xs text-gray-500">
-                                    Discounts and collected need per-ticket detail &mdash; run <strong>Sync ticket history</strong> to fill them in.
+                                    Discounts and revenue need per-ticket detail &mdash; run <strong>Sync ticket history</strong> to fill them in.
                                 </p>
-                            {% else %}
+                            {% elif event.face_value_understated %}
                                 <p class="mt-3 text-xs text-gray-500">
-                                    Collected is what attendees actually paid. Raised is face value from release list prices, which
-                                    several releases don't set &mdash; so the two won't reconcile by subtraction.
+                                    Revenue is above Raised because some releases sold without a list price set in Ti.to, so face
+                                    value undercounts them.
                                 </p>
                             {% endif %}
                             {% if event.last_synced %}
@@ -394,9 +392,9 @@
                                     <span class="text-green-400">{{ event.total_sold }}</span>
                                     sold
                                     {% if event.total_revenue %}&middot; <span class="text-green-300">${{ event.total_revenue|floatformat:"0g" }}</span> raised{% endif %}
-                                    {% if event.collected_total is not None %}
-                                        &middot; <span class="text-yellow-300">&minus;${{ event.discount_total|floatformat:"0g" }}</span> discounts
-                                        &middot; <span class="font-semibold text-white">${{ event.collected_total|floatformat:"0g" }}</span> collected{% if event.totals_partial %}<span class="text-yellow-500" title="Only {{ event.discounted_ticket_count }} of {{ event.total_sold }} tickets synced">*</span>{% endif %}
+                                    {% if event.revenue_total is not None %}
+                                        &middot; <span class="text-yellow-300">${{ event.discount_total|floatformat:"0g" }}</span> discounts
+                                        &middot; <span class="font-semibold text-white">${{ event.revenue_total|floatformat:"0g" }}</span> revenue{% if event.totals_partial %}<span class="text-yellow-500" title="Only {{ event.ticket_detail_count }} of {{ event.total_sold }} tickets synced">*</span>{% endif %}
                                     {% endif %}
                                     {% if event.goal %}&middot; <span class="text-yellow-300">{{ event.percent_of_goal }}%</span> of goal{% endif %}
                                     &middot; {{ event.releases|length }} release{{ event.releases|length|pluralize }}

--- a/titowebhooks/tests/test_event_totals.py
+++ b/titowebhooks/tests/test_event_totals.py
@@ -7,12 +7,11 @@ from titowebhooks.views import _annotate_event_totals
 User = get_user_model()
 
 URL = "/tito/sales/"
-RELEASE_ID = 1598009
 
 
 def make_event(year=2026, sold=10, price="100.0", is_current=True, releases=None):
     if releases is None:
-        releases = [{"id": RELEASE_ID, "title": "Individual", "tickets_count": sold, "price": price, "quantity": 100}]
+        releases = [{"id": 1, "title": "Individual", "tickets_count": sold, "price": price, "quantity": 100}]
     return TitoHistoricalEvent.objects.create(
         slug=f"djangocon-us-{year}",
         year=year,
@@ -22,14 +21,11 @@ def make_event(year=2026, sold=10, price="100.0", is_current=True, releases=None
     )
 
 
-def make_ticket(slug, year=2026, price=100.0, release_id=RELEASE_ID, release_price=0.0, voided=False):
-    """A ticket as the /tickets API gives it to us: paid price, no release_price."""
+def make_ticket(slug, year=2026, price=100.0, voided=False):
     return TitoTicket.objects.create(
         ticket_slug=slug,
         event_slug=f"djangocon-us-{year}",
         year=year,
-        release_id=release_id,
-        release_price=release_price,
         price=price,
         voided=voided,
     )
@@ -42,78 +38,56 @@ def annotated(events=None):
 
 
 @pytest.mark.django_db
-def test_discount_is_face_value_minus_paid_using_the_release_list_price():
-    make_event(sold=3, price="100.0")
+def test_the_three_figures_reconcile():
+    make_event(sold=3, price="100.0")  # raised = $300
     make_ticket("full", price=100.0)
     make_ticket("half", price=50.0)
     make_ticket("comp", price=0.0)
 
     event = annotated()[2026]
 
-    assert event.discount_total == 150.0  # $50 off one, $100 off another
-    assert event.collected_total == 150.0  # what actually came in
+    assert event.total_revenue == 300.0
+    assert event.revenue_total == 150.0
+    assert event.discount_total == 150.0
+    assert event.total_revenue - event.discount_total == event.revenue_total
 
 
 @pytest.mark.django_db
-def test_discount_is_never_negative():
-    """The whole reason this broke: the API omits release_price, so a naive
-    face-minus-paid produced negative discounts that rendered as -$-1,234."""
-    make_event(sold=1, price="100.0")
-    make_ticket("api-shaped", price=749.0)  # paid more than list
+def test_discount_is_the_gap_between_raised_and_revenue():
+    # The shape of the real 2026 numbers: $104,637 raised, $73,655 taken in.
+    make_event(sold=1, price="104637.0")
+    make_ticket("a", price=73655.0)
+
+    event = annotated()[2026]
+
+    assert event.discount_total == 30982.0
+
+
+@pytest.mark.django_db
+def test_no_discount_when_everyone_paid_list():
+    make_event(sold=2, price="100.0")
+    make_ticket("a", price=100.0)
+    make_ticket("b", price=100.0)
 
     event = annotated()[2026]
 
     assert event.discount_total == 0.0
-    assert event.discount_total >= 0
-    assert event.collected_total == 749.0
+    assert event.revenue_total == event.total_revenue
 
 
 @pytest.mark.django_db
-def test_missing_release_price_on_the_ticket_falls_back_to_the_release():
-    make_event(sold=1, price="600.0")
-    make_ticket("no-price-on-ticket", price=100.0, release_price=0.0)
-
-    assert annotated()[2026].discount_total == 500.0
-
-
-@pytest.mark.django_db
-def test_release_price_on_the_ticket_wins_when_present():
-    make_event(sold=1, price="600.0")
-    make_ticket("webhook-shaped", price=100.0, release_price=400.0)
-
-    assert annotated()[2026].discount_total == 300.0
-
-
-@pytest.mark.django_db
-def test_collected_is_the_sum_of_what_was_paid_not_raised_minus_discounts():
-    # Sponsor releases carry no list price, so face value can't be derived for them.
-    make_event(
-        sold=2,
-        releases=[
-            {"id": 1, "title": "Individual", "tickets_count": 1, "price": "500.0"},
-            {"id": 2, "title": "Sponsor", "tickets_count": 1, "price": None},
-        ],
-    )
-    make_ticket("individual", price=400.0, release_id=1)
-    make_ticket("sponsor", price=750.0, release_id=2)
+def test_discount_is_never_negative():
+    """Unpriced releases sell for real money against no list price, so revenue can
+    exceed face value. That is not a negative discount."""
+    make_event(sold=1, releases=[{"id": 1, "title": "Sponsor", "tickets_count": 1, "price": None}])
+    make_ticket("sponsor", price=750.0)
 
     event = annotated()[2026]
 
-    assert event.collected_total == 1150.0  # real money, both tickets
-    assert event.discount_total == 100.0  # only the priced release can be compared
-    assert event.discounts_incomplete is True
-    assert event.priced_ticket_count == 1
-
-
-@pytest.mark.django_db
-def test_unpriced_releases_do_not_count_as_free_giveaways():
-    make_event(sold=1, releases=[{"id": 1, "title": "Comp", "tickets_count": 1, "price": None}])
-    make_ticket("comp", price=0.0, release_id=1)
-
-    event = annotated()[2026]
-
-    assert event.discount_total == 0.0  # unknown face value, not a $0 face value
-    assert event.discounts_incomplete is True
+    assert event.total_revenue == 0.0  # no list price, so nothing counts toward Raised
+    assert event.revenue_total == 750.0
+    assert event.discount_total == 0.0
+    assert event.face_value_understated is True
 
 
 @pytest.mark.django_db
@@ -124,20 +98,20 @@ def test_year_without_ticket_detail_reports_none_not_zero():
 
     assert event.has_ticket_detail is False
     assert event.discount_total is None
-    assert event.collected_total is None
+    assert event.revenue_total is None
     assert event.totals_partial is False
 
 
 @pytest.mark.django_db
-def test_voided_tickets_are_excluded_from_both_figures():
+def test_voided_tickets_are_excluded_from_revenue():
     make_event(sold=1, price="100.0")
     make_ticket("kept", price=0.0)
     make_ticket("gone", price=500.0, voided=True)
 
     event = annotated()[2026]
 
+    assert event.revenue_total == 0.0
     assert event.discount_total == 100.0
-    assert event.collected_total == 0.0
 
 
 @pytest.mark.django_db
@@ -148,7 +122,7 @@ def test_partial_sync_is_flagged():
     event = annotated()[2026]
 
     assert event.totals_partial is True
-    assert event.discounted_ticket_count == 1
+    assert event.ticket_detail_count == 1
 
 
 @pytest.mark.django_db
@@ -170,13 +144,13 @@ def test_each_year_gets_its_own_totals():
     events = annotated()
 
     assert events[2026].discount_total == 75.0
-    assert events[2026].collected_total == 25.0
+    assert events[2026].revenue_total == 25.0
     assert events[2024].discount_total == 0.0
-    assert events[2024].collected_total == 200.0
+    assert events[2024].revenue_total == 200.0
 
 
 @pytest.mark.django_db
-def test_dashboard_shows_discounts_and_collected_without_a_double_negative(client):
+def test_dashboard_shows_revenue_and_a_positive_discount(client):
     user = User.objects.create_superuser(username="root", email="r@example.com", password="pw12345!")
     client.force_login(user)
     make_event(year=2026, sold=2, price="100.0")
@@ -186,7 +160,9 @@ def test_dashboard_shows_discounts_and_collected_without_a_double_negative(clien
 
     body = client.get(URL).content.decode()
 
-    assert "Discounts" in body
-    assert "Collected" in body
-    assert "&minus;$-" not in body
+    assert "Revenue" in body
+    assert "revenue" in body
+    assert "Collected" not in body
+    # No hardcoded minus in front of the discount figure, and nothing like -$-1,234.
+    assert "&minus;$" not in body
     assert "-$-" not in body

--- a/titowebhooks/views.py
+++ b/titowebhooks/views.py
@@ -490,81 +490,44 @@ def _discount_breakdown(event_slug: str) -> dict:
     }
 
 
-def _release_price_map(event: TitoHistoricalEvent) -> dict[int, float]:
-    """Release id -> list price, for the releases that have one.
-
-    Plenty of releases (comps, sponsor allocations) carry no price at all, so this
-    map is deliberately sparse - a missing id means "we don't know the face value",
-    which is different from "it was free".
-    """
-    prices = {}
-    for release in event.releases or []:
-        release_id = release.get("id")
-        price = release.get("price")
-        if release_id is None or price is None:
-            continue
-        try:
-            prices[int(release_id)] = float(price)
-        except (TypeError, ValueError):
-            continue
-    return prices
-
-
 def _annotate_event_totals(events: list[TitoHistoricalEvent]) -> None:
-    """Hang collected-revenue and discount totals off each event, in place.
+    """Hang revenue and discount totals off each event, in place.
 
-    Total is the sum of what attendees actually paid, straight from the ticket rows.
-    It is deliberately not "Raised minus Discounts": Raised is face value derived from
-    release list prices, and a good number of releases have no price set, so that
-    subtraction drifts from reality.
+    Revenue is what attendees actually paid, summed from the ticket rows. Discounts
+    are the gap between that and Raised, so the three figures reconcile on sight:
+    Raised minus Discounts is Revenue.
 
-    Discounts compare each ticket against its own release's list price, and only for
-    the tickets whose release has one. Years with no per-ticket detail get None rather
-    than a zero, since "nothing synced" and "nothing given away" look identical at a
-    glance and only one of them is good news.
+    Years with no per-ticket detail get None rather than a zero, since "nothing
+    synced" and "nothing given away" look identical at a glance and only one of them
+    is good news.
     """
-    per_year: dict[int, list] = {}
-    rows = TitoTicket.objects.filter(voided=False).values_list("year", "release_id", "release_price", "price")
-    for year, release_id, release_price, price in rows:
-        per_year.setdefault(year, []).append((release_id, release_price or 0.0, price or 0.0))
+    revenue_by_year: dict[int, float] = {}
+    counts: dict[int, int] = {}
+
+    for year, price in TitoTicket.objects.filter(voided=False).values_list("year", "price"):
+        revenue_by_year[year] = revenue_by_year.get(year, 0.0) + (price or 0.0)
+        counts[year] = counts.get(year, 0) + 1
 
     for event in events:
-        tickets = per_year.get(event.year)
-        event.has_ticket_detail = bool(tickets)
+        revenue = revenue_by_year.get(event.year)
+        event.has_ticket_detail = revenue is not None
 
-        if not tickets:
-            event.collected_total = None
+        if revenue is None:
+            event.revenue_total = None
             event.discount_total = None
-            event.discounted_ticket_count = 0
-            event.priced_ticket_count = 0
+            event.ticket_detail_count = 0
             event.totals_partial = False
-            event.discounts_incomplete = False
+            event.face_value_understated = False
             continue
 
-        prices = _release_price_map(event)
-        collected = 0.0
-        discount = 0.0
-        priced = 0
-
-        for release_id, ticket_release_price, price in tickets:
-            collected += price
-            # The ticket's own release_price when the webhook gave us one, otherwise
-            # the release's list price. The /tickets API sends neither for some rows.
-            face = ticket_release_price or prices.get(release_id)
-            if face:
-                priced += 1
-                # Cash value given away. A ticket sold at or above list isn't a
-                # negative discount, so it contributes nothing rather than netting off.
-                discount += max(face - price, 0.0)
-
-        event.collected_total = collected
-        event.discount_total = discount
-        event.discounted_ticket_count = len(tickets)
-        event.priced_ticket_count = priced
-        # A partial sync understates both numbers; unpriced releases understate only
-        # the discount. Either way the figures aren't final, so say so.
-        event.totals_partial = len(tickets) < (event.total_sold or 0)
-        event.discounts_incomplete = priced < len(tickets)
+        event.revenue_total = revenue
+        event.ticket_detail_count = counts[event.year]
+        # Raised only counts releases that have a list price set. Comps and sponsor
+        # allocations sell for real money against no list price, so a year can take in
+        # more than its face value - which is not a discount, negative or otherwise.
+        event.discount_total = max(event.total_revenue - revenue, 0.0)
+        event.face_value_understated = revenue > event.total_revenue
+        event.totals_partial = counts[event.year] < (event.total_sold or 0)
 
 
 @superuser_required


### PR DESCRIPTION
Fixes the `−$0` discounts and the numbers that didn't add up.

## What was wrong

Discounts were computed per ticket against release list prices. Most releases have **no list price set** in Ti.to, so almost nothing could be compared and the total came out `$0` — while the template still prefixed it with a hardcoded `&minus;`, rendering `−$0` next to a Raised and a Collected that visibly disagreed.

Overengineered, and wrong in a way that was worse than the naive answer.

## What it does now

`Discounts = Raised − Revenue`. The three figures reconcile on sight, which is the whole point of putting them side by side. The hardcoded minus is gone — the value reads positive because it's the result of a subtraction, not a negative number.

`Collected` is renamed **Revenue**.

Against the live data:

| Year | Sold | Raised | Discounts | Revenue |
|------|-----:|-------:|----------:|--------:|
| 2026 | 280 | $104,637 | $30,982 | $73,655 |
| 2025 | 557 | $160,590 | $41,616 | $118,974 |
| 2024 | 727 | $191,386 | $47,865 | $143,521 |
| 2023 | 830 | $181,229 | $45,555 | $135,674 |
| 2022 | 745 | $187,686 | $37,696 | $149,990 |
| 2019 | 694 | $213,485 | $0 | $214,103 |

## The one edge case

A year can take in *more* than its face value, because releases that sell with no list price set contribute nothing to Raised but real money to Revenue. 2019 does this. Rather than show a negative discount, it floors at zero and the card explains why.

## Cleanup

`_release_price_map` and the per-ticket face-value comparison are deleted — about 40 lines of machinery replaced by one subtraction. The `release_id` field stays; it's already migrated and costs nothing.

Tests rewritten around the new semantics, including an explicit check that the three figures reconcile, that the discount never goes negative, and that no hardcoded minus reaches the page. 169 pass, lint clean.