### PR TITLE
:lipstick: Brand every email as DjangoCon US

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -185,6 +185,12 @@ AUTHENTICATION_BACKENDS = [
 
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
 ACCOUNT_EMAIL_VERIFICATION = "none"
+# Left unset, allauth prefixes every subject with "[{Site.name}] " — which in
+# production is the bare hostname, so sign-in codes arrived as
+# "[automation.defna.org] Sign-In Code". Our own emails carry the brand in the
+# subject itself (see tickets/tasks.py SUBJECTS), so drop the prefix entirely
+# and name DjangoCon US in the overridden *_subject.txt templates instead.
+ACCOUNT_EMAIL_SUBJECT_PREFIX = ""
 # Passwordless sign-in: allauth emails a short-lived code (and our email template
 # adds a clickable link that prefills it). See #91/#99.
 ACCOUNT_LOGIN_BY_CODE_ENABLED = True

--- a/config/tests/test_email_branding.py
+++ b/config/tests/test_email_branding.py
@@ -1,0 +1,132 @@
+"""Every email we send must be branded DjangoCon US, in the subject and the body.
+
+Before this, allauth's account emails inherited their branding from
+``Site.name``, which in production is the bare hostname — so the main sign-in
+email arrived as "[automation.defna.org] Sign-In Code" and opened with "Hello
+from automation.defna.org!". These tests pin the fix by driving the real flows
+and asserting the site name never reaches a subject or body again.
+"""
+
+import datetime
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from django.core import mail
+from django.core.cache import cache
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django.utils import timezone
+
+from tickets.tasks import SUBJECTS
+from volunteers.models import Role, Shift, VolunteerSignup
+from volunteers.tasks import notify_shift_uncovered, send_shift_reminders
+
+User = get_user_model()
+
+BRAND = "DjangoCon US"
+
+
+@pytest.fixture(autouse=True)
+def _clear_rate_limits():
+    """Allauth throttles the login-code and password-reset views per IP."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+
+
+@pytest.fixture
+def hostile_site(db):
+    """Give the Site the bare hostname production actually uses.
+
+    If any template still leans on ``Site.name``, these tests fail loudly
+    instead of passing on a dev database that happens to say "example.com".
+    """
+    site = Site.objects.get_current()
+    site.name = "automation.defna.org"
+    site.domain = "automation.defna.org"
+    site.save()
+    Site.objects.clear_cache()
+    return site
+
+
+def assert_branded(message, *, allow_domain_in_body=False):
+    """Subject and body must name DjangoCon US and must not leak the site name."""
+    assert BRAND in message.subject, f"subject not branded: {message.subject!r}"
+    assert "automation.defna.org" not in message.subject, f"site name leaked into subject: {message.subject!r}"
+    assert BRAND in message.body, f"body not branded: {message.body!r}"
+    if not allow_domain_in_body:
+        assert "automation.defna.org" not in message.body
+    assert "Hello from" not in message.body, "allauth's unbranded greeting is still being used"
+
+
+@pytest.mark.django_db
+class TestAccountEmailBranding:
+    def test_login_code_email_is_branded(self, client, user, hostile_site):
+        client.post(reverse("account_request_login_code"), {"email": user.email})
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        # The sign-in link legitimately contains the domain; the branding must not.
+        assert_branded(message, allow_domain_in_body=True)
+        assert message.subject == "Your DjangoCon US sign-in code"
+
+    def test_password_reset_email_is_branded(self, client, user, hostile_site):
+        client.post(reverse("account_reset_password"), {"email": user.email})
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        assert_branded(message, allow_domain_in_body=True)
+        assert message.subject == "Reset your DjangoCon US password"
+
+    def test_no_subject_carries_a_bracketed_hostname_prefix(self, client, user, hostile_site):
+        client.post(reverse("account_request_login_code"), {"email": user.email})
+        assert not mail.outbox[0].subject.startswith("["), "allauth's [site] subject prefix is back"
+
+
+@pytest.mark.django_db
+class TestVolunteerEmailBranding:
+    @pytest.fixture
+    def shift(self, db):
+        role = Role.objects.create(name="Registration Desk")
+        start = timezone.now() + datetime.timedelta(hours=2)
+        return Shift.objects.create(
+            role=role, title="Test Shift", starts_at=start, ends_at=start + datetime.timedelta(hours=2)
+        )
+
+    def test_shift_reminder_is_branded(self, user, shift, hostile_site):
+        VolunteerSignup.objects.create(shift=shift, user=user)
+        assert send_shift_reminders() == 1
+        assert_branded(mail.outbox[0])
+
+    def test_uncovered_alert_is_branded(self, user, shift, hostile_site, settings):
+        settings.VOLUNTEER_COORDINATOR_EMAILS = ["coordinator@example.com"]
+        signup = VolunteerSignup.objects.create(shift=shift, user=user, cancelled=True)
+        VolunteerSignup.objects.filter(pk=signup.pk).update(
+            created_at=timezone.now() - datetime.timedelta(minutes=120)
+        )
+        assert notify_shift_uncovered(signup.pk) is True
+        assert_branded(mail.outbox[0])
+
+
+@pytest.mark.django_db
+class TestTicketEmailBranding:
+    def test_every_ticket_subject_is_branded(self):
+        for kind, subject in SUBJECTS.items():
+            assert BRAND in subject, f"{kind} subject not branded: {subject!r}"
+
+    @pytest.mark.parametrize("template", ["tickets/email/ticket_link.txt", "tickets/email/ticket_link.html"])
+    def test_ticket_bodies_are_branded(self, template):
+        body = render_to_string(
+            template,
+            {
+                "name": "Ada",
+                "ticket_link": "https://example.com/t/abc",
+                "year": 2026,
+                "support_email": "hello@mail.defna.org",
+            },
+        )
+        assert BRAND in body

--- a/templates/account/email/base_message.txt
+++ b/templates/account/email/base_message.txt
@@ -1,0 +1,10 @@
+{% load i18n %}{% autoescape off %}{% block greeting %}Hi there,{% endblock greeting %}
+
+{% block content %}{% endblock content %}
+
+— The DjangoCon US Team
+
+--
+{% block footer %}Questions? Reply to this email and we'll help you out.
+DjangoCon US is organized by DEFNA, the Django Events Foundation North America.{% endblock footer %}
+{% endautoescape %}

--- a/templates/account/email/login_code_subject.txt
+++ b/templates/account/email/login_code_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktranslate %}Your DjangoCon US sign-in code{% endblocktranslate %}
+{% endautoescape %}

--- a/templates/account/email/password_reset_key_subject.txt
+++ b/templates/account/email/password_reset_key_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktranslate %}Reset your DjangoCon US password{% endblocktranslate %}
+{% endautoescape %}

--- a/volunteers/tasks.py
+++ b/volunteers/tasks.py
@@ -86,7 +86,7 @@ def notify_shift_uncovered(signup_id):
     )
     try:
         send_mail(
-            subject=f"Volunteer needed: “{shift.title}” just lost its only volunteer",
+            subject=f"DjangoCon US volunteer needed: “{shift.title}” just lost its only volunteer",
             message=body,
             from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
             recipient_list=recipients,

--- a/volunteers/templates/volunteers/email/shift_reminder.txt
+++ b/volunteers/templates/volunteers/email/shift_reminder.txt
@@ -10,3 +10,7 @@ Thanks so much for helping out! If you can no longer make it, please cancel your
 signup so someone else can fill the spot.
 
 — The DjangoCon US Team
+
+--
+Questions? Reply to this email and we'll help you out.
+DjangoCon US is organized by DEFNA, the Django Events Foundation North America.

--- a/volunteers/templates/volunteers/email/shift_uncovered.txt
+++ b/volunteers/templates/volunteers/email/shift_uncovered.txt
@@ -10,4 +10,4 @@ This upcoming volunteer shift just lost its only volunteer and is now uncovered:
 
 You may want to find a replacement or cover it from the dashboard.
 
-— The DjangoCon US Automation
+— The DjangoCon US Team


### PR DESCRIPTION
Follow-up to the email audit. All five emails we send now say DjangoCon US consistently, in both subject and body.

## The live bug

Allauth's account emails took their branding from `Site.name`, which in production is the bare hostname. Confirmed against prod (`Site.objects.values_list` → `automation.defna.org`), the **sign-in code email — the primary login path for the whole app** — has been going out as:

```
Subject: [automation.defna.org] Sign-In Code
Body:    Hello from automation.defna.org!
         ...
         Thank you for using automation.defna.org!
```

Same for password reset.

## The fix

I did **not** rename the `Site` row. Its name differs per environment and reads `example.com` on a fresh dev database, so a data migration would paper over the problem rather than remove the dependency. Instead the templates no longer reference `Site.name` at all:

- **`templates/account/email/base_message.txt`** (new override) — our greeting, sign-off, and DEFNA footer in place of allauth's site-name greeting/footer. Every allauth message template extends this, so all of them inherit the branding.
- **`login_code_subject.txt` / `password_reset_key_subject.txt`** (new overrides) — "Your DjangoCon US sign-in code", "Reset your DjangoCon US password".
- **`ACCOUNT_EMAIL_SUBJECT_PREFIX = """"** — drops the `[hostname] ` prefix. Our own subjects already carry the brand inline, so this matches existing house style rather than introducing a bracketed prefix everywhere.

Two inconsistencies in our own email, found in the same pass:

- The uncovered-shift alert subject never said DjangoCon US.
- It signed off as "The DjangoCon US **Automation**" where every other email says "The DjangoCon US **Team**".
- The shift reminder gained the same DEFNA footer the ticket email already had.

## Verification

Rendered all five end to end and read the actual output — not just diffed templates. Subjects now:

| Email | Subject |
|---|---|
| Sign-in code | Your DjangoCon US sign-in code |
| Password reset | Reset your DjangoCon US password |
| Ticket link | Your DjangoCon US online conference link |
| Shift reminder | Reminder: your DjangoCon US volunteer shift "…" |
| Uncovered alert | DjangoCon US volunteer needed: "…" just lost its only volunteer |

New `config/tests/test_email_branding.py` drives the real flows (posting to the login-code and password-reset views, running the volunteer tasks) with `Site.name` deliberately set to the **production hostname**, so the tests fail loudly rather than passing on a dev database that happens to say `example.com`.

**Verified 4 of the 8 tests fail without this change** — one per real defect. The other 4 guard emails that were already correct.

- `just test` — 279 passed
- `just lint` — clean