### PR TITLE
:sparkles: Add day jump links to volunteer shifts, tidy homepage

### DIFF
--- a/config/nav.py
+++ b/config/nav.py
@@ -32,14 +32,6 @@ NAV_ITEMS = [
         ],
     ),
     NavGroup(
-        title="Administration",
-        permissions=["is_authenticated"],
-        items=[
-            NavItem(title="Django Admin", url="admin:index", permissions=["is_staff"]),
-            NavItem(title="Sign Out", url="account_logout"),
-        ],
-    ),
-    NavGroup(
         title="Volunteers",
         permissions=["is_authenticated"],
         items=[
@@ -47,6 +39,14 @@ NAV_ITEMS = [
             NavItem(title="My Shifts", url="volunteers:my_shifts"),
             NavItem(title="Volunteer Dashboard", url="volunteers:dashboard", permissions=["is_staff"]),
             NavItem(title="Volunteer Interest Report", url="volunteer_interest", permissions=["is_superuser"]),
+        ],
+    ),
+    NavGroup(
+        title="Administration",
+        permissions=["is_authenticated"],
+        items=[
+            NavItem(title="Django Admin", url="admin:index", permissions=["is_staff"]),
+            NavItem(title="Sign Out", url="account_logout"),
         ],
     ),
     NavItem(title="Sign In", url="account_login", extra_context={"anonymous_only": True}),

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -43,7 +43,5 @@
                 Sign In or Register
             </a>
         {% endif %}
-
-        <div class="text-xl">version {{ app_version }}</div>
     </div>
 {% endblock content %}

--- a/volunteers/templates/volunteers/shift_list.html
+++ b/volunteers/templates/volunteers/shift_list.html
@@ -26,6 +26,17 @@
             {% endif %}
         </div>
 
+        {% if days %}
+            <nav aria-label="Jump to a day" class="flex flex-wrap gap-2 justify-center print-hide">
+                {% for day, shifts in days %}
+                    <a href="#day-{{ day|date:'Y-m-d' }}"
+                       class="py-1 px-3 text-sm font-medium text-yellow-200 bg-green-800 rounded-full border border-green-700 hover:bg-green-700 hover:text-yellow-100">
+                        {{ day|date:"D, M j" }}
+                    </a>
+                {% endfor %}
+            </nav>
+        {% endif %}
+
         {% if my_upcoming %}
             <section class="p-4 bg-green-800 rounded-lg border border-yellow-300 print-hide">
                 <h2 class="mb-2 text-lg font-semibold text-yellow-300">Your upcoming shifts</h2>
@@ -75,7 +86,7 @@
         </form>
 
         {% for day, shifts in days %}
-            <section class="p-6 bg-green-800 rounded-lg border border-green-700">
+            <section id="day-{{ day|date:'Y-m-d' }}" class="p-6 bg-green-800 rounded-lg border border-green-700 scroll-mt-4">
                 <h2 class="mb-4 text-2xl font-semibold text-yellow-300">{{ day|date:"l, F j" }}</h2>
                 {% regroup shifts by starts_at as time_groups %}
                 <div class="flex flex-col gap-6">


### PR DESCRIPTION
## Summary
- **/volunteers/**: added a row of day pills under the header that jump to each day's section (`#day-YYYY-MM-DD`), so folks can skip to the day they want to help on. Hidden in print; respects active filters since it renders from the same filtered `days` list.
- **Homepage**: moved the Administration group (Django Admin + Sign Out) to the bottom of the nav.
- **Homepage**: dropped the duplicate version line — the base footer already shows it on every page.

## Test plan
- `just test volunteers/tests` — 53 passed
- `just test config/tests` — 24 passed