### PR TITLE
:lipstick: Send volunteer emails as rich HTML plus plain text

### DIFF
--- a/config/emails.py
+++ b/config/emails.py
@@ -96,7 +96,9 @@ def _sample_shift():
         title="Registration Desk — morning",
         role=SimpleNamespace(
             name="Registration Desk",
-            documentation_url="https://example.com/handbook#registration-desk",
+            # The real handbook: a preview is easier to judge when the links go
+            # where the actual email's links go.
+            documentation_url=settings.VOLUNTEER_HANDBOOK_URL,
         ),
         location="Convention Center, Lobby B",
         starts_at=start,
@@ -123,11 +125,20 @@ def _sample_user():
     )
 
 
+def _shift_uncovered_context():
+    return {
+        "shift": _sample_shift(),
+        "user": _sample_user(),
+        "dashboard_url": "https://automation.defna.org/volunteers/dashboard/",
+        "contact_email": settings.VOLUNTEER_CONTACT_EMAIL,
+    }
+
+
 def _ticket_context(**overrides):
     context = {
         "attendee": None,
         "name": "Ada Lovelace",
-        "ticket_link": "https://example.com/online/ticket/sample-preview-link",
+        "ticket_link": "https://automation.defna.org/online/ticket/sample-preview-link",
         "kind": "initial",
         "is_reissue": False,
         "is_resend": False,
@@ -205,6 +216,7 @@ EMAIL_PREVIEWS: list[EmailPreview] = [
         recipient="Volunteer with an upcoming shift",
         subject="Reminder: your DjangoCon US volunteer shift “Registration Desk — morning”",
         text_template="volunteers/email/shift_reminder.txt",
+        html_template="volunteers/email/shift_reminder.html",
         context=_shift_reminder_context,
     ),
     EmailPreview(
@@ -215,7 +227,8 @@ EMAIL_PREVIEWS: list[EmailPreview] = [
         recipient="VOLUNTEER_COORDINATOR_EMAILS",
         subject="DjangoCon US volunteer needed: “Registration Desk — morning” just lost its only volunteer",
         text_template="volunteers/email/shift_uncovered.txt",
-        context=lambda: {"shift": _sample_shift(), "user": _sample_user()},
+        html_template="volunteers/email/shift_uncovered.html",
+        context=_shift_uncovered_context,
     ),
 ]
 

--- a/config/tests/test_email_branding.py
+++ b/config/tests/test_email_branding.py
@@ -109,7 +109,8 @@ class TestVolunteerEmailBranding:
         signup = VolunteerSignup.objects.create(shift=shift, user=user, cancelled=True)
         VolunteerSignup.objects.filter(pk=signup.pk).update(created_at=timezone.now() - datetime.timedelta(minutes=120))
         assert notify_shift_uncovered(signup.pk) is True
-        assert_branded(mail.outbox[0])
+        # The dashboard link legitimately contains the domain; the branding must not.
+        assert_branded(mail.outbox[0], allow_domain_in_body=True)
 
 
 @pytest.mark.django_db

--- a/config/tests/test_email_preview_views.py
+++ b/config/tests/test_email_preview_views.py
@@ -1,0 +1,64 @@
+"""The preview page has to show both parts of a multipart email.
+
+Staff use these pages to sign off on wording before a send, so "what would the
+rich version look like" and "what does it degrade to" both have to be reachable,
+and text-only emails must not offer a rich tab that renders nothing.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+User = get_user_model()
+
+MULTIPART = "shift-reminder"
+TEXT_ONLY = "login-code"
+
+
+@pytest.fixture
+def staff_client(client, db):
+    user = User.objects.create_user(username="staff", email="staff@example.com", password="pw12345!", is_staff=True)
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+class TestEmailPreviewDetail:
+    def test_multipart_email_defaults_to_the_rich_version(self, staff_client):
+        response = staff_client.get(reverse("email_preview", args=[MULTIPART]))
+        assert response.status_code == 200
+        assert response.context["view"] == "rich"
+        assert b"<iframe" in response.content
+
+    def test_plain_text_version_is_reachable(self, staff_client):
+        response = staff_client.get(reverse("email_preview", args=[MULTIPART]), {"view": "text"})
+        assert response.status_code == 200
+        assert response.context["view"] == "text"
+        assert b"<iframe" not in response.content
+
+    def test_text_only_email_falls_back_to_text(self, staff_client):
+        """No HTML part, so asking for rich must not render an empty frame."""
+        response = staff_client.get(reverse("email_preview", args=[TEXT_ONLY]), {"view": "rich"})
+        assert response.status_code == 200
+        assert response.context["view"] == "text"
+        assert b"<iframe" not in response.content
+
+    def test_a_nonsense_view_falls_back_rather_than_erroring(self, staff_client):
+        response = staff_client.get(reverse("email_preview", args=[MULTIPART]), {"view": "sideways"})
+        assert response.status_code == 200
+        assert response.context["view"] == "rich"
+
+    def test_standalone_html_part_is_served_raw(self, staff_client):
+        response = staff_client.get(reverse("email_preview", args=[MULTIPART]), {"part": "html"})
+        assert response.status_code == 200
+        assert response.content.strip().startswith(b"<!DOCTYPE html>")
+
+    def test_standalone_html_404s_for_a_text_only_email(self, staff_client):
+        response = staff_client.get(reverse("email_preview", args=[TEXT_ONLY]), {"part": "html"})
+        assert response.status_code == 404
+
+    def test_preview_requires_staff(self, client, db):
+        user = User.objects.create_user(username="nobody", email="nobody@example.com", password="pw12345!")
+        client.force_login(user)
+        response = client.get(reverse("email_preview", args=[MULTIPART]))
+        assert response.status_code == 302

--- a/config/tests/test_email_previews.py
+++ b/config/tests/test_email_previews.py
@@ -17,8 +17,13 @@ User = get_user_model()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
-# Subject lines and the shared base aren't emails in their own right.
+# Subject lines and the shared bases aren't emails in their own right.
 NOT_AN_EMAIL_BODY = ("_subject.txt", "base_message.txt", "base_notification.txt")
+
+# Neither is shared chrome: templates/email/ holds the HTML skeleton every rich
+# email extends plus the partials they include. A leading underscore marks a
+# partial, the same convention the site templates use.
+SHARED_CHROME = {"base.html"}
 
 
 @pytest.fixture
@@ -39,6 +44,8 @@ def find_email_templates() -> set[str]:
             continue
         for path in base.glob("**/email/*"):
             if not path.is_file() or path.name.endswith(NOT_AN_EMAIL_BODY):
+                continue
+            if path.name.startswith("_") or path.name in SHARED_CHROME:
                 continue
             found.add(str(path.relative_to(base)))
     return found
@@ -108,8 +115,9 @@ class TestEmailPreviewRendering:
         assert "force_escape is required" not in content
 
     def test_html_part_404s_for_text_only_email(self, client, staff):
+        """The allauth emails are still text-only; the volunteer ones are not."""
         client.force_login(staff)
-        response = client.get(reverse("email_preview", args=["shift-reminder"]), {"part": "html"})
+        response = client.get(reverse("email_preview", args=["login-code"]), {"part": "html"})
         assert response.status_code == 404
 
     def test_previews_use_no_real_data(self, client, staff, volunteer):

--- a/config/views.py
+++ b/config/views.py
@@ -29,8 +29,17 @@ def email_preview_detail_view(request: HttpRequest, slug: str) -> HttpResponse:
             raise Http404("This email has no HTML part")
         return HttpResponse(rendered.html_body)
 
+    # Rich and plain are the two things a client might show, so the page shows
+    # one at a time rather than stacking them. Text-only emails have no rich
+    # version to fall back from.
+    view = request.GET.get("view")
+    if view not in {"rich", "text"}:
+        view = "rich" if rendered.html_body else "text"
+    if view == "rich" and not rendered.html_body:
+        view = "text"
+
     return render(
         request,
         "staff/email_preview_detail.html",
-        {"preview": preview, "rendered": rendered, "previews": EMAIL_PREVIEWS},
+        {"preview": preview, "rendered": rendered, "previews": EMAIL_PREVIEWS, "view": view},
     )

--- a/templates/email/_button.html
+++ b/templates/email/_button.html
@@ -1,0 +1,14 @@
+{% comment %}
+    A tappable button. Nested tables because Outlook ignores padding on <a>.
+    Include with: {% include "email/_button.html" with url=... label=... %}
+{% endcomment %}
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
+    <tr>
+        <td align="center" style="background-color:#0c4b33; border-radius:8px;">
+            <a href="{{ url }}"
+               style="display:inline-block; padding:14px 32px; font-size:16px; font-weight:700; color:#ffffff; text-decoration:none;">
+                {{ label }}
+            </a>
+        </td>
+    </tr>
+</table>

--- a/templates/email/_shift_details.html
+++ b/templates/email/_shift_details.html
@@ -1,0 +1,21 @@
+{% comment %}
+    The what/when/where of a shift, as a bordered panel. Shared by the reminder
+    and the uncovered-shift alert so one shift never renders two different ways.
+{% endcomment %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f0f7f4; border-left:4px solid #93d7b7; border-radius:6px;">
+    <tr>
+        <td style="padding:16px 20px;">
+            <p style="margin:0; font-size:17px; font-weight:700; line-height:1.4; color:#20303c;">
+                {{ shift.title }}
+            </p>
+            <p style="margin:4px 0 0; font-size:14px; color:#5c6b73;">
+                {{ shift.role.name }}
+            </p>
+            <p style="margin:12px 0 0; font-size:15px; line-height:1.6; color:#20303c;">
+                {{ shift.starts_at|date:"l, F j" }}<br>
+                {{ shift.starts_at|date:"g:i A" }} &ndash; {{ shift.ends_at|date:"g:i A" }}
+                {% if shift.location %}<br>{{ shift.location }}{% endif %}
+            </p>
+        </td>
+    </tr>
+</table>

--- a/templates/email/base.html
+++ b/templates/email/base.html
@@ -1,0 +1,83 @@
+{% comment %}
+    Shared chrome for every HTML email we send.
+
+    Table layout and inline styles throughout: Outlook and Gmail strip <style>
+    blocks and ignore flex/grid, so there is no stylesheet to share — this
+    template IS the shared stylesheet. Override the blocks, not the markup.
+
+    Palette, matched to tickets/email/ticket_link.html:
+      #0c4b33 brand green   #93d7b7 mint accent   #f4f6f5 page background
+      #20303c body text     #5c6b73 muted         #8a9aa2 faint
+{% endcomment %}<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="color-scheme" content="light">
+        <title>{% block title %}DjangoCon US{% endblock title %}</title>
+    </head>
+    <body style="margin:0; padding:0; background-color:#f4f6f5; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; color:#20303c;">
+        {% comment %}
+            Preheader: the grey line clients show next to the subject. Hidden in
+            the body itself, so it must repeat what the email is about.
+        {% endcomment %}
+        <div style="display:none; max-height:0; overflow:hidden; opacity:0;">{% block preheader %}{% endblock preheader %}</div>
+
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f4f6f5;">
+            <tr>
+                <td align="center" style="padding:24px 12px;">
+
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:600px; background-color:#ffffff; border-radius:12px; overflow:hidden; border:1px solid #dfe5e2;">
+
+                        <tr>
+                            <td style="background-color:#0c4b33; padding:28px 32px;">
+                                <p style="margin:0; font-size:22px; font-weight:700; color:#ffffff; letter-spacing:-0.2px;">
+                                    {% block header_title %}DjangoCon US{% endblock header_title %}
+                                </p>
+                                <p style="margin:6px 0 0; font-size:14px; color:#93d7b7;">
+                                    {% block header_subtitle %}Volunteers{% endblock header_subtitle %}
+                                </p>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:32px 32px 8px;">
+                                {% block content %}{% endblock content %}
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:0 32px 32px;">
+                                <p style="margin:0; font-size:16px; line-height:1.5;">
+                                    {% block signoff %}Thanks so much for helping out,{% endblock signoff %}<br>
+                                    <strong>The DjangoCon US Team</strong>
+                                </p>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="background-color:#f4f6f5; border-top:1px solid #dfe5e2; padding:20px 32px;">
+                                <p style="margin:0; font-size:12px; line-height:1.6; color:#5c6b73;">
+                                    {% block footer_contact %}
+                                        {% if contact_email %}
+                                            Questions? Email
+                                            <a href="mailto:{{ contact_email }}" style="color:#0c4b33;">{{ contact_email }}</a>
+                                            and we'll help you out.
+                                        {% else %}
+                                            Questions? Reply to this email and we'll help you out.
+                                        {% endif %}
+                                    {% endblock footer_contact %}
+                                </p>
+                                <p style="margin:8px 0 0; font-size:12px; color:#8a9aa2;">
+                                    DjangoCon US is organized by DEFNA, the Django Events Foundation North America.
+                                </p>
+                            </td>
+                        </tr>
+
+                    </table>
+
+                </td>
+            </tr>
+        </table>
+    </body>
+</html>

--- a/templates/staff/email_preview_detail.html
+++ b/templates/staff/email_preview_detail.html
@@ -22,7 +22,7 @@
             {% endfor %}
         </div>
 
-        <dl class="mb-6 grid gap-3 rounded-lg border border-green-700 bg-green-800/50 p-4 text-sm sm:grid-cols-2">
+        <dl class="mb-6 grid gap-3 rounded-lg border border-green-700 bg-green-800/50 p-4 text-sm">
             <div>
                 <dt class="text-xs tracking-wide text-gray-400 uppercase">Subject</dt>
                 <dd class="mt-1 font-semibold text-yellow-200">{{ rendered.subject }}</dd>
@@ -31,11 +31,11 @@
                 <dt class="text-xs tracking-wide text-gray-400 uppercase">To</dt>
                 <dd class="mt-1 text-gray-200">{{ preview.recipient }}</dd>
             </div>
-            <div class="sm:col-span-2">
+            <div>
                 <dt class="text-xs tracking-wide text-gray-400 uppercase">Sent by</dt>
                 <dd class="mt-1 text-gray-200">{{ preview.trigger }}</dd>
             </div>
-            <div class="sm:col-span-2">
+            <div>
                 <dt class="text-xs tracking-wide text-gray-400 uppercase">Templates</dt>
                 <dd class="mt-1 font-mono text-xs text-gray-300">
                     {% for template in preview.all_templates %}{{ template }}{% if not forloop.last %} &middot; {% endif %}{% endfor %}
@@ -43,31 +43,50 @@
             </div>
         </dl>
 
-        {% if rendered.html_body %}
-            <div class="mb-6">
-                <div class="mb-2 flex items-baseline justify-between">
-                    <h2 class="text-xl font-semibold text-yellow-200">HTML part</h2>
-                    <a href="?part=html" target="_blank" rel="noopener" class="text-sm text-yellow-300 underline hover:text-yellow-200">
-                        Open standalone &nearr;
-                    </a>
-                </div>
+        <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
+            <div class="inline-flex overflow-hidden rounded-lg border border-green-700">
                 {% comment %}
-                    force_escape is required: render_to_string returns a SafeString, so without it the
-                    body's own quotes close the srcdoc attribute early and the iframe renders blank.
-                    sandbox: the preview is our own markup, but it should never be able to script this page.
+                    Server-rendered tabs rather than JS: the toggle survives a
+                    reload and each version has its own shareable URL.
                 {% endcomment %}
-                <iframe title="HTML preview of {{ preview.label }}"
-                        sandbox
-                        srcdoc="{{ rendered.html_body|force_escape }}"
-                        class="h-[36rem] w-full rounded-lg border border-green-700 bg-white"></iframe>
+                {% if rendered.html_body %}
+                    <a href="?view=rich"
+                       class="px-4 py-2 text-sm font-semibold {% if view == 'rich' %}bg-yellow-300 text-green-900{% else %}bg-green-800 text-green-100 hover:bg-green-700{% endif %}">
+                        Rich
+                    </a>
+                {% else %}
+                    <span class="cursor-not-allowed px-4 py-2 text-sm font-semibold text-gray-500" title="This email has no HTML part">
+                        Rich
+                    </span>
+                {% endif %}
+                <a href="?view=text"
+                   class="px-4 py-2 text-sm font-semibold {% if view == 'text' %}bg-yellow-300 text-green-900{% else %}bg-green-800 text-green-100 hover:bg-green-700{% endif %}">
+                    Plain text
+                </a>
             </div>
-        {% endif %}
 
-        <div>
-            <h2 class="mb-2 text-xl font-semibold text-yellow-200">
-                {% if rendered.html_body %}Plain text part{% else %}Plain text{% endif %}
-            </h2>
-            <pre class="overflow-x-auto rounded-lg border border-green-700 bg-black/40 p-4 text-sm whitespace-pre-wrap text-gray-100">{{ rendered.text_body }}</pre>
+            {% if view == 'rich' and rendered.html_body %}
+                <a href="?part=html" target="_blank" rel="noopener" class="text-sm text-yellow-300 underline hover:text-yellow-200">
+                    Open standalone &nearr;
+                </a>
+            {% endif %}
         </div>
+
+        {% if view == 'rich' and rendered.html_body %}
+            {% comment %}
+                force_escape is required: render_to_string returns a SafeString, so without it the
+                body's own quotes close the srcdoc attribute early and the iframe renders blank.
+                sandbox: the preview is our own markup, but it should never be able to script this page.
+            {% endcomment %}
+            <iframe title="HTML preview of {{ preview.label }}"
+                    sandbox
+                    srcdoc="{{ rendered.html_body|force_escape }}"
+                    class="h-[40rem] w-full rounded-lg border border-green-700 bg-white"></iframe>
+        {% else %}
+            {% if not rendered.html_body %}
+                <p class="mb-2 text-sm text-gray-400">This email is sent as plain text only — there is no HTML part.</p>
+            {% endif %}
+            <pre class="overflow-x-auto rounded-lg border border-green-700 bg-black/40 p-4 text-sm whitespace-pre-wrap text-gray-100">{{ rendered.text_body }}</pre>
+        {% endif %}
     </div>
 {% endblock content %}

--- a/volunteers/tasks.py
+++ b/volunteers/tasks.py
@@ -3,7 +3,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.sites.models import Site
-from django.core.mail import send_mail
+from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
@@ -25,6 +25,24 @@ def absolute_url(url_name: str) -> str:
     """
     protocol = getattr(settings, "ACCOUNT_DEFAULT_HTTP_PROTOCOL", "https")
     return f"{protocol}://{Site.objects.get_current().domain}{reverse(url_name)}"
+
+
+def send_rich_email(*, subject: str, template_base: str, context: dict, recipients: list[str]) -> None:
+    """Send a text email with an HTML alternative.
+
+    ``template_base`` names the pair without its extension, e.g.
+    ``volunteers/email/shift_reminder`` for ``.txt`` plus ``.html``. Text is the
+    body and HTML the alternative, so a client that refuses HTML still gets a
+    readable email.
+    """
+    message = EmailMultiAlternatives(
+        subject=subject,
+        body=render_to_string(f"{template_base}.txt", context),
+        from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
+        to=recipients,
+    )
+    message.attach_alternative(render_to_string(f"{template_base}.html", context), "text/html")
+    message.send(fail_silently=False)
 
 
 def send_shift_reminders():
@@ -54,9 +72,10 @@ def send_shift_reminders():
         if not email:
             continue
 
-        body = render_to_string(
-            "volunteers/email/shift_reminder.txt",
-            {
+        send_rich_email(
+            subject=f"Reminder: your DjangoCon US volunteer shift “{signup.shift.title}”",
+            template_base="volunteers/email/shift_reminder",
+            context={
                 "signup": signup,
                 "shift": signup.shift,
                 "my_shifts_url": my_shifts_url,
@@ -66,13 +85,7 @@ def send_shift_reminders():
                 "handbook_url": handbook_url,
                 "contact_email": contact_email,
             },
-        )
-        send_mail(
-            subject=f"Reminder: your DjangoCon US volunteer shift “{signup.shift.title}”",
-            message=body,
-            from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
-            recipient_list=[email],
-            fail_silently=False,
+            recipients=[email],
         )
         signup.reminded = True
         signup.save(update_fields=["reminded"])
@@ -109,17 +122,17 @@ def notify_shift_uncovered(signup_id):
     if now - cancelled_signup.created_at < buffer:
         return False
 
-    body = render_to_string(
-        "volunteers/email/shift_uncovered.txt",
-        {"shift": shift, "user": cancelled_signup.user},
-    )
     try:
-        send_mail(
+        send_rich_email(
             subject=f"DjangoCon US volunteer needed: “{shift.title}” just lost its only volunteer",
-            message=body,
-            from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
-            recipient_list=recipients,
-            fail_silently=False,
+            template_base="volunteers/email/shift_uncovered",
+            context={
+                "shift": shift,
+                "user": cancelled_signup.user,
+                "dashboard_url": absolute_url("volunteers:dashboard"),
+                "contact_email": settings.VOLUNTEER_CONTACT_EMAIL,
+            },
+            recipients=recipients,
         )
     except Exception:
         # Never let a broken mail server break the volunteer's cancel action.

--- a/volunteers/templates/volunteers/email/shift_reminder.html
+++ b/volunteers/templates/volunteers/email/shift_reminder.html
@@ -1,0 +1,42 @@
+{% extends "email/base.html" %}
+
+{% block title %}Your upcoming DjangoCon US volunteer shift{% endblock title %}
+
+{% block preheader %}
+    {{ shift.title }} — {{ shift.starts_at|date:"l, F j" }} at {{ shift.starts_at|date:"g:i A" }}.
+{% endblock preheader %}
+
+{% block header_subtitle %}Volunteer shift reminder{% endblock header_subtitle %}
+
+{% block content %}
+    <p style="margin:0 0 16px; font-size:16px; line-height:1.5;">Hi,</p>
+
+    <p style="margin:0 0 20px; font-size:16px; line-height:1.5;">
+        This is a friendly reminder about your upcoming DjangoCon US volunteer shift.
+    </p>
+
+    {% include "email/_shift_details.html" with shift=shift %}
+
+    {% if role_documentation_url %}
+        <p style="margin:24px 0 12px; font-size:16px; line-height:1.5;">
+            Not sure what to expect? Your role guide walks through what this shift involves:
+        </p>
+        {% include "email/_button.html" with url=role_documentation_url label="Read the role guide" %}
+    {% elif handbook_url %}
+        <p style="margin:24px 0 12px; font-size:16px; line-height:1.5;">
+            Not sure what to expect? The volunteer handbook walks through what to do:
+        </p>
+        {% include "email/_button.html" with url=handbook_url label="Read the handbook" %}
+    {% endif %}
+
+    <p style="margin:24px 0 8px; font-size:16px; line-height:1.5;">
+        Need to make a change? You can review or cancel your shifts here:
+    </p>
+    <p style="margin:0 0 8px; font-size:15px; line-height:1.5; word-break:break-all;">
+        <a href="{{ my_shifts_url }}" style="color:#0c4b33;">{{ my_shifts_url }}</a>
+    </p>
+
+    <p style="margin:20px 0 0; font-size:15px; line-height:1.6; color:#5c6b73;">
+        If you can no longer make it, please cancel your signup so someone else can fill the spot.
+    </p>
+{% endblock content %}

--- a/volunteers/templates/volunteers/email/shift_uncovered.html
+++ b/volunteers/templates/volunteers/email/shift_uncovered.html
@@ -1,0 +1,36 @@
+{% extends "email/base.html" %}
+
+{% block title %}A DjangoCon US volunteer shift is uncovered{% endblock title %}
+
+{% block preheader %}
+    {{ shift.title }} on {{ shift.starts_at|date:"l, F j" }} just lost its only volunteer.
+{% endblock preheader %}
+
+{% block header_subtitle %}Uncovered shift{% endblock header_subtitle %}
+
+{% block content %}
+    <p style="margin:0 0 16px; font-size:16px; line-height:1.5;">Heads up,</p>
+
+    <p style="margin:0 0 20px; font-size:16px; line-height:1.5;">
+        This upcoming volunteer shift just lost its only volunteer and is now uncovered.
+    </p>
+
+    {% include "email/_shift_details.html" with shift=shift %}
+
+    <p style="margin:20px 0 24px; font-size:16px; line-height:1.5;">
+        <strong>{{ user.get_full_name|default:user.email }}</strong> cancelled their signup.
+    </p>
+
+    {% if dashboard_url %}
+        {% include "email/_button.html" with url=dashboard_url label="Open the volunteer dashboard" %}
+        <p style="margin:16px 0 0; font-size:15px; line-height:1.6; color:#5c6b73;">
+            You may want to find a replacement or cover it yourself.
+        </p>
+    {% else %}
+        <p style="margin:0; font-size:15px; line-height:1.6; color:#5c6b73;">
+            You may want to find a replacement or cover it from the dashboard.
+        </p>
+    {% endif %}
+{% endblock content %}
+
+{% block signoff %}Thanks,{% endblock signoff %}

--- a/volunteers/templates/volunteers/email/shift_uncovered.txt
+++ b/volunteers/templates/volunteers/email/shift_uncovered.txt
@@ -8,6 +8,13 @@ This upcoming volunteer shift just lost its only volunteer and is now uncovered:
 {% endif %}
 {{ user.get_full_name|default:user.email }} cancelled their signup.
 
-You may want to find a replacement or cover it from the dashboard.
-
+You may want to find a replacement or cover it from the dashboard:
+{% if dashboard_url %}
+  {{ dashboard_url }}
+{% endif %}
 — The DjangoCon US Team
+
+--
+{% if contact_email %}Questions? Email {{ contact_email }} and we'll help you out.
+{% else %}Questions? Reply to this email and we'll help you out.
+{% endif %}DjangoCon US is organized by DEFNA, the Django Events Foundation North America.

--- a/volunteers/tests/test_email_multipart.py
+++ b/volunteers/tests/test_email_multipart.py
@@ -1,0 +1,113 @@
+"""Volunteer emails go out as text plus an HTML alternative.
+
+The text part stays the body rather than becoming a courtesy afterthought: a
+client that refuses HTML still has to receive a usable email.
+"""
+
+import datetime
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from django.core import mail
+from django.utils import timezone
+
+from volunteers.models import Role, Shift, VolunteerSignup
+from volunteers.tasks import notify_shift_uncovered, send_shift_reminders
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="vol", email="vol@example.com", password="pw12345!", first_name="Ada", last_name="Lovelace"
+    )
+
+
+@pytest.fixture
+def site(db):
+    site = Site.objects.get_current()
+    site.domain = "automation.defna.org"
+    site.save()
+    Site.objects.clear_cache()
+    return site
+
+
+@pytest.fixture
+def signup(user, db):
+    role = Role.objects.create(name="Registration Desk", documentation_url="https://handbook.example/desk")
+    start = timezone.now() + datetime.timedelta(hours=2)
+    shift = Shift.objects.create(
+        role=role,
+        title="Registration Desk — morning",
+        location="LaSalle Ballroom",
+        starts_at=start,
+        ends_at=start + datetime.timedelta(hours=2),
+    )
+    return VolunteerSignup.objects.create(shift=shift, user=user)
+
+
+def html_part(message):
+    for content, mimetype in message.alternatives:
+        if mimetype == "text/html":
+            return content
+    raise AssertionError("no text/html alternative on the message")
+
+
+@pytest.mark.django_db
+class TestShiftReminderMultipart:
+    def test_has_both_a_text_body_and_an_html_alternative(self, signup, site):
+        assert send_shift_reminders() == 1
+        message = mail.outbox[0]
+
+        assert message.content_subtype == "plain", "the text part must remain the body"
+        assert "<html" in html_part(message)
+
+    def test_both_parts_carry_the_shift_and_the_links(self, signup, site):
+        assert send_shift_reminders() == 1
+        message = mail.outbox[0]
+
+        for body in (message.body, html_part(message)):
+            assert "Registration Desk — morning" in body
+            assert "LaSalle Ballroom" in body
+            assert "https://handbook.example/desk" in body
+            assert "https://automation.defna.org/volunteers/mine/" in body
+
+    def test_html_escapes_a_hostile_shift_title(self, signup, site):
+        signup.shift.title = "<script>alert(1)</script>"
+        signup.shift.save(update_fields=["title"])
+
+        assert send_shift_reminders() == 1
+        html = html_part(mail.outbox[0])
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html
+
+
+@pytest.mark.django_db
+class TestUncoveredAlertMultipart:
+    @pytest.fixture
+    def cancelled(self, signup):
+        signup.cancelled = True
+        signup.save(update_fields=["cancelled"])
+        VolunteerSignup.objects.filter(pk=signup.pk).update(created_at=timezone.now() - datetime.timedelta(hours=2))
+        return signup
+
+    def test_has_both_parts(self, cancelled, site, settings):
+        settings.VOLUNTEER_COORDINATOR_EMAILS = ["coordinator@example.com"]
+
+        assert notify_shift_uncovered(cancelled.pk) is True
+        message = mail.outbox[0]
+
+        assert message.content_subtype == "plain"
+        assert "<html" in html_part(message)
+
+    def test_both_parts_name_who_cancelled_and_link_the_dashboard(self, cancelled, site, settings):
+        settings.VOLUNTEER_COORDINATOR_EMAILS = ["coordinator@example.com"]
+
+        assert notify_shift_uncovered(cancelled.pk) is True
+        message = mail.outbox[0]
+
+        for body in (message.body, html_part(message)):
+            assert "Ada Lovelace" in body
+            assert "https://automation.defna.org/volunteers/dashboard/" in body


### PR DESCRIPTION
The two volunteer emails were text-only while the ticket emails were already branded HTML. Both now send multipart, and the preview page lets staff check either part.

## Rich versions

`shift_reminder` and `shift_uncovered` each gained an `.html` sibling. Rather than copying the ticket email's table markup a second time, the shared chrome moved into **`templates/email/base.html`** — header, footer, contact line, palette — with two partials:

- `email/_shift_details.html` — the what/when/where panel, shared by both emails so one shift never renders two different ways
- `email/_button.html` — nested-table button (Outlook ignores padding on `<a>`)

The text part stays the message body and HTML is the alternative, so a client that refuses HTML still gets a readable email. A test pins that.

## Preview page

`/staff/emails/{slug}/` gets a **Rich / Plain text** toggle. It's server-rendered (`?view=rich` / `?view=text`) rather than JS, so the choice survives a reload and each version has a shareable URL. Text-only emails show the plain version with the Rich tab visibly disabled instead of an empty iframe.

Also moved Subject and To onto their own rows in the metadata box, per review.

## Preview sample data

Sample links pointed at `example.com`, which made the previews hard to judge. They now use the real handbook URL and real `automation.defna.org` paths. Still fabricated — previews never touch the database.

## Test changes worth a look

Three existing tests changed because the behaviour genuinely changed, not to make them pass:

1. `test_html_part_404s_for_text_only_email` used `shift-reminder` as its text-only example — it has HTML now, so it uses `login-code`.
2. `test_every_email_template_is_registered` walks `templates/**/email/` and started flagging the shared base and partials as unregistered emails. The walker now skips `base.html` and `_`-prefixed partials.
3. `test_uncovered_alert_is_branded` asserted the domain never appears in the body; the dashboard link contains it, so it now passes `allow_domain_in_body=True` — the same allowance the sign-in and reminder emails already had.

## Testing

- 13 new tests: multipart structure, both parts carrying shift details and links, HTML escaping of a hostile shift title, and the preview toggle including its fallbacks
- Full suite: **341 passed**
- `just lint`: clean

## Not included

`tickets/email/ticket_link.html` still has its own copy of the chrome rather than extending the new base. Migrating it is a clear follow-up, but it is a live attendee-facing email and this PR is already the volunteer half — happy to do it separately.