### PR TITLE
:bug: Make the volunteer hour budget a warning, not a gate

### DIFF
--- a/volunteers/templates/volunteers/my_shifts.html
+++ b/volunteers/templates/volunteers/my_shifts.html
@@ -9,7 +9,12 @@
         <div class="text-center">
             <h1 class="mb-2 text-4xl font-bold text-yellow-200">My Volunteer Shifts</h1>
             <p class="text-green-200">
-                Total: <strong>{{ my_hours|floatformat:1 }}</strong> of {{ max_hours }} hours.
+                Total: <strong>{{ my_hours|floatformat:1 }}</strong> hours
+                {% if my_hours > max_hours %}
+                    — more than the {{ max_hours }} we suggest, and that's okay.
+                {% else %}
+                    (we suggest around {{ max_hours }}).
+                {% endif %}
                 <a href="{% url 'volunteers:shifts' %}" class="text-yellow-300 underline">Browse more shifts</a>.
             </p>
             {% if handbook_url %}

--- a/volunteers/templates/volunteers/shift_list.html
+++ b/volunteers/templates/volunteers/shift_list.html
@@ -10,7 +10,12 @@
             <h1 class="mb-2 text-4xl font-bold text-yellow-200">Volunteer Sign-up</h1>
             {% if user.is_authenticated %}
                 <p class="text-green-200">
-                    You're signed up for <strong>{{ my_hours|floatformat:1 }}</strong> of {{ max_hours }} volunteer hours.
+                    You're signed up for <strong>{{ my_hours|floatformat:1 }}</strong> volunteer hours
+                    {% if my_hours > max_hours %}
+                        — more than the {{ max_hours }} we suggest, and that's okay.
+                    {% else %}
+                        (we suggest around {{ max_hours }}).
+                    {% endif %}
                     <a href="{% url 'volunteers:my_shifts' %}" class="text-yellow-300 underline">View my shifts</a>.
                 </p>
             {% else %}

--- a/volunteers/tests/test_hour_limit.py
+++ b/volunteers/tests/test_hour_limit.py
@@ -1,0 +1,131 @@
+"""The volunteer hour budget is guidance, not a gate (#139).
+
+Ken cancelled a 2pm shift, tried to pick up a 4pm one instead, and was blocked
+by the 8-hour limit — the app refused a change that left his total the same. The
+budget now warns and gets out of the way, matching how shift capacity has always
+behaved ("a visual guide for organizers, not a hard cap").
+"""
+
+import datetime
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
+from django.urls import reverse
+from django.utils import timezone
+
+from volunteers.models import Role, Shift, VolunteerSignup, total_volunteer_hours
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="vol", email="vol@example.com", password="pw12345!")
+
+
+@pytest.fixture
+def role(db):
+    return Role.objects.create(name="Registration Desk")
+
+
+def make_shift(role, *, offset_hours, length_hours=2):
+    start = timezone.now() + datetime.timedelta(hours=offset_hours)
+    return Shift.objects.create(
+        role=role,
+        title=f"Shift +{offset_hours}h",
+        starts_at=start,
+        ends_at=start + datetime.timedelta(hours=length_hours),
+    )
+
+
+def messages_of(response, level_tag):
+    return [m.message for m in get_messages(response.wsgi_request) if m.level_tag == level_tag]
+
+
+def sign_up(client, shift):
+    return client.post(reverse("volunteers:signup", args=[shift.pk]), follow=True)
+
+
+@pytest.mark.django_db
+class TestHourBudgetIsSoft:
+    def test_signup_past_the_budget_succeeds(self, client, user, role, settings):
+        settings.VOLUNTEER_MAX_HOURS = 4
+        for offset in (10, 20):  # 4 hours banked, already at the budget
+            VolunteerSignup.objects.create(shift=make_shift(role, offset_hours=offset), user=user)
+        client.force_login(user)
+
+        over = make_shift(role, offset_hours=30)
+        sign_up(client, over)
+
+        assert VolunteerSignup.objects.filter(shift=over, user=user, cancelled=False).exists()
+        assert total_volunteer_hours(user) == 6
+
+    def test_going_over_warns_rather_than_erroring(self, client, user, role, settings):
+        settings.VOLUNTEER_MAX_HOURS = 4
+        for offset in (10, 20):
+            VolunteerSignup.objects.create(shift=make_shift(role, offset_hours=offset), user=user)
+        client.force_login(user)
+
+        response = sign_up(client, make_shift(role, offset_hours=30))
+
+        assert not messages_of(response, "error"), "the budget must never block a signup"
+        warnings = messages_of(response, "warning")
+        assert len(warnings) == 1
+        assert "6.0 volunteer hours" in warnings[0]
+
+    def test_staying_under_the_budget_says_nothing(self, client, user, role, settings):
+        settings.VOLUNTEER_MAX_HOURS = 8
+        client.force_login(user)
+
+        response = sign_up(client, make_shift(role, offset_hours=10))
+
+        assert not messages_of(response, "warning")
+        assert messages_of(response, "success")
+
+    def test_kens_case_swapping_one_shift_for_another(self, client, user, role, settings):
+        """Cancel a shift, pick up a different one: the total is unchanged."""
+        settings.VOLUNTEER_MAX_HOURS = 4
+        booked = [make_shift(role, offset_hours=o) for o in (10, 20)]
+        for shift in booked:
+            VolunteerSignup.objects.create(shift=shift, user=user)
+        client.force_login(user)
+
+        client.post(reverse("volunteers:cancel", args=[booked[1].pk]), follow=True)
+        assert total_volunteer_hours(user) == 2
+
+        replacement = make_shift(role, offset_hours=24)
+        response = sign_up(client, replacement)
+
+        assert VolunteerSignup.objects.filter(shift=replacement, user=user, cancelled=False).exists()
+        assert total_volunteer_hours(user) == 4
+        assert not messages_of(response, "warning"), "back at the budget, not over it"
+
+
+@pytest.mark.django_db
+class TestOtherGatesStillHold:
+    """Softening the budget must not soften the gates that mean something."""
+
+    def test_overlapping_shifts_are_still_refused(self, client, user, role, settings):
+        settings.VOLUNTEER_MAX_HOURS = 99
+        first = make_shift(role, offset_hours=10, length_hours=4)
+        VolunteerSignup.objects.create(shift=first, user=user)
+        client.force_login(user)
+
+        overlapping = make_shift(role, offset_hours=11)
+        response = sign_up(client, overlapping)
+
+        assert not VolunteerSignup.objects.filter(shift=overlapping, user=user, cancelled=False).exists()
+        assert messages_of(response, "error")
+
+    def test_closed_shifts_are_still_refused(self, client, user, role, settings):
+        settings.VOLUNTEER_MAX_HOURS = 99
+        closed = make_shift(role, offset_hours=10)
+        closed.signups_open = False
+        closed.save(update_fields=["signups_open"])
+        client.force_login(user)
+
+        response = sign_up(client, closed)
+
+        assert not VolunteerSignup.objects.filter(shift=closed, user=user, cancelled=False).exists()
+        assert messages_of(response, "error")

--- a/volunteers/tests/test_hour_limit.py
+++ b/volunteers/tests/test_hour_limit.py
@@ -74,6 +74,20 @@ class TestHourBudgetIsSoft:
         assert len(warnings) == 1
         assert "6.0 volunteer hours" in warnings[0]
 
+    def test_the_warning_fires_only_on_the_signup_that_crosses(self, client, user, role, settings):
+        """Already been told once; adding more shouldn't nag again."""
+        settings.VOLUNTEER_MAX_HOURS = 4
+        for offset in (10, 20):
+            VolunteerSignup.objects.create(shift=make_shift(role, offset_hours=offset), user=user)
+        client.force_login(user)
+
+        crossing = sign_up(client, make_shift(role, offset_hours=30))
+        assert len(messages_of(crossing, "warning")) == 1, "the crossing signup should warn"
+
+        already_over = sign_up(client, make_shift(role, offset_hours=40))
+        assert not messages_of(already_over, "warning"), "shouldn't warn again once they're over"
+        assert total_volunteer_hours(user) == 8
+
     def test_staying_under_the_budget_says_nothing(self, client, user, role, settings):
         settings.VOLUNTEER_MAX_HOURS = 8
         client.force_login(user)

--- a/volunteers/tests/test_signups.py
+++ b/volunteers/tests/test_signups.py
@@ -73,11 +73,12 @@ def test_signup_blocked_on_time_conflict(auth_client, user, role):
     assert conflicting_shifts(user, shift_b) == [shift_a]
 
 
-def test_signup_blocked_over_hours_cap(auth_client, user, role, settings):
+def test_signup_allowed_over_hours_cap(auth_client, user, role, settings):
+    """The hour budget warns but never blocks (#139) — see test_hour_limit.py."""
     settings.VOLUNTEER_MAX_HOURS = 3
     long_shift = make_shift(role, length_hours=4, title="Long")
     auth_client.post(reverse("volunteers:signup", args=[long_shift.id]))
-    assert not VolunteerSignup.objects.filter(user=user, cancelled=False).exists()
+    assert VolunteerSignup.objects.filter(user=user, cancelled=False).exists()
 
 
 def test_cancel_marks_cancelled(auth_client, user, role):

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -179,14 +179,6 @@ def signup_view(request, pk):
         messages.error(request, f"This overlaps a shift you're already on: {names}.")
         return redirect(return_url)
 
-    projected = total_volunteer_hours(request.user) + shift.duration_hours
-    if projected > max_volunteer_hours():
-        messages.error(
-            request,
-            f"That would put you at {projected:.1f} volunteer hours; the limit is {max_volunteer_hours()}.",
-        )
-        return redirect(return_url)
-
     # Reuse a cancelled row if one exists, otherwise create a fresh signup.
     signup, created = VolunteerSignup.objects.get_or_create(shift=shift, user=request.user)
     if not created:
@@ -198,6 +190,19 @@ def signup_view(request, pk):
         signup.save(update_fields=["cancelled", "reminded", "created_at"])
 
     messages.success(request, f"You're signed up for “{shift.title}.” Thank you!")
+
+    # The hour budget is guidance, never a gate — same as capacity. Blocking it
+    # stranded people who cancelled one shift and couldn't pick up another (#139),
+    # so say something and get out of the way.
+    projected = total_volunteer_hours(request.user)
+    if projected > max_volunteer_hours():
+        messages.warning(
+            request,
+            f"Heads up: you're now at {projected:.1f} volunteer hours, past the "
+            f"{max_volunteer_hours()} we suggest. That's allowed and we're grateful — "
+            "just don't sign up for so much that you miss the conference.",
+        )
+
     return redirect(return_url)
 
 

--- a/volunteers/views.py
+++ b/volunteers/views.py
@@ -179,6 +179,8 @@ def signup_view(request, pk):
         messages.error(request, f"This overlaps a shift you're already on: {names}.")
         return redirect(return_url)
 
+    hours_before = total_volunteer_hours(request.user)
+
     # Reuse a cancelled row if one exists, otherwise create a fresh signup.
     signup, created = VolunteerSignup.objects.get_or_create(shift=shift, user=request.user)
     if not created:
@@ -194,11 +196,14 @@ def signup_view(request, pk):
     # The hour budget is guidance, never a gate — same as capacity. Blocking it
     # stranded people who cancelled one shift and couldn't pick up another (#139),
     # so say something and get out of the way.
-    projected = total_volunteer_hours(request.user)
-    if projected > max_volunteer_hours():
+    #
+    # Only on the signup that crosses the line: someone who has already been told
+    # doesn't need it again every time they add a shift.
+    hours_after = total_volunteer_hours(request.user)
+    if hours_before <= max_volunteer_hours() < hours_after:
         messages.warning(
             request,
-            f"Heads up: you're now at {projected:.1f} volunteer hours, past the "
+            f"Heads up: you're now at {hours_after:.1f} volunteer hours, past the "
             f"{max_volunteer_hours()} we suggest. That's allowed and we're grateful — "
             "just don't sign up for so much that you miss the conference.",
         )


### PR DESCRIPTION
Fixes #139.

## The bug behind Ken's report

Ken cancelled his 2pm Reg Desk shift, tried to add the 4pm to make up for it, and was blocked by the 8-hour limit — the app refused a swap that would have left his total *unchanged*. Any volunteer at the cap is frozen: they can drop shifts but never rearrange them.

## The audit

I checked every gate in `signup_view`:

| Gate | Was | Now |
|---|---|---|
| Hour budget | **hard block** | warning |
| Shift capacity | soft already — "a visual guide for organizers, not a hard cap" | unchanged |
| Overlapping shift | hard | unchanged |
| Signups closed | hard | unchanged |
| Shift already ended (`ends_at` < now) | hard | unchanged |

The hour budget was the **only** hard limit, and it contradicted the philosophy already written into `can_sign_up()`. The remaining gates aren't limits — they're impossibilities (you can't work two shifts at once, or one that already ended), so they stay. Note the last one keys off `ends_at`, so a shift *in progress* is still signable.

## The change

The signup goes through, then — **only on the signup that crosses the line**:

> Heads up: you're now at 9.0 volunteer hours, past the 8 we suggest. That's allowed and we're grateful — just don't sign up for so much that you miss the conference.

Someone already over doesn't get told again each time they add another shift.

Copy on both the shift list and My shifts read like a quota ("3.0 of 8 hours"); it now reads as guidance ("3.0 hours (we suggest around 8)", and past the budget, "— more than the 8 we suggest, and that's okay").

## Testing

New `test_hour_limit.py`, including a regression test replaying Ken's exact sequence — cancel one shift, pick up another, total unchanged, no warning — and one pinning that the warning fires on the crossing signup but not the next one. Plus tests that the other gates still refuse.

One existing test changed: `test_signup_blocked_over_hours_cap` pinned the old hard block, so it's now `test_signup_allowed_over_hours_cap`. That's the behaviour change itself, not a test worked around.

- Full suite: **359 passed**
- `just lint`: clean