### PR TITLE
:sparkles: Add a staff email preview page

### DIFF
--- a/config/emails.py
+++ b/config/emails.py
@@ -1,0 +1,207 @@
+"""A registry of every email the app sends, so staff can preview them.
+
+Adding an email? Add an ``EmailPreview`` here too. ``test_email_previews.py``
+walks the repo for email templates and fails if one isn't registered, so this
+list can't quietly fall behind the code.
+
+Sample context is deliberately fabricated — previews never touch the database,
+so no attendee's name or ticket link can leak into a preview page.
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Callable
+
+from django.template.loader import render_to_string
+from django.utils import timezone
+
+
+@dataclass(frozen=True)
+class RenderedEmail:
+    subject: str
+    text_body: str
+    html_body: str | None
+
+
+@dataclass(frozen=True)
+class EmailPreview:
+    """One email we send.
+
+    Either ``allauth_prefix`` (allauth builds the whole message, including the
+    subject, from its own templates) or ``subject`` + ``text_template`` (we
+    build it ourselves) must be given.
+    """
+
+    slug: str
+    label: str
+    description: str
+    trigger: str
+    context: Callable[[], dict]
+    subject: str = ""
+    text_template: str | None = None
+    html_template: str | None = None
+    allauth_prefix: str | None = None
+    recipient: str = "The attendee or volunteer"
+    templates: tuple[str, ...] = field(default_factory=tuple)
+
+    def render(self, request=None) -> RenderedEmail:
+        if self.allauth_prefix:
+            return self._render_allauth(request)
+
+        context = self.context()
+        html = render_to_string(self.html_template, context) if self.html_template else None
+        return RenderedEmail(
+            subject=self.subject,
+            text_body=render_to_string(self.text_template, context),
+            html_body=html,
+        )
+
+    def _render_allauth(self, request) -> RenderedEmail:
+        """Build the message through allauth itself.
+
+        Going through the adapter rather than rendering templates directly means
+        the preview shows exactly what ships — including the subject prefix
+        behaviour that ACCOUNT_EMAIL_SUBJECT_PREFIX controls.
+        """
+        from allauth.account.adapter import get_adapter
+
+        context = self.context()
+        if request is not None:
+            context.setdefault("request", request)
+
+        message = get_adapter().render_mail(self.allauth_prefix, "preview@example.com", context)
+        html_body = None
+        for content, mimetype in getattr(message, "alternatives", []):
+            if mimetype == "text/html":
+                html_body = content
+        return RenderedEmail(subject=message.subject, text_body=message.body, html_body=html_body)
+
+    @property
+    def all_templates(self) -> tuple[str, ...]:
+        """Every template this email owns, for the registry-coverage test."""
+        explicit = [t for t in (self.text_template, self.html_template) if t]
+        return tuple(explicit) + self.templates
+
+
+def _sample_shift():
+    # localtime, not now(): the templates render in local time, so building this in
+    # UTC makes a 9am sample shift display as the middle of the night.
+    start = timezone.localtime(timezone.now()).replace(hour=9, minute=0, second=0, microsecond=0)
+    start += datetime.timedelta(days=1)
+    return SimpleNamespace(
+        title="Registration Desk — morning",
+        role=SimpleNamespace(name="Registration Desk"),
+        location="Convention Center, Lobby B",
+        starts_at=start,
+        ends_at=start + datetime.timedelta(hours=2),
+    )
+
+
+def _sample_user():
+    return SimpleNamespace(
+        email="volunteer@example.com",
+        get_full_name=lambda: "Ada Lovelace",
+    )
+
+
+def _ticket_context(**overrides):
+    from django.conf import settings
+
+    context = {
+        "attendee": None,
+        "name": "Ada Lovelace",
+        "ticket_link": "https://example.com/online/ticket/sample-preview-link",
+        "kind": "initial",
+        "is_reissue": False,
+        "is_resend": False,
+        "year": timezone.now().year,
+        "support_email": settings.DEFAULT_FROM_EMAIL,
+    }
+    context.update(overrides)
+    return context
+
+
+EMAIL_PREVIEWS: list[EmailPreview] = [
+    EmailPreview(
+        slug="login-code",
+        label="Sign-in code",
+        description="The passwordless sign-in code. This is how nearly everyone logs in.",
+        trigger="Requesting a sign-in code at /accounts/login/code/",
+        recipient="Anyone signing in",
+        allauth_prefix="account/email/login_code",
+        context=lambda: {"code": "123456"},
+        templates=("account/email/login_code_message.txt",),
+    ),
+    EmailPreview(
+        slug="password-reset",
+        label="Password reset",
+        description="Sent when someone asks to reset a password. Uses allauth's default body on our branded base.",
+        trigger="Submitting the form at /accounts/password/reset/",
+        recipient="Anyone resetting a password",
+        allauth_prefix="account/email/password_reset_key",
+        context=lambda: {
+            "password_reset_url": "https://automation.defna.org/accounts/password/reset/key/sample-preview-key/",
+            "username": "ada",
+        },
+    ),
+    EmailPreview(
+        slug="ticket-link-initial",
+        label="Ticket link — initial",
+        description="The online conference link, sent once a ticket is bought.",
+        trigger="tickets.services queues it; sent by tickets.tasks.send_ticket_link_email",
+        recipient="Online attendee",
+        subject="Your DjangoCon US online conference link",
+        text_template="tickets/email/ticket_link.txt",
+        html_template="tickets/email/ticket_link.html",
+        context=_ticket_context,
+    ),
+    EmailPreview(
+        slug="ticket-link-resend",
+        label="Ticket link — resent",
+        description="The same link again, when an attendee asks for it a second time.",
+        trigger="Resending from the ticket admin",
+        recipient="Online attendee",
+        subject="Your DjangoCon US online conference link (resent)",
+        text_template="tickets/email/ticket_link.txt",
+        html_template="tickets/email/ticket_link.html",
+        context=lambda: _ticket_context(kind="resend", is_resend=True),
+    ),
+    EmailPreview(
+        slug="ticket-link-reissue",
+        label="Ticket link — reissued",
+        description="A brand new link that invalidates the previous one.",
+        trigger="Reissuing from the ticket admin",
+        recipient="Online attendee",
+        subject="Your new DjangoCon US online conference link",
+        text_template="tickets/email/ticket_link.txt",
+        html_template="tickets/email/ticket_link.html",
+        context=lambda: _ticket_context(kind="reissue", is_reissue=True),
+    ),
+    EmailPreview(
+        slug="shift-reminder",
+        label="Volunteer shift reminder",
+        description="Reminder sent to a volunteer 24 hours before their shift.",
+        trigger="Hourly schedule → volunteers.tasks.send_shift_reminders",
+        recipient="Volunteer with an upcoming shift",
+        subject="Reminder: your DjangoCon US volunteer shift “Registration Desk — morning”",
+        text_template="volunteers/email/shift_reminder.txt",
+        context=lambda: {"shift": _sample_shift(), "signup": SimpleNamespace(shift=_sample_shift())},
+    ),
+    EmailPreview(
+        slug="shift-uncovered",
+        label="Uncovered shift alert",
+        description="Alerts the coordinators when a near-term shift loses its last volunteer.",
+        trigger="Cancelling a signup → volunteers.tasks.notify_shift_uncovered",
+        recipient="VOLUNTEER_COORDINATOR_EMAILS",
+        subject="DjangoCon US volunteer needed: “Registration Desk — morning” just lost its only volunteer",
+        text_template="volunteers/email/shift_uncovered.txt",
+        context=lambda: {"shift": _sample_shift(), "user": _sample_user()},
+    ),
+]
+
+
+def get_preview(slug: str) -> EmailPreview | None:
+    return next((preview for preview in EMAIL_PREVIEWS if preview.slug == slug), None)

--- a/config/nav.py
+++ b/config/nav.py
@@ -46,6 +46,7 @@ NAV_ITEMS = [
         permissions=["is_authenticated"],
         items=[
             NavItem(title="Django Admin", url="admin:index", permissions=["is_staff"]),
+            NavItem(title="Email Previews", url="email_previews", permissions=["is_staff"]),
             NavItem(title="Sign Out", url="account_logout"),
         ],
     ),

--- a/config/tests/test_email_branding.py
+++ b/config/tests/test_email_branding.py
@@ -105,9 +105,7 @@ class TestVolunteerEmailBranding:
     def test_uncovered_alert_is_branded(self, user, shift, hostile_site, settings):
         settings.VOLUNTEER_COORDINATOR_EMAILS = ["coordinator@example.com"]
         signup = VolunteerSignup.objects.create(shift=shift, user=user, cancelled=True)
-        VolunteerSignup.objects.filter(pk=signup.pk).update(
-            created_at=timezone.now() - datetime.timedelta(minutes=120)
-        )
+        VolunteerSignup.objects.filter(pk=signup.pk).update(created_at=timezone.now() - datetime.timedelta(minutes=120))
         assert notify_shift_uncovered(signup.pk) is True
         assert_branded(mail.outbox[0])
 

--- a/config/tests/test_email_previews.py
+++ b/config/tests/test_email_previews.py
@@ -1,0 +1,149 @@
+"""Tests for the staff email preview pages.
+
+The important one is ``test_every_email_template_is_registered``: it walks the
+repo for email templates and fails when one isn't in ``EMAIL_PREVIEWS``, so an
+email added later can't quietly skip the preview page.
+"""
+
+from pathlib import Path
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from config.emails import EMAIL_PREVIEWS, get_preview
+
+User = get_user_model()
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Subject lines and the shared base aren't emails in their own right.
+NOT_AN_EMAIL_BODY = ("_subject.txt", "base_message.txt", "base_notification.txt")
+
+
+@pytest.fixture
+def staff(db):
+    return User.objects.create_user(username="staffer", email="staff@example.com", password="pw12345!", is_staff=True)
+
+
+@pytest.fixture
+def volunteer(db):
+    return User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+
+
+def find_email_templates() -> set[str]:
+    """Every template under a templates/**/email/ directory, as a template name."""
+    found = set()
+    for base in REPO_ROOT.glob("**/templates"):
+        if ".venv" in base.parts or "node_modules" in base.parts:
+            continue
+        for path in base.glob("**/email/*"):
+            if not path.is_file() or path.name.endswith(NOT_AN_EMAIL_BODY):
+                continue
+            found.add(str(path.relative_to(base)))
+    return found
+
+
+@pytest.mark.django_db
+class TestEmailPreviewAccess:
+    def test_anonymous_is_redirected(self, client):
+        response = client.get(reverse("email_previews"))
+        assert response.status_code == 302
+        assert "/admin/login/" in response["Location"]
+
+    def test_non_staff_is_redirected(self, client, volunteer):
+        client.force_login(volunteer)
+        response = client.get(reverse("email_previews"))
+        assert response.status_code == 302
+
+    def test_staff_sees_the_index(self, client, staff):
+        client.force_login(staff)
+        response = client.get(reverse("email_previews"))
+        assert response.status_code == 200
+        content = response.content.decode()
+        for preview in EMAIL_PREVIEWS:
+            assert preview.label in content
+
+    def test_non_staff_cannot_read_a_detail_page(self, client, volunteer):
+        client.force_login(volunteer)
+        response = client.get(reverse("email_preview", args=["login-code"]))
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestEmailPreviewRendering:
+    @pytest.mark.parametrize("slug", [preview.slug for preview in EMAIL_PREVIEWS])
+    def test_every_preview_renders(self, client, staff, slug):
+        client.force_login(staff)
+        response = client.get(reverse("email_preview", args=[slug]))
+        assert response.status_code == 200
+        content = response.content.decode()
+        # Every email is branded, so this doubles as a smoke test that a body rendered.
+        assert "DjangoCon US" in content
+
+    def test_unknown_slug_is_404(self, client, staff):
+        client.force_login(staff)
+        assert client.get(reverse("email_preview", args=["nope"])).status_code == 404
+
+    def test_html_part_is_served_standalone(self, client, staff):
+        client.force_login(staff)
+        response = client.get(reverse("email_preview", args=["ticket-link-initial"]), {"part": "html"})
+        assert response.status_code == 200
+        assert response.content.decode().lstrip().startswith("<!DOCTYPE html>")
+
+    def test_html_iframe_body_is_escaped(self, client, staff):
+        """render_to_string returns a SafeString.
+
+        Interpolated bare into srcdoc, the email's own quotes close the
+        attribute early and the iframe renders blank — so the body must arrive
+        escaped, with no raw markup loose in the page.
+        """
+        client.force_login(staff)
+        response = client.get(reverse("email_preview", args=["ticket-link-initial"]))
+        content = response.content.decode()
+        assert 'srcdoc="&lt;!DOCTYPE html&gt;' in content
+        # The unescaped body would leave a second <html> tag loose in the page.
+        assert content.count("<html") == 1
+        # Django's {# #} comment is single-line only; a multi-line one renders as page text.
+        assert "force_escape is required" not in content
+
+    def test_html_part_404s_for_text_only_email(self, client, staff):
+        client.force_login(staff)
+        response = client.get(reverse("email_preview", args=["shift-reminder"]), {"part": "html"})
+        assert response.status_code == 404
+
+    def test_previews_use_no_real_data(self, client, staff, volunteer):
+        """Sample context is fabricated; a preview must not reach into the database."""
+        client.force_login(staff)
+        for preview in EMAIL_PREVIEWS:
+            response = client.get(reverse("email_preview", args=[preview.slug]))
+            assert volunteer.email not in response.content.decode()
+
+    def test_reissue_and_resend_differ_from_initial(self):
+        initial = get_preview("ticket-link-initial").render().text_body
+        resend = get_preview("ticket-link-resend").render().text_body
+        reissue = get_preview("ticket-link-reissue").render().text_body
+        assert initial != resend != reissue
+        assert "no longer works" in reissue
+        assert "same link we sent you before" in resend
+
+
+class TestRegistryCoverage:
+    def test_every_email_template_is_registered(self):
+        registered = {template for preview in EMAIL_PREVIEWS for template in preview.all_templates}
+        missing = find_email_templates() - registered
+        assert not missing, (
+            f"These email templates have no preview registered in config/emails.py: {sorted(missing)}. "
+            "Add an EmailPreview for each so staff can see it at /staff/emails/."
+        )
+
+    def test_the_scanner_actually_finds_templates(self):
+        """Guard the guard: a broken glob would make the test above vacuously pass."""
+        found = find_email_templates()
+        assert "tickets/email/ticket_link.txt" in found
+        assert "volunteers/email/shift_reminder.txt" in found
+        assert len(found) >= 4
+
+    def test_slugs_are_unique(self):
+        slugs = [preview.slug for preview in EMAIL_PREVIEWS]
+        assert len(slugs) == len(set(slugs))

--- a/config/urls.py
+++ b/config/urls.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.urls import include, path
 
 from config import __version__
-from config.views import homepage_view
+from config.views import email_preview_detail_view, email_preview_index_view, homepage_view
 from thunderdome.views import (
     bulk_set_state_view,
     grants_view,
@@ -39,6 +39,8 @@ urlpatterns = [
     path("", homepage_view, name="home"),
     path("accounts/", include("allauth.urls")),
     path("admin/", admin.site.urls),
+    path("staff/emails/", email_preview_index_view, name="email_previews"),
+    path("staff/emails/<slug:slug>/", email_preview_detail_view, name="email_preview"),
     path("titowebhook/", tito_webhook),
     path("tickets/", tickets_info, name="tickets_info"),
     path("tickets/create/", create_tickets_view, name="create_tickets"),

--- a/config/views.py
+++ b/config/views.py
@@ -1,6 +1,36 @@
-from django.http import HttpRequest, HttpResponse
+from django.contrib.admin.views.decorators import staff_member_required
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import render
+
+from config.emails import EMAIL_PREVIEWS, get_preview
 
 
 def homepage_view(request: HttpRequest) -> HttpResponse:
     return render(request, "homepage.html")
+
+
+@staff_member_required
+def email_preview_index_view(request: HttpRequest) -> HttpResponse:
+    return render(request, "staff/email_preview_index.html", {"previews": EMAIL_PREVIEWS})
+
+
+@staff_member_required
+def email_preview_detail_view(request: HttpRequest, slug: str) -> HttpResponse:
+    preview = get_preview(slug)
+    if preview is None:
+        raise Http404(f"No email preview named {slug!r}")
+
+    rendered = preview.render(request)
+
+    # ?part=html serves the HTML body alone, so the iframe below can show it at
+    # full width and staff can open it in a tab to test in a real client.
+    if request.GET.get("part") == "html":
+        if not rendered.html_body:
+            raise Http404("This email has no HTML part")
+        return HttpResponse(rendered.html_body)
+
+    return render(
+        request,
+        "staff/email_preview_detail.html",
+        {"preview": preview, "rendered": rendered, "previews": EMAIL_PREVIEWS},
+    )

--- a/templates/staff/email_preview_detail.html
+++ b/templates/staff/email_preview_detail.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+
+{% block body_class %}flex flex-col p-4 min-h-screen text-white bg-green-900 bg-gradient-to-b from-green-900 to-black via-green-950{% endblock body_class %}
+{% block main_class %}flex-1 mx-auto w-full text-white{% endblock main_class %}
+
+{% block title %}{{ preview.label }} - Email Previews{% endblock title %}
+
+{% block content %}
+    <div class="mx-auto max-w-5xl p-6">
+        <div class="mb-6">
+            <a href="{% url 'email_previews' %}" class="text-sm text-gray-400 hover:text-gray-200">&larr; All email previews</a>
+            <h1 class="text-3xl font-bold">{{ preview.label }}</h1>
+            <p class="mt-1 text-sm text-gray-400">{{ preview.description }}</p>
+        </div>
+
+        <div class="mb-6 flex flex-wrap gap-2">
+            {% for other in previews %}
+                <a href="{% url 'email_preview' other.slug %}"
+                   class="rounded-full border px-3 py-1 text-sm {% if other.slug == preview.slug %}border-yellow-300 bg-yellow-300 font-semibold text-green-900{% else %}border-green-700 bg-green-800 text-green-100 hover:bg-green-700{% endif %}">
+                    {{ other.label }}
+                </a>
+            {% endfor %}
+        </div>
+
+        <dl class="mb-6 grid gap-3 rounded-lg border border-green-700 bg-green-800/50 p-4 text-sm sm:grid-cols-2">
+            <div>
+                <dt class="text-xs uppercase tracking-wide text-gray-400">Subject</dt>
+                <dd class="mt-1 font-semibold text-yellow-200">{{ rendered.subject }}</dd>
+            </div>
+            <div>
+                <dt class="text-xs uppercase tracking-wide text-gray-400">To</dt>
+                <dd class="mt-1 text-gray-200">{{ preview.recipient }}</dd>
+            </div>
+            <div class="sm:col-span-2">
+                <dt class="text-xs uppercase tracking-wide text-gray-400">Sent by</dt>
+                <dd class="mt-1 text-gray-200">{{ preview.trigger }}</dd>
+            </div>
+            <div class="sm:col-span-2">
+                <dt class="text-xs uppercase tracking-wide text-gray-400">Templates</dt>
+                <dd class="mt-1 font-mono text-xs text-gray-300">
+                    {% for template in preview.all_templates %}{{ template }}{% if not forloop.last %} &middot; {% endif %}{% endfor %}
+                </dd>
+            </div>
+        </dl>
+
+        {% if rendered.html_body %}
+            <div class="mb-6">
+                <div class="mb-2 flex items-baseline justify-between">
+                    <h2 class="text-xl font-semibold text-yellow-200">HTML part</h2>
+                    <a href="?part=html" target="_blank" rel="noopener" class="text-sm text-yellow-300 underline hover:text-yellow-200">
+                        Open standalone &nearr;
+                    </a>
+                </div>
+                {% comment %}
+                    force_escape is required: render_to_string returns a SafeString, so without it the
+                    body's own quotes close the srcdoc attribute early and the iframe renders blank.
+                    sandbox: the preview is our own markup, but it should never be able to script this page.
+                {% endcomment %}
+                <iframe title="HTML preview of {{ preview.label }}"
+                        sandbox
+                        srcdoc="{{ rendered.html_body|force_escape }}"
+                        class="h-[36rem] w-full rounded-lg border border-green-700 bg-white"></iframe>
+            </div>
+        {% endif %}
+
+        <div>
+            <h2 class="mb-2 text-xl font-semibold text-yellow-200">
+                {% if rendered.html_body %}Plain text part{% else %}Plain text{% endif %}
+            </h2>
+            <pre class="overflow-x-auto rounded-lg border border-green-700 bg-black/40 p-4 text-sm whitespace-pre-wrap text-gray-100">{{ rendered.text_body }}</pre>
+        </div>
+    </div>
+{% endblock content %}

--- a/templates/staff/email_preview_index.html
+++ b/templates/staff/email_preview_index.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block body_class %}flex flex-col p-4 min-h-screen text-white bg-green-900 bg-gradient-to-b from-green-900 to-black via-green-950{% endblock body_class %}
+{% block main_class %}flex-1 mx-auto w-full text-white{% endblock main_class %}
+
+{% block title %}Email Previews - DjangoCon US Automation{% endblock title %}
+
+{% block content %}
+    <div class="mx-auto max-w-5xl p-6">
+        <div class="mb-6">
+            <a href="{% url 'home' %}" class="text-sm text-gray-400 hover:text-gray-200">&larr; Home</a>
+            <h1 class="text-3xl font-bold">Email Previews</h1>
+            <p class="mt-1 text-sm text-gray-400">
+                Every email this app sends, rendered with sample data. Nothing here touches the database
+                or sends mail &mdash; the contents are fabricated, so no attendee data can appear.
+            </p>
+        </div>
+
+        <div class="flex flex-col gap-3">
+            {% for preview in previews %}
+                <a href="{% url 'email_preview' preview.slug %}"
+                   class="block rounded-lg border border-green-700 bg-green-800/50 p-4 hover:border-yellow-300">
+                    <div class="flex flex-wrap items-baseline justify-between gap-2">
+                        <p class="text-lg font-semibold text-yellow-200">{{ preview.label }}</p>
+                        <div class="flex gap-2">
+                            {% if preview.html_template %}
+                                <span class="rounded-full bg-green-700 px-2 py-0.5 text-xs text-green-100">HTML + text</span>
+                            {% else %}
+                                <span class="rounded-full bg-green-700 px-2 py-0.5 text-xs text-green-100">text only</span>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <p class="mt-1 text-sm text-gray-300">{{ preview.description }}</p>
+                    <p class="mt-2 text-xs text-gray-400">
+                        <span class="text-gray-500">To:</span> {{ preview.recipient }}
+                        &middot;
+                        <span class="text-gray-500">Sent by:</span> {{ preview.trigger }}
+                    </p>
+                </a>
+            {% empty %}
+                <p class="text-gray-400">No emails are registered.</p>
+            {% endfor %}
+        </div>
+    </div>
+{% endblock content %}


### PR DESCRIPTION
Stacked on #124 — review that first; the base will retarget to `main` once it merges.

Every email we send, rendered with sample data, at **/staff/emails/** (staff only, linked from the homepage nav under Administration).

## Design

`config/emails.py` is one declarative registry. Two things worth calling out:

- **Allauth emails render through allauth's own adapter**, not by rendering templates directly. The preview therefore shows exactly what ships, including the subject-prefix behaviour `ACCOUNT_EMAIL_SUBJECT_PREFIX` controls — so it would have caught the bug #124 fixes.
- **No preview touches the database.** Sample context is fabricated, so no attendee's name or ticket link can appear on a preview page. There's a test asserting a real user's email never shows up.

Each page shows the subject, who it goes to, what triggers it, the templates it uses, the HTML part in a sandboxed iframe (with an "open standalone" link for testing in a real client), and the plain text part.

## Keeping it honest as we add emails

`test_every_email_template_is_registered` walks the repo for email templates and fails when one isn't registered:

```
These email templates have no preview registered in config/emails.py:
['volunteers/email/_probe_new_email.txt']
```

That's from actually dropping a probe template in to confirm it fires, not from reading the code. There's also a test guarding the guard — a broken glob would make it vacuously pass.

## Two bugs found by looking at the page

I screenshotted the running app rather than trusting the diff, which turned up two things the tests as first written would have missed:

1. **The HTML iframe rendered blank.** `render_to_string` returns a `SafeString`, so interpolating the body bare into `srcdoc` left its own quotes unescaped, closing the attribute early. Needs `force_escape`.
2. **A template comment rendered as visible page text.** Django's `{# #}` is single-line only; the multi-line comment I'd written printed onto the page.

Both are now pinned by assertions in `test_html_iframe_body_is_escaped`.

Also: sample shift times are built in `localtime`, which is what the templates render in — otherwise a 9am sample shift displayed as 4am.

## Verification

- `just test` — 299 passed
- `just lint` — clean
- Drove the real app and read the screenshots: index, an HTML+text email, and a text-only email

Note: `start-dev.sh` runs `uv run -m manage`, which this image's uv rejects (`unexpected argument '-m'`), so `just up` doesn't currently start the dev server. Pre-existing and unrelated — I worked around it — but worth a separate fix.