### PR TITLE
:lipstick: Stop shift cards printing the role name twice

### DIFF
--- a/volunteers/models.py
+++ b/volunteers/models.py
@@ -52,6 +52,21 @@ class Shift(models.Model):
         return f"{self.title} ({self.starts_at:%a %b %d %H:%M})"
 
     @property
+    def display_title(self):
+        """The title, or blank when it only repeats the role name.
+
+        Shift titles are conventionally "<Role> · <Day> <time>", and the card
+        prints the role, the time and the day right underneath — so showing both
+        stutters ("In-person sprints welcomer · Thu 9:00 AM" above "In-person
+        sprints welcomer · 9:00 AM–11:00 AM"). Titles that say something the
+        role name doesn't, like "Morning Session Manager", still show.
+        """
+        title = self.title.strip()
+        if title.casefold().startswith(self.role.name.casefold()):
+            return ""
+        return title
+
+    @property
     def covered_talks(self):
         return self.talks.order_by("starts_at", "title")
 

--- a/volunteers/templates/volunteers/shift_list.html
+++ b/volunteers/templates/volunteers/shift_list.html
@@ -106,9 +106,9 @@
                                 {% for shift in slot.list %}
                                     <div class="flex flex-col gap-2 p-4 bg-green-900 rounded-lg border {% if shift.id in my_shift_ids %}border-yellow-300{% else %}border-green-700{% endif %} shift-card">
                                         <div>
-                                            <p class="text-lg font-semibold text-yellow-100">{{ shift.title }}</p>
+                                            <p class="text-lg font-semibold text-yellow-100">{{ shift.display_title|default:shift.role.name }}</p>
                                             <p class="text-sm text-green-300">
-                                                {{ shift.role.name }} ·
+                                                {% if shift.display_title %}{{ shift.role.name }} · {% endif %}
                                                 <time datetime="{{ shift.starts_at|date:'c' }}" class="whitespace-nowrap">{{ shift.starts_at|date:"g:i A" }}</time>–<time datetime="{{ shift.ends_at|date:'c' }}" class="whitespace-nowrap">{{ shift.ends_at|date:"g:i A" }}</time>
                                                 {% if shift.location %} · {{ shift.location }}{% endif %}
                                             </p>
@@ -134,7 +134,7 @@
                                             {% if shift.role.documentation_url %}
                                                 <p class="mt-1 text-xs">
                                                     <a href="{{ shift.role.documentation_url }}" target="_blank" rel="noopener" class="text-yellow-300 underline">
-                                                        📄 {{ shift.role.name }} documentation
+                                                        📄 Role documentation
                                                     </a>
                                                 </p>
                                             {% endif %}

--- a/volunteers/tests/test_display_title.py
+++ b/volunteers/tests/test_display_title.py
@@ -1,0 +1,44 @@
+"""Shift cards shouldn't print the role name twice.
+
+Titles are conventionally "<Role> · <Day> <time>" and the card already prints
+the role and the time on its own line, so a title that only repeats the role is
+suppressed. A title that says something extra survives.
+"""
+
+import datetime
+
+import pytest
+from django.utils import timezone
+
+from volunteers.models import Role, Shift
+
+
+def make_shift(role_name, title):
+    role = Role.objects.create(name=role_name)
+    start = timezone.now() + datetime.timedelta(hours=2)
+    return Shift.objects.create(
+        role=role, title=title, starts_at=start, ends_at=start + datetime.timedelta(hours=2)
+    )
+
+
+@pytest.mark.django_db
+class TestDisplayTitle:
+    def test_title_that_only_repeats_the_role_is_suppressed(self):
+        shift = make_shift("In-person sprints welcomer", "In-person sprints welcomer · Thu 9:00 AM")
+        assert shift.display_title == ""
+
+    def test_title_matching_the_role_exactly_is_suppressed(self):
+        shift = make_shift("Swag Bag Stuffing", "Swag Bag Stuffing")
+        assert shift.display_title == ""
+
+    def test_title_that_adds_something_is_kept(self):
+        shift = make_shift("Session Manager", "Morning Session Manager · Mon")
+        assert shift.display_title == "Morning Session Manager · Mon"
+
+    def test_an_unrelated_title_is_kept(self):
+        shift = make_shift("Online Moderator", "Moderator 1")
+        assert shift.display_title == "Moderator 1"
+
+    def test_comparison_ignores_case_and_padding(self):
+        shift = make_shift("Registration Desk", "  registration desk · Sun 2:00 PM  ")
+        assert shift.display_title == ""


### PR DESCRIPTION
Cleanup pass on the shift cards, from the sprint welcomer timeslot.

## The stutter

Both cards said the role name twice and the time three times:

```
In-person sprints welcomer · Thu 9:00 AM        <- card title
In-person sprints welcomer · 9:00 AM–11:00 AM · LaSalle Ballroom
```

...under a group heading that already reads **Thu 9:00 AM**.

Shift titles are conventionally `<Role> · <Day> <time>`, which the detail line directly below already covers. `Shift.display_title` now returns blank when the title merely repeats the role, so the card leads with the role name and the detail line carries just time and location:

```
In-person sprints welcomer
9:00 AM–11:00 AM · LaSalle Ballroom
```

Titles that say something the role doesn't — "Morning Session Manager · Mon", "Moderator 1" — are unaffected and still show, with the role on the line beneath. The role-documentation link was also repeating the role name ("📄 In-person sprints welcomer documentation"); it's now just "📄 Role documentation", since the role is the heading.

## Also fixed, in production data

The In-person role's description had a stray line pasted in from the issue text:

> ...comfortable joining a project.
> **Documentation URL (details in handbook under Sprints)**

That was rendering to volunteers inside "What this role involves", which is why the left card looked longer and messier than the right. Removed directly in production — it's data, not code, so it isn't part of this diff. The Online role was already clean.

## Testing

- 5 new tests for `display_title`: exact match, prefix match, case/padding, and the two shapes that must survive
- Full suite: **346 passed**
- `just lint`: clean