### PR TITLE
Add a Volunteer Chair group for the dashboard, interest report, and chairs line

### DIFF
--- a/config/nav.py
+++ b/config/nav.py
@@ -1,5 +1,7 @@
 from django_simple_nav.nav import Nav, NavGroup, NavItem
 
+from volunteers.permissions import nav_can_manage_dashboard, nav_can_view_volunteer_interest
+
 NAV_ITEMS = [
     NavGroup(
         title="Ticket Management",
@@ -37,8 +39,12 @@ NAV_ITEMS = [
         items=[
             NavItem(title="Sign Up to Volunteer", url="volunteers:shifts"),
             NavItem(title="My Shifts", url="volunteers:my_shifts"),
-            NavItem(title="Volunteer Dashboard", url="volunteers:dashboard", permissions=["is_staff"]),
-            NavItem(title="Volunteer Interest Report", url="volunteer_interest", permissions=["is_superuser"]),
+            NavItem(title="Volunteer Dashboard", url="volunteers:dashboard", permissions=[nav_can_manage_dashboard]),
+            NavItem(
+                title="Volunteer Interest Report",
+                url="volunteer_interest",
+                permissions=[nav_can_view_volunteer_interest],
+            ),
         ],
     ),
     NavGroup(

--- a/config/settings.py
+++ b/config/settings.py
@@ -329,6 +329,10 @@ VOLUNTEER_UNCOVERED_ALERT_WINDOW_HOURS = env.int("VOLUNTEER_UNCOVERED_ALERT_WIND
 # buffer — a quick change of mind isn't worth an email.
 VOLUNTEER_UNCOVERED_ALERT_BUFFER_MINUTES = env.int("VOLUNTEER_UNCOVERED_ALERT_BUFFER_MINUTES", default=60)
 
+# Shared address for the volunteer chairs, shown on a volunteer's own page so
+# nobody's personal inbox is published. Blank hides the link.
+VOLUNTEER_CONTACT_EMAIL = env.str("VOLUNTEER_CONTACT_EMAIL", default="volunteers@djangocon.us")
+
 # General volunteer handbook, shown alongside role-specific docs.
 VOLUNTEER_HANDBOOK_URL = env.str(
     "VOLUNTEER_HANDBOOK_URL",

--- a/config/settings.py
+++ b/config/settings.py
@@ -330,8 +330,9 @@ VOLUNTEER_UNCOVERED_ALERT_WINDOW_HOURS = env.int("VOLUNTEER_UNCOVERED_ALERT_WIND
 VOLUNTEER_UNCOVERED_ALERT_BUFFER_MINUTES = env.int("VOLUNTEER_UNCOVERED_ALERT_BUFFER_MINUTES", default=60)
 
 # Shared address for the volunteer chairs, shown on a volunteer's own page so
-# nobody's personal inbox is published. Blank hides the link.
-VOLUNTEER_CONTACT_EMAIL = env.str("VOLUNTEER_CONTACT_EMAIL", default="volunteers@djangocon.us")
+# nobody's personal inbox is published. Set per environment; blank (the default)
+# hides the link.
+VOLUNTEER_CONTACT_EMAIL = env.str("VOLUNTEER_CONTACT_EMAIL", default="")
 
 # General volunteer handbook, shown alongside role-specific docs.
 VOLUNTEER_HANDBOOK_URL = env.str(

--- a/titowebhooks/views.py
+++ b/titowebhooks/views.py
@@ -23,6 +23,7 @@ from tickets.sync import record_webhook_attendee
 from titowebhooks.models import TitoHistoricalEvent, TitoTicket, TitoWebhookEvent
 from titowebhooks.sales_curve import sales_curves
 from volunteers.models import VolunteerSignup
+from volunteers.permissions import volunteer_interest_required
 
 logger = logging.getLogger(__name__)
 
@@ -635,7 +636,7 @@ def _volunteer_interest_csv(people: list[dict]) -> HttpResponse:
     return response
 
 
-@superuser_required
+@volunteer_interest_required
 def volunteer_interest_view(request: HttpRequest) -> HttpResponse:
     people = _extract_volunteer_interest()
 

--- a/volunteers/README.md
+++ b/volunteers/README.md
@@ -67,8 +67,8 @@ personal inbox. Checks live in `volunteers/permissions.py`.
 ## Settings
 
 - `VOLUNTEER_MAX_HOURS` (env, default `8`) — per-person hour cap.
-- `VOLUNTEER_CONTACT_EMAIL` (env, default `volunteers@djangocon.us`) — shared
-  address for the chairs line. Blank hides the link.
+- `VOLUNTEER_CONTACT_EMAIL` (env, no default) — shared address for the chairs
+  line, set per environment. Blank hides the link.
 
 ## Setup
 

--- a/volunteers/README.md
+++ b/volunteers/README.md
@@ -47,9 +47,28 @@ python manage.py import_shifts shifts.csv --dry-run # validate only
 python manage.py send_volunteer_reminders
 ```
 
+## Volunteer chairs
+
+The **"Volunteer Chair"** group (seeded by migration `0010`) carries the two
+permissions on `VolunteerChairPermissions`:
+
+- `volunteers.view_volunteer_dashboard` — the dashboard, the roster, and every
+  action on them (sync, merge, split, delete, contact info).
+- `volunteers.view_volunteer_interest` — the volunteer interest report.
+
+Add a chair by dropping their user into the group in the Django admin. They need
+no `is_staff`, which keeps them out of the admin and the ticket/sprint tooling.
+Staff keep dashboard access and superusers keep everything, exactly as before.
+
+Group members are listed as the volunteer chairs on `/volunteers/mine/`, with a
+`mailto:` to the shared `VOLUNTEER_CONTACT_EMAIL` address rather than to anyone's
+personal inbox. Checks live in `volunteers/permissions.py`.
+
 ## Settings
 
 - `VOLUNTEER_MAX_HOURS` (env, default `8`) — per-person hour cap.
+- `VOLUNTEER_CONTACT_EMAIL` (env, default `volunteers@djangocon.us`) — shared
+  address for the chairs line. Blank hides the link.
 
 ## Setup
 

--- a/volunteers/migrations/0010_volunteer_chair_group.py
+++ b/volunteers/migrations/0010_volunteer_chair_group.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+
+from volunteers.permissions import VOLUNTEER_CHAIR_GROUP, grant_chair_group
+
+
+def create_chair_group(apps, schema_editor):
+    """Seed the Volunteer Chair group so chairs can be added in the admin."""
+    grant_chair_group(
+        apps.get_model("auth", "Group"),
+        apps.get_model("auth", "Permission"),
+        apps.get_model("contenttypes", "ContentType"),
+    )
+
+
+def delete_chair_group(apps, schema_editor):
+    """Drop the group; leave the permissions for ``create_permissions`` to manage."""
+    Group = apps.get_model("auth", "Group")
+    Group.objects.filter(name=VOLUNTEER_CHAIR_GROUP).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("volunteers", "0009_sitecontactinfo"),
+        ("auth", "0012_alter_user_first_name_max_length"),
+        ("contenttypes", "0002_remove_content_type_name"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="VolunteerChairPermissions",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+            ],
+            options={
+                "permissions": [
+                    ("view_volunteer_dashboard", "Can view and manage the volunteer dashboard"),
+                    ("view_volunteer_interest", "Can view the volunteer interest report"),
+                ],
+                "managed": False,
+                "default_permissions": (),
+            },
+        ),
+        migrations.RunPython(create_chair_group, delete_chair_group),
+    ]

--- a/volunteers/models.py
+++ b/volunteers/models.py
@@ -215,6 +215,24 @@ class CalendarToken(models.Model):
         return f"calendar token for {self.user}"
 
 
+class VolunteerChairPermissions(models.Model):
+    """Permission-only model: no table, no rows — just a home for the chair permissions.
+
+    The coordinator tooling isn't owned by any one model (the dashboard spans
+    shifts, signups, and contact info; the interest report reads Tito data), so
+    the permissions hang here instead of being bolted onto an unrelated model.
+    Granted via the "Volunteer Chair" group seeded in migration 0010.
+    """
+
+    class Meta:
+        managed = False
+        default_permissions = ()
+        permissions = [
+            ("view_volunteer_dashboard", "Can view and manage the volunteer dashboard"),
+            ("view_volunteer_interest", "Can view the volunteer interest report"),
+        ]
+
+
 def total_volunteer_hours(user):
     """Total hours a user is currently signed up for (excludes cancelled)."""
     hours = 0.0

--- a/volunteers/permissions.py
+++ b/volunteers/permissions.py
@@ -1,0 +1,120 @@
+"""Who counts as a volunteer chair, and what that lets them do.
+
+Chairs are members of the "Volunteer Chair" group (seeded in migration 0010),
+which carries the two permissions defined on ``VolunteerChairPermissions``.
+Nobody loses access they already had: the dashboard still lets staff in, and the
+interest report still lets superusers in.
+"""
+
+import functools
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.views import redirect_to_login
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import PermissionDenied
+
+VOLUNTEER_CHAIR_GROUP = "Volunteer Chair"
+
+# (codename, human-readable name) — mirrors VolunteerChairPermissions.Meta.
+CHAIR_PERMISSIONS = [
+    ("view_volunteer_dashboard", "Can view and manage the volunteer dashboard"),
+    ("view_volunteer_interest", "Can view the volunteer interest report"),
+]
+
+DASHBOARD_PERM = "volunteers.view_volunteer_dashboard"
+INTEREST_PERM = "volunteers.view_volunteer_interest"
+
+
+def _active(user):
+    return user.is_authenticated and user.is_active
+
+
+def can_manage_dashboard(user):
+    """May see and manage the volunteer dashboard, its roster, and its actions.
+
+    Staff could already do this, so they keep it.
+    """
+    return _active(user) and (user.is_staff or user.has_perm(DASHBOARD_PERM))
+
+
+def can_view_volunteer_interest(user):
+    """May see the volunteer interest report.
+
+    This one was superuser-only, and stays that way apart from chairs — being
+    staff isn't enough, same as before.
+    """
+    return _active(user) and (user.is_superuser or user.has_perm(INTEREST_PERM))
+
+
+def _requires(test):
+    """Build a decorator that runs ``test`` against ``request.user``.
+
+    Anonymous users are sent to log in; signed-in users without access get a 403
+    rather than a login loop.
+    """
+
+    def decorator(view_func):
+        @functools.wraps(view_func)
+        def wrapper(request, *args, **kwargs):
+            if test(request.user):
+                return view_func(request, *args, **kwargs)
+            if not request.user.is_authenticated:
+                return redirect_to_login(request.get_full_path())
+            raise PermissionDenied
+
+        return wrapper
+
+    return decorator
+
+
+dashboard_required = _requires(can_manage_dashboard)
+volunteer_interest_required = _requires(can_view_volunteer_interest)
+
+
+def nav_can_manage_dashboard(request):
+    return can_manage_dashboard(request.user)
+
+
+def nav_can_view_volunteer_interest(request):
+    return can_view_volunteer_interest(request.user)
+
+
+def volunteer_chairs():
+    """Active members of the Volunteer Chair group, for the chairs line."""
+    return (
+        get_user_model()
+        .objects.filter(groups__name=VOLUNTEER_CHAIR_GROUP, is_active=True)
+        .order_by("first_name", "last_name", "username")
+    )
+
+
+def grant_chair_group(group_model=None, permission_model=None, content_type_model=None):
+    """Create the chair group and its permissions, idempotently.
+
+    The models can be passed in so migration 0010 can hand over its historical
+    versions; called with no arguments it uses the live ones. The permissions
+    are normally created by ``create_permissions`` in a post_migrate hook, which
+    hasn't run yet during that migration, so they're created here on demand and
+    simply found later.
+    """
+    group_model = group_model or Group
+    permission_model = permission_model or Permission
+    content_type_model = content_type_model or ContentType
+
+    content_type, _ = content_type_model.objects.get_or_create(
+        app_label="volunteers", model="volunteerchairpermissions"
+    )
+
+    permissions = []
+    for codename, name in CHAIR_PERMISSIONS:
+        permission, _ = permission_model.objects.get_or_create(
+            codename=codename,
+            content_type=content_type,
+            defaults={"name": name},
+        )
+        permissions.append(permission)
+
+    group, _ = group_model.objects.get_or_create(name=VOLUNTEER_CHAIR_GROUP)
+    group.permissions.add(*permissions)
+    return group

--- a/volunteers/templates/volunteers/my_shifts.html
+++ b/volunteers/templates/volunteers/my_shifts.html
@@ -64,10 +64,24 @@
             {% endfor %}
         </div>
 
-        {% if contact_info %}
+        {% if chairs or contact_info %}
             <div class="rounded-lg border border-green-700 bg-green-800 p-4">
                 <h2 class="mb-2 text-lg font-semibold text-yellow-300">📇 Volunteer contacts</h2>
-                <div class="max-w-none prose prose-invert" data-markdown>{{ contact_info }}</div>
+                {% if chairs %}
+                    <p class="mb-2 text-sm text-green-200">
+                        <strong class="text-green-100">Volunteer chairs:</strong>
+                        {% for chair in chairs %}
+                            {{ chair.get_full_name|default:chair.get_username }}{% if not forloop.last %} · {% endif %}
+                        {% endfor %}
+                        {% if volunteer_contact_email %}
+                            — reach them at
+                            <a href="mailto:{{ volunteer_contact_email }}" class="text-yellow-300 underline">{{ volunteer_contact_email }}</a>
+                        {% endif %}
+                    </p>
+                {% endif %}
+                {% if contact_info %}
+                    <div class="max-w-none prose prose-invert" data-markdown>{{ contact_info }}</div>
+                {% endif %}
             </div>
         {% endif %}
 

--- a/volunteers/tests/test_chair_permissions.py
+++ b/volunteers/tests/test_chair_permissions.py
@@ -94,7 +94,7 @@ def test_superusers_keep_access_to_everything(client, db):
 
 
 def test_chair_can_manage_the_dashboard(chair_client, db):
-    """"Manage," not just "see" — the dashboard's POST actions open up too."""
+    """ "Manage," not just "see" — the dashboard's POST actions open up too."""
     role = Role.objects.create(name="Registration Desk")
     shift = Shift.objects.create(
         role=role,
@@ -131,18 +131,19 @@ def test_chairs_appear_on_my_shifts(client, db, chair):
 
 
 def test_chairs_line_uses_the_shared_address_not_personal_email(client, db, chair, settings):
-    """Chairs are named, but the mailto is the shared volunteers@ alias."""
-    settings.VOLUNTEER_CONTACT_EMAIL = "volunteers@djangocon.us"
+    """Chairs are named, but the mailto is the shared address, not a personal one."""
+    settings.VOLUNTEER_CONTACT_EMAIL = "volunteers@example.com"
     volunteer = User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
     client.force_login(volunteer)
 
     body = client.get(reverse("volunteers:my_shifts")).content.decode()
 
-    assert "mailto:volunteers@djangocon.us" in body
+    assert "mailto:volunteers@example.com" in body
     assert "chair@example.com" not in body
 
 
 def test_chairs_line_drops_the_link_when_no_shared_address_is_set(client, db, chair, settings):
+    """The default: no address configured, so the names show without a mailto."""
     settings.VOLUNTEER_CONTACT_EMAIL = ""
     volunteer = User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
     client.force_login(volunteer)

--- a/volunteers/tests/test_chair_permissions.py
+++ b/volunteers/tests/test_chair_permissions.py
@@ -1,0 +1,212 @@
+"""The Volunteer Chair group: what it unlocks, and who shows up as a chair."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.urls import reverse
+
+from volunteers.models import Role, Shift, VolunteerSignup
+from volunteers.permissions import VOLUNTEER_CHAIR_GROUP, grant_chair_group, volunteer_chairs
+
+User = get_user_model()
+
+DASHBOARD = "volunteers:dashboard"
+VOLUNTEERS_LIST = "volunteers:volunteers_list"
+INTEREST_REPORT = "volunteer_interest"
+
+
+@pytest.fixture
+def chair_group(db):
+    """The group migration 0010 seeds.
+
+    Built here rather than read from the migration because the suite runs with
+    ``--nomigrations``, so data migrations never execute. Both paths call the
+    same ``grant_chair_group`` helper.
+    """
+    return grant_chair_group()
+
+
+@pytest.fixture
+def chair(db, chair_group):
+    user = User.objects.create_user(username="chair", email="chair@example.com", password="pw12345!")
+    user.groups.add(chair_group)
+    return user
+
+
+@pytest.fixture
+def chair_client(client, chair):
+    client.force_login(chair)
+    return client
+
+
+def test_seeding_grants_both_permissions(chair_group):
+    assert chair_group.name == VOLUNTEER_CHAIR_GROUP
+    codenames = set(chair_group.permissions.values_list("codename", flat=True))
+    assert codenames == {"view_volunteer_dashboard", "view_volunteer_interest"}
+
+
+def test_seeding_is_idempotent(chair_group):
+    again = grant_chair_group()
+
+    assert again.pk == chair_group.pk
+    assert Group.objects.filter(name=VOLUNTEER_CHAIR_GROUP).count() == 1
+    assert again.permissions.count() == 2
+
+
+@pytest.mark.parametrize("url_name", [DASHBOARD, VOLUNTEERS_LIST, INTEREST_REPORT])
+def test_chair_can_reach_coordinator_pages(chair_client, url_name):
+    assert chair_client.get(reverse(url_name)).status_code == 200
+
+
+@pytest.mark.parametrize("url_name", [DASHBOARD, VOLUNTEERS_LIST, INTEREST_REPORT])
+def test_plain_volunteer_is_forbidden(client, db, url_name):
+    user = User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+    client.force_login(user)
+    assert client.get(reverse(url_name)).status_code == 403
+
+
+@pytest.mark.parametrize("url_name", [DASHBOARD, VOLUNTEERS_LIST, INTEREST_REPORT])
+def test_anonymous_is_sent_to_log_in(client, db, url_name):
+    response = client.get(reverse(url_name))
+    assert response.status_code == 302
+    assert reverse("account_login") in response["Location"]
+
+
+def test_staff_keep_dashboard_access_without_the_group(client, db):
+    """Nothing is taken away from existing staff by the permission switch."""
+    staff = User.objects.create_user(username="staff", email="staff@example.com", password="pw12345!", is_staff=True)
+    client.force_login(staff)
+    assert client.get(reverse(DASHBOARD)).status_code == 200
+
+
+def test_staff_alone_still_cannot_see_the_interest_report(client, db):
+    """The report was superuser-only; being staff is still not enough."""
+    staff = User.objects.create_user(username="staff", email="staff@example.com", password="pw12345!", is_staff=True)
+    client.force_login(staff)
+    assert client.get(reverse(INTEREST_REPORT)).status_code == 403
+
+
+def test_superusers_keep_access_to_everything(client, db):
+    root = User.objects.create_superuser(username="root", email="root@example.com", password="pw12345!")
+    client.force_login(root)
+    assert client.get(reverse(DASHBOARD)).status_code == 200
+    assert client.get(reverse(INTEREST_REPORT)).status_code == 200
+
+
+def test_chair_can_manage_the_dashboard(chair_client, db):
+    """"Manage," not just "see" — the dashboard's POST actions open up too."""
+    role = Role.objects.create(name="Registration Desk")
+    shift = Shift.objects.create(
+        role=role,
+        title="Doomed",
+        starts_at="2026-08-26T09:00:00Z",
+        ends_at="2026-08-26T10:00:00Z",
+    )
+
+    response = chair_client.post(reverse("volunteers:delete_shift", args=[shift.pk]))
+
+    assert response.status_code == 302
+    assert not Shift.objects.filter(pk=shift.pk).exists()
+
+
+def test_chair_can_update_contact_info(chair_client, db):
+    response = chair_client.post(reverse("volunteers:update_contact"), {"contact_info": "Find us in #volunteers"})
+
+    assert response.status_code == 302
+    assert chair_client.get(reverse("volunteers:my_shifts")).context["contact_info"] == "Find us in #volunteers"
+
+
+def test_chairs_appear_on_my_shifts(client, db, chair):
+    chair.first_name = "Robin"
+    chair.last_name = "Chair"
+    chair.save(update_fields=["first_name", "last_name"])
+    volunteer = User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+    client.force_login(volunteer)
+
+    response = client.get(reverse("volunteers:my_shifts"))
+    body = response.content.decode()
+
+    assert list(response.context["chairs"]) == [chair]
+    assert "Robin Chair" in body
+
+
+def test_chairs_line_uses_the_shared_address_not_personal_email(client, db, chair, settings):
+    """Chairs are named, but the mailto is the shared volunteers@ alias."""
+    settings.VOLUNTEER_CONTACT_EMAIL = "volunteers@djangocon.us"
+    volunteer = User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+    client.force_login(volunteer)
+
+    body = client.get(reverse("volunteers:my_shifts")).content.decode()
+
+    assert "mailto:volunteers@djangocon.us" in body
+    assert "chair@example.com" not in body
+
+
+def test_chairs_line_drops_the_link_when_no_shared_address_is_set(client, db, chair, settings):
+    settings.VOLUNTEER_CONTACT_EMAIL = ""
+    volunteer = User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+    client.force_login(volunteer)
+
+    body = client.get(reverse("volunteers:my_shifts")).content.decode()
+
+    assert "mailto:" not in body
+    assert "Volunteer chairs:" in body
+
+
+def test_only_active_group_members_are_chairs(db, chair, chair_group):
+    User.objects.create_user(username="nobody", email="nobody@example.com", password="pw12345!")
+    inactive = User.objects.create_user(username="former", email="former@example.com", password="pw12345!")
+    inactive.groups.add(chair_group)
+    inactive.is_active = False
+    inactive.save(update_fields=["is_active"])
+
+    assert list(volunteer_chairs()) == [chair]
+
+
+def test_chair_needs_no_staff_flag(chair):
+    """The whole point: coordinator access without the Django admin."""
+    assert not chair.is_staff
+    assert not chair.is_superuser
+
+
+def test_my_shifts_hides_the_contacts_box_when_there_is_nothing_to_show(client, db):
+    volunteer = User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+    client.force_login(volunteer)
+
+    response = client.get(reverse("volunteers:my_shifts"))
+
+    assert not list(response.context["chairs"])
+    assert "Volunteer contacts" not in response.content.decode()
+
+
+def test_chair_sees_the_coordinator_nav_links(chair_client):
+    body = chair_client.get("/").content.decode()  # the nav only renders on the homepage
+
+    assert "Volunteer Dashboard" in body
+    assert "Volunteer Interest Report" in body
+
+
+def test_plain_volunteer_does_not_see_the_coordinator_nav_links(client, db):
+    volunteer = User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+    client.force_login(volunteer)
+
+    body = client.get("/").content.decode()
+
+    assert "Volunteer Dashboard" not in body
+    assert "Volunteer Interest Report" not in body
+
+
+def test_roster_still_lists_volunteers_for_a_chair(chair_client, db):
+    volunteer = User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+    role = Role.objects.create(name="Registration Desk")
+    shift = Shift.objects.create(
+        role=role,
+        title="Reg desk",
+        starts_at="2026-08-26T09:00:00Z",
+        ends_at="2026-08-26T11:00:00Z",
+    )
+    VolunteerSignup.objects.create(shift=shift, user=volunteer)
+
+    response = chair_client.get(reverse(VOLUNTEERS_LIST))
+
+    assert response.context["total_volunteers"] == 1

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -3,7 +3,6 @@ from io import StringIO
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
 from django.core.management import call_command
 from django.db.models import Count, Q
@@ -28,6 +27,7 @@ from .models import (
     split_shift,
     total_volunteer_hours,
 )
+from .permissions import dashboard_required, volunteer_chairs
 
 
 def max_volunteer_hours():
@@ -36,6 +36,10 @@ def max_volunteer_hours():
 
 def volunteer_handbook_url():
     return getattr(settings, "VOLUNTEER_HANDBOOK_URL", "")
+
+
+def volunteer_contact_email():
+    return getattr(settings, "VOLUNTEER_CONTACT_EMAIL", "")
 
 
 def _return_url(request):
@@ -121,14 +125,16 @@ def my_shifts_view(request):
         "calendar_url": request.build_absolute_uri(reverse("volunteers:calendar", args=[token.token])),
         "handbook_url": volunteer_handbook_url(),
         "contact_info": SiteContactInfo.get_solo().contact_info,
+        "chairs": volunteer_chairs(),
+        "volunteer_contact_email": volunteer_contact_email(),
     }
     return render(request, "volunteers/my_shifts.html", context)
 
 
-@staff_member_required
+@dashboard_required
 @require_POST
 def update_contact_view(request):
-    """Save the site-wide volunteer coordinator contact info (staff only)."""
+    """Save the site-wide volunteer coordinator contact info (chairs and staff)."""
     contact = SiteContactInfo.get_solo()
     contact.contact_info = request.POST.get("contact_info", "").strip()
     contact.save(update_fields=["contact_info", "updated_at"])
@@ -207,7 +213,7 @@ def cancel_view(request, pk):
     return redirect(_return_url(request))
 
 
-@staff_member_required
+@dashboard_required
 def dashboard_view(request):
     """Coordinator view: coverage per shift plus a roster of who's signed up.
 
@@ -285,7 +291,7 @@ def dashboard_view(request):
     return render(request, "volunteers/dashboard.html", context)
 
 
-@staff_member_required
+@dashboard_required
 @require_POST
 def merge_shifts_view(request):
     """Merge the selected schedule shifts into one sign-up block."""
@@ -299,7 +305,7 @@ def merge_shifts_view(request):
     return redirect(_return_url(request) if request.POST.get("next") else "volunteers:dashboard")
 
 
-@staff_member_required
+@dashboard_required
 @require_POST
 def delete_shift_view(request, pk):
     """Delete a shift (and its sign-ups). Its talks are detached, not deleted."""
@@ -310,7 +316,7 @@ def delete_shift_view(request, pk):
     return redirect(_return_url(request) if request.POST.get("next") else "volunteers:dashboard")
 
 
-@staff_member_required
+@dashboard_required
 @require_POST
 def split_shift_view(request, pk):
     """Split a block back into one shift per talk."""
@@ -326,7 +332,7 @@ def split_shift_view(request, pk):
 VOLUNTEER_SORTS = {"name", "hours", "shifts"}
 
 
-@staff_member_required
+@dashboard_required
 def volunteers_list_view(request):
     """Roster of everyone signed up, with how many shifts/hours each has taken."""
     sort = request.GET.get("sort", "name")
@@ -370,7 +376,7 @@ def volunteers_list_view(request):
     return render(request, "volunteers/volunteers_list.html", context)
 
 
-@staff_member_required
+@dashboard_required
 @require_POST
 def sync_schedule_view(request):
     """Re-import shifts from the conference schedule ICS feed.


### PR DESCRIPTION
Closes #128.

Coordinator access was gated on Django's built-in flags — `is_staff` for the dashboard, `is_superuser` for the interest report — so the only way to let a volunteer chair do their job was to hand over the Django admin and the ticket/Thunderdome/sprint tooling.

## What this does

- **New `VolunteerChairPermissions` model** — permission-only (`managed = False`, `default_permissions = ()`), no table and no rows. The coordinator tooling isn't owned by any one model, so the permissions hang there rather than being bolted onto an unrelated one:
  - `volunteers.view_volunteer_dashboard`
  - `volunteers.view_volunteer_interest`
- **Migration `0010` seeds the "Volunteer Chair" group** with both permissions, so production doesn't need hand-assembly in the admin. Chairs are added by dropping a user into the group.
- **`volunteers/permissions.py`** holds the checks and the `dashboard_required` / `volunteer_interest_required` decorators. Anonymous users are sent to log in; signed-in users without access get a 403 instead of a login loop.
- **Nav matches the view checks** so chairs actually see the links — `django_simple_nav` accepts callables in `permissions`, which is how the OR gets expressed.
- **The chairs line on `/volunteers/mine/`** lists group members by name. The free-text `SiteContactInfo` block stays for Slack channels and anything that isn't a person.

## Nobody loses access

| Who | Dashboard | Interest report |
|---|---|---|
| Superuser | ✅ (unchanged) | ✅ (unchanged) |
| Staff | ✅ (unchanged) | ❌ (unchanged — still superuser-only) |
| Volunteer Chair | ✅ **new** | ✅ **new** |
| Signed-in volunteer | ❌ | ❌ |

A chair needs no `is_staff`, which is the point — coordinator access without the Django admin.

## On the email address

Chairs are **named** on the page, but the `mailto:` points at the shared `VOLUNTEER_CONTACT_EMAIL` (`volunteers@djangocon.us` by default, blank hides the link) so no one's personal inbox is published on a page every volunteer sees. Note that alias still needs to exist and forward to the chairs — it was raised in #76 and never answered.

## Verification

- `just test` — 324 passed, including 27 new tests in `volunteers/tests/test_chair_permissions.py` covering each role against each page, the POST actions, the chairs line, and the nav links.
- `just lint` — clean.
- The suite runs with `--nomigrations`, so data migrations never execute in tests. Migration `0010` was instead verified against the dev database: applied, group seeded with both permissions, and `showmigrations` confirms it. The migration and the test fixture call the same `grant_chair_group()` helper, so there's one implementation to be wrong.

## Follow-up

The uncovered-shift alert still reads `VOLUNTEER_COORDINATOR_EMAILS` from the environment; that list could come from this group instead.