### PR TITLE
:lipstick: Apply the card cleanup to My shifts too

### DIFF
--- a/volunteers/templates/volunteers/my_shifts.html
+++ b/volunteers/templates/volunteers/my_shifts.html
@@ -31,9 +31,9 @@
             {% for signup in signups %}
                 <div class="shift-card flex flex-col gap-2 rounded-lg border border-green-700 bg-green-800 p-4 md:flex-row md:items-center md:justify-between">
                     <div>
-                        <p class="text-lg font-semibold text-yellow-100">{{ signup.shift.title }}</p>
+                        <p class="text-lg font-semibold text-yellow-100">{{ signup.shift.display_title|default:signup.shift.role.name }}</p>
                         <p class="text-sm text-green-300">
-                            {{ signup.shift.role.name }} ·
+                            {% if signup.shift.display_title %}{{ signup.shift.role.name }} · {% endif %}
                             <time datetime="{{ signup.shift.starts_at|date:'c' }}">{{ signup.shift.starts_at|date:"l, F j," }} <span class="whitespace-nowrap">{{ signup.shift.starts_at|date:"g:i A" }}</span></time>–<time datetime="{{ signup.shift.ends_at|date:'c' }}" class="whitespace-nowrap">{{ signup.shift.ends_at|date:"g:i A" }}</time>
                             {% if signup.shift.location %} · {{ signup.shift.location }}{% endif %}
                         </p>
@@ -46,7 +46,7 @@
                         {% if signup.shift.role.documentation_url %}
                             <p class="mt-1 text-xs">
                                 <a href="{{ signup.shift.role.documentation_url }}" target="_blank" rel="noopener" class="text-yellow-300 underline">
-                                    📄 {{ signup.shift.role.name }} documentation
+                                    📄 Role documentation
                                 </a>
                             </p>
                         {% endif %}

--- a/volunteers/tests/test_shift_card_rendering.py
+++ b/volunteers/tests/test_shift_card_rendering.py
@@ -1,0 +1,78 @@
+"""Both pages that draw shift cards have to agree.
+
+The shift list and "my shifts" render the same card from two templates. The
+first fix only landed on the shift list, so the page a volunteer reaches from
+the reminder email kept stuttering. These tests cover both.
+"""
+
+import datetime
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from volunteers.models import Role, Shift, VolunteerSignup
+
+User = get_user_model()
+
+ROLE = "In-person sprints welcomer"
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+
+
+@pytest.fixture
+def shift(db):
+    role = Role.objects.create(name=ROLE, documentation_url="https://handbook.example/sprints")
+    start = timezone.now() + datetime.timedelta(hours=4)
+    return Shift.objects.create(
+        role=role,
+        title=f"{ROLE} · Thu 9:00 AM",
+        location="LaSalle Ballroom",
+        starts_at=start,
+        ends_at=start + datetime.timedelta(hours=2),
+    )
+
+
+@pytest.mark.django_db
+class TestShiftListCard:
+    def test_the_redundant_title_is_not_rendered(self, client, shift):
+        """The role filter legitimately names the role, so target the stutter itself."""
+        content = client.get(reverse("volunteers:shifts")).content.decode()
+        assert shift.title not in content, "the card still prints '<Role> · <Day> <time>' above the role line"
+        assert ROLE in content, "the role name should still head the card"
+
+    def test_the_time_and_place_still_show(self, client, shift):
+        content = client.get(reverse("volunteers:shifts")).content.decode()
+        assert "LaSalle Ballroom" in content
+
+    def test_documentation_link_does_not_repeat_the_role(self, client, shift):
+        content = client.get(reverse("volunteers:shifts")).content.decode()
+        assert "Role documentation" in content
+        assert f"{ROLE} documentation" not in content
+
+
+@pytest.mark.django_db
+class TestMyShiftsCard:
+    @pytest.fixture(autouse=True)
+    def signed_up(self, client, user, shift):
+        VolunteerSignup.objects.create(shift=shift, user=user)
+        client.force_login(user)
+
+    def test_the_redundant_title_is_not_rendered(self, client, shift):
+        content = client.get(reverse("volunteers:my_shifts")).content.decode()
+        assert shift.title not in content, "the card still prints '<Role> · <Day> <time>' above the role line"
+        assert ROLE in content, "the role name should still head the card"
+        assert content.count(ROLE) == 1, "the role name is rendered twice on this page"
+
+    def test_the_time_and_place_still_show(self, client):
+        content = client.get(reverse("volunteers:my_shifts")).content.decode()
+        assert "LaSalle Ballroom" in content
+
+    def test_documentation_link_does_not_repeat_the_role(self, client):
+        content = client.get(reverse("volunteers:my_shifts")).content.decode()
+        assert "Role documentation" in content
+        assert f"{ROLE} documentation" not in content


### PR DESCRIPTION
Follow-up to #136, which fixed the stutter on only one of the two pages that draw shift cards.

`my_shifts.html` renders the same card from its own template and kept printing:

```
In-person sprints welcomer · Thu 9:00 AM
In-person sprints welcomer · Thursday, August 27, 9:00 AM–11:00 AM · LaSalle Ballroom
📄 In-person sprints welcomer documentation
```

That's the page the shift-reminder email links to, so it's the one volunteers actually land on — which is probably why the change looked smaller than expected.

Now matches the shift list: role name heads the card, the detail line carries time and place, and the doc link reads "📄 Role documentation".

`dashboard.html` deliberately keeps both — it's a table with separate Title and Role columns, where showing both is correct.

## Testing

- New `test_shift_card_rendering.py` covers **both** templates so they can't drift apart again. The shift-list assertion targets the stutter specifically rather than counting the role name globally — the role filter dropdown legitimately lists it, which my first attempt tripped over.
- Full suite: **352 passed**
- `just lint`: clean