### PR TITLE
:bug: Use {% comment %} blocks for multi-line template comments

### DIFF
--- a/templates/tickets/email/ticket_link.html
+++ b/templates/tickets/email/ticket_link.html
@@ -6,7 +6,9 @@
         <meta name="color-scheme" content="light">
         <title>Your DjangoCon US online conference link</title>
     </head>
-    {# Table layout and inline styles throughout: Outlook and Gmail strip <style> blocks and ignore flex/grid. #}
+    {% comment %}
+        Table layout and inline styles throughout: Outlook and Gmail strip <style> blocks and ignore flex/grid.
+    {% endcomment %}
     <body style="margin:0; padding:0; background-color:#f4f6f5; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; color:#20303c;">
         <div style="display:none; max-height:0; overflow:hidden; opacity:0;">
             {% if is_reissue %}

--- a/templates/titowebhooks/_sales_chart.html
+++ b/templates/titowebhooks/_sales_chart.html
@@ -45,9 +45,11 @@ copying the rendered SVG - there is no second rendering path to drift out of syn
 
         {% for line in chart.lines %}
             {% for marker in line.markers %}
-                {# Hit target first: the dot is a following sibling so CSS can grow it,
-                   and .chart-dot ignores pointer events so hovering the dot still
-                   lands on this generous transparent circle. #}
+                {% comment %}
+                    Hit target first: the dot is a following sibling so CSS can grow it,
+                    and .chart-dot ignores pointer events so hovering the dot still
+                    lands on this generous transparent circle.
+                {% endcomment %}
                 <circle class="chart-hit"
                         cx="{{ marker.x|floatformat:1 }}"
                         cy="{{ marker.y|floatformat:1 }}"

--- a/volunteers/templates/volunteers/shift_list.html
+++ b/volunteers/templates/volunteers/shift_list.html
@@ -122,8 +122,10 @@
                                                 </p>
                                             {% endfor %}
                                             {% if shift.role.description %}
-                                                {# Collapsed by default: a role's duties repeat across every one of its
-                                                   shifts, so rendering them inline would swamp the list. #}
+                                                {% comment %}
+                                                    Collapsed by default: a role's duties repeat across every one of its
+                                                    shifts, so rendering them inline would swamp the list.
+                                                {% endcomment %}
                                                 <details class="mt-1 text-xs">
                                                     <summary class="cursor-pointer text-yellow-300 select-none">What this role involves</summary>
                                                     <p class="mt-1 text-sm whitespace-pre-line text-green-200">{{ shift.role.description }}</p>


### PR DESCRIPTION
Django's `{# #}` is single-line only. The multi-line comments in `shift_list.html` and `_sales_chart.html` were therefore never parsed as comments — their text rendered literally into the page for users to see.

Converts both to `{% comment %} ... {% endcomment %}` blocks, plus the single-line one in `ticket_link.html` for consistency with the project standard.

`grep -rn '{#' templates volunteers travel_safety` now returns nothing.

## Testing

- Full suite: **324 passed**
- `just lint`: all hooks pass (DjHTML included)

Fixes #131