### PR TITLE
:lipstick: Quiet the timeslot badge so the time leads

### DIFF
--- a/volunteers/templates/volunteers/shift_list.html
+++ b/volunteers/templates/volunteers/shift_list.html
@@ -92,13 +92,18 @@
                 <div class="flex flex-col gap-6">
                     {% for slot in time_groups %}
                         <div class="flex flex-col gap-2 border-l-2 border-green-600 pl-4">
-                            <div class="flex flex-wrap items-baseline gap-2">
-                                <h3 class="text-lg font-semibold text-yellow-100">
+                            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                                <h3 class="text-xl font-semibold text-yellow-100">
                                     <time datetime="{{ slot.grouper|date:'c' }}" class="whitespace-nowrap">{{ slot.grouper|date:"g:i A" }}</time>
                                 </h3>
                                 {% if slot.list|length > 1 %}
-                                    <span class="rounded-full bg-yellow-300 px-2 py-0.5 text-xs font-semibold text-green-900">
-                                        {{ slot.list|length }} shifts at this time — sign up for any
+                                    {% comment %}
+                                        Deliberately not yellow. Yellow is the sign-up colour on this page,
+                                        and with this many slots a bright informational pill on every one of
+                                        them competes with the buttons a volunteer is actually hunting for.
+                                    {% endcomment %}
+                                    <span class="rounded-full border border-green-600 bg-green-900/60 px-2.5 py-0.5 text-xs font-medium text-green-200">
+                                        {{ slot.list|length }} shifts — sign up for any
                                     </span>
                                 {% endif %}
                             </div>

--- a/volunteers/tests/test_display_title.py
+++ b/volunteers/tests/test_display_title.py
@@ -16,9 +16,7 @@ from volunteers.models import Role, Shift
 def make_shift(role_name, title):
     role = Role.objects.create(name=role_name)
     start = timezone.now() + datetime.timedelta(hours=2)
-    return Shift.objects.create(
-        role=role, title=title, starts_at=start, ends_at=start + datetime.timedelta(hours=2)
-    )
+    return Shift.objects.create(role=role, title=title, starts_at=start, ends_at=start + datetime.timedelta(hours=2))
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Readability pass on the timeslot heading — no restructuring, since there are a lot of slots and the layout itself works.

## Before

```
2:00 PM  [ 2 shifts at this time — sign up for any ]   <- solid yellow pill
```

Three things worked against scanning:

1. **The pill was yellow** — the same colour as every *Sign up* button on the page. An informational count rendered in the action colour competes with the buttons a volunteer is actually hunting for, and it repeats on every multi-shift slot.
2. **The time was smaller than the pill was loud**, even though the time is the thing you scan by.
3. **"at this time"** restates the heading it sits next to.

## After

```
2:00 PM  ( 2 shifts — sign up for any )   <- bordered green chip
```

- Badge becomes a bordered green chip (`border-green-600`, `bg-green-900/60`, `text-green-200`), so yellow stays reserved for actions.
- Time goes `text-lg` → `text-xl` to anchor the row.
- Label drops "at this time".

## Also in here

`ruff format` on `volunteers/tests/test_display_title.py`. It was untracked when I ran lint before #136, and `pre-commit --all-files` only sees tracked files — so it merged one reformat short. `just lint` is clean now.

## Testing

- Full suite: **346 passed**
- `just lint`: clean