### PR TITLE
:sparkles: Add role handbook and manage-shifts links to the reminder email

### DIFF
--- a/config/emails.py
+++ b/config/emails.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Callable
 
+from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils import timezone
 
@@ -93,11 +94,26 @@ def _sample_shift():
     start += datetime.timedelta(days=1)
     return SimpleNamespace(
         title="Registration Desk — morning",
-        role=SimpleNamespace(name="Registration Desk"),
+        role=SimpleNamespace(
+            name="Registration Desk",
+            documentation_url="https://example.com/handbook#registration-desk",
+        ),
         location="Convention Center, Lobby B",
         starts_at=start,
         ends_at=start + datetime.timedelta(hours=2),
     )
+
+
+def _shift_reminder_context():
+    shift = _sample_shift()
+    return {
+        "shift": shift,
+        "signup": SimpleNamespace(shift=shift),
+        "my_shifts_url": "https://automation.defna.org/volunteers/mine/",
+        "role_documentation_url": shift.role.documentation_url,
+        "handbook_url": settings.VOLUNTEER_HANDBOOK_URL,
+        "contact_email": settings.VOLUNTEER_CONTACT_EMAIL,
+    }
 
 
 def _sample_user():
@@ -108,8 +124,6 @@ def _sample_user():
 
 
 def _ticket_context(**overrides):
-    from django.conf import settings
-
     context = {
         "attendee": None,
         "name": "Ada Lovelace",
@@ -183,12 +197,15 @@ EMAIL_PREVIEWS: list[EmailPreview] = [
     EmailPreview(
         slug="shift-reminder",
         label="Volunteer shift reminder",
-        description="Reminder sent to a volunteer 24 hours before their shift.",
+        description=(
+            "Reminder sent to a volunteer 24 hours before their shift. Carries the role's own "
+            "handbook link and a link to manage their shifts."
+        ),
         trigger="Hourly schedule → volunteers.tasks.send_shift_reminders",
         recipient="Volunteer with an upcoming shift",
         subject="Reminder: your DjangoCon US volunteer shift “Registration Desk — morning”",
         text_template="volunteers/email/shift_reminder.txt",
-        context=lambda: {"shift": _sample_shift(), "signup": SimpleNamespace(shift=_sample_shift())},
+        context=_shift_reminder_context,
     ),
     EmailPreview(
         slug="shift-uncovered",

--- a/config/tests/test_email_branding.py
+++ b/config/tests/test_email_branding.py
@@ -100,7 +100,9 @@ class TestVolunteerEmailBranding:
     def test_shift_reminder_is_branded(self, user, shift, hostile_site):
         VolunteerSignup.objects.create(shift=shift, user=user)
         assert send_shift_reminders() == 1
-        assert_branded(mail.outbox[0])
+        # The "manage your shifts" link legitimately contains the domain; the
+        # branding must not — same allowance as the sign-in email.
+        assert_branded(mail.outbox[0], allow_domain_in_body=True)
 
     def test_uncovered_alert_is_branded(self, user, shift, hostile_site, settings):
         settings.VOLUNTEER_COORDINATOR_EMAILS = ["coordinator@example.com"]

--- a/volunteers/tasks.py
+++ b/volunteers/tasks.py
@@ -2,8 +2,10 @@ import datetime
 import logging
 
 from django.conf import settings
+from django.contrib.sites.models import Site
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils import timezone
 from rich import print
 
@@ -13,6 +15,16 @@ logger = logging.getLogger(__name__)
 
 # How far ahead of a shift we send the reminder.
 REMINDER_WINDOW_HOURS = 24
+
+
+def absolute_url(url_name: str) -> str:
+    """Build a full URL for an email.
+
+    Tasks run on the worker with no request to hang ``build_absolute_uri`` off,
+    so the host comes from the Site and the scheme from allauth's setting.
+    """
+    protocol = getattr(settings, "ACCOUNT_DEFAULT_HTTP_PROTOCOL", "https")
+    return f"{protocol}://{Site.objects.get_current().domain}{reverse(url_name)}"
 
 
 def send_shift_reminders():
@@ -31,13 +43,30 @@ def send_shift_reminders():
         shift__starts_at__lte=window_end,
     ).select_related("user", "shift", "shift__role")
 
+    # Same for every recipient, so build them once rather than per signup.
+    my_shifts_url = absolute_url("volunteers:my_shifts")
+    handbook_url = settings.VOLUNTEER_HANDBOOK_URL
+    contact_email = settings.VOLUNTEER_CONTACT_EMAIL
+
     sent = 0
     for signup in signups:
         email = signup.user.email
         if not email:
             continue
 
-        body = render_to_string("volunteers/email/shift_reminder.txt", {"signup": signup, "shift": signup.shift})
+        body = render_to_string(
+            "volunteers/email/shift_reminder.txt",
+            {
+                "signup": signup,
+                "shift": signup.shift,
+                "my_shifts_url": my_shifts_url,
+                # The role's own guide when it has one; the general handbook is
+                # the fallback so the email is never left without a link.
+                "role_documentation_url": signup.shift.role.documentation_url,
+                "handbook_url": handbook_url,
+                "contact_email": contact_email,
+            },
+        )
         send_mail(
             subject=f"Reminder: your DjangoCon US volunteer shift “{signup.shift.title}”",
             message=body,

--- a/volunteers/templates/volunteers/email/shift_reminder.txt
+++ b/volunteers/templates/volunteers/email/shift_reminder.txt
@@ -6,11 +6,23 @@ This is a friendly reminder about your upcoming DjangoCon US volunteer shift:
   {{ shift.starts_at|date:"l, F j" }} from {{ shift.starts_at|date:"g:i A" }} to {{ shift.ends_at|date:"g:i A" }}
 {% if shift.location %}  Location: {{ shift.location }}
 {% endif %}
+{% if role_documentation_url %}What this role involves:
+
+  {{ role_documentation_url }}
+{% elif handbook_url %}The volunteer handbook:
+
+  {{ handbook_url }}
+{% endif %}
+Need to make a change? You can review or cancel your shifts here:
+
+  {{ my_shifts_url }}
+
 Thanks so much for helping out! If you can no longer make it, please cancel your
 signup so someone else can fill the spot.
 
 — The DjangoCon US Team
 
 --
-Questions? Reply to this email and we'll help you out.
-DjangoCon US is organized by DEFNA, the Django Events Foundation North America.
+{% if contact_email %}Questions? Email {{ contact_email }} and we'll help you out.
+{% else %}Questions? Reply to this email and we'll help you out.
+{% endif %}DjangoCon US is organized by DEFNA, the Django Events Foundation North America.

--- a/volunteers/tests/test_shift_reminder_content.py
+++ b/volunteers/tests/test_shift_reminder_content.py
@@ -1,0 +1,88 @@
+"""The reminder has to tell a volunteer where to go next (#133).
+
+Rachell's ask: every volunteer should get the handbook for the role they signed
+up for, and a link to where they can change their shifts. The reminder is the
+one email they reliably receive, so it carries both.
+"""
+
+import datetime
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from django.core import mail
+from django.utils import timezone
+
+from volunteers.models import Role, Shift, VolunteerSignup
+from volunteers.tasks import send_shift_reminders
+
+User = get_user_model()
+
+HANDBOOK = "https://example.com/general-handbook"
+ROLE_DOC = "https://example.com/handbook#registration-desk"
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+
+
+@pytest.fixture
+def site(db):
+    site = Site.objects.get_current()
+    site.domain = "automation.defna.org"
+    site.save()
+    Site.objects.clear_cache()
+    return site
+
+
+def make_signup(user, *, documentation_url=""):
+    role = Role.objects.create(name="Registration Desk", documentation_url=documentation_url)
+    start = timezone.now() + datetime.timedelta(hours=2)
+    shift = Shift.objects.create(
+        role=role, title="Test Shift", starts_at=start, ends_at=start + datetime.timedelta(hours=2)
+    )
+    return VolunteerSignup.objects.create(shift=shift, user=user)
+
+
+@pytest.mark.django_db
+class TestShiftReminderContent:
+    def test_links_to_the_page_where_shifts_can_be_changed(self, user, site, settings):
+        settings.VOLUNTEER_HANDBOOK_URL = HANDBOOK
+        make_signup(user)
+
+        assert send_shift_reminders() == 1
+        assert "https://automation.defna.org/volunteers/mine/" in mail.outbox[0].body
+
+    def test_uses_the_roles_own_documentation_when_it_has_some(self, user, site, settings):
+        settings.VOLUNTEER_HANDBOOK_URL = HANDBOOK
+        make_signup(user, documentation_url=ROLE_DOC)
+
+        assert send_shift_reminders() == 1
+        body = mail.outbox[0].body
+        assert ROLE_DOC in body
+        # The role-specific guide replaces the general handbook rather than
+        # sitting alongside it — two links compete for the same click.
+        assert HANDBOOK not in body
+
+    def test_falls_back_to_the_general_handbook(self, user, site, settings):
+        settings.VOLUNTEER_HANDBOOK_URL = HANDBOOK
+        make_signup(user, documentation_url="")
+
+        assert send_shift_reminders() == 1
+        assert HANDBOOK in mail.outbox[0].body
+
+    def test_survives_a_role_and_handbook_with_no_links_at_all(self, user, site, settings):
+        settings.VOLUNTEER_HANDBOOK_URL = ""
+        make_signup(user, documentation_url="")
+
+        assert send_shift_reminders() == 1
+        # No handbook anywhere, but the volunteer still gets the shifts page.
+        assert "https://automation.defna.org/volunteers/mine/" in mail.outbox[0].body
+
+    def test_contact_email_is_used_when_configured(self, user, site, settings):
+        settings.VOLUNTEER_CONTACT_EMAIL = "volunteers@djangocon.us"
+        make_signup(user)
+
+        assert send_shift_reminders() == 1
+        assert "volunteers@djangocon.us" in mail.outbox[0].body


### PR DESCRIPTION
Part of #133 — the reminder half.

Rachell's ask: volunteers should get the handbook **for the role they signed up for**, plus a link to where they can change their shifts. The shift reminder is the one email they reliably receive, so it now carries both.

## What changed

```
What this role involves:

  https://example.com/handbook#registration-desk

Need to make a change? You can review or cancel your shifts here:

  https://automation.defna.org/volunteers/mine/
```

- The role's own `documentation_url` is used when set, falling back to `VOLUNTEER_HANDBOOK_URL` — so the email is never left without a guide. The two never appear together; they'd compete for the same click.
- The footer now uses `VOLUNTEER_CONTACT_EMAIL` when configured (`volunteers@djangocon.us` in production), otherwise the existing "reply to this email".
- URLs come from the Site framework — the worker has no request to `build_absolute_uri` from.
- Preview at `/staff/emails/shift-reminder/` updated to match.

## Note on the branding test

`test_shift_reminder_is_branded` asserted the domain never appears in the reminder body. A "manage your shifts" link necessarily contains it, so it now passes `allow_domain_in_body=True` — the same allowance the sign-in email already had. The branding assertions themselves are unchanged.

## Testing

- 5 new tests covering: the shifts link, role doc preferred over handbook, handbook fallback, neither configured, and the contact email
- Full suite: **329 passed**
- `just lint`: clean

## Not covered

#133 also asks for an email **at signup time**. This PR does not add one — the reminder only fires within 24h of a shift, so someone signing up weeks ahead still waits. Left for a follow-up.