### PR TITLE
:bug: Follow the talk's room when re-syncing the schedule

### DIFF
--- a/volunteers/models.py
+++ b/volunteers/models.py
@@ -94,8 +94,18 @@ class Shift(models.Model):
             self.title = talks[0].title
         else:
             self.title = f"{self.role.name} · {len(talks)} slots"
+
+        # Rooms get renamed and sessions get moved after the schedule is first
+        # imported, so the shift has to follow its talks — otherwise the card
+        # keeps sending volunteers to where the session used to be. Only when
+        # the feed actually names a room: a blank LOCATION shouldn't wipe one an
+        # organizer set by hand.
+        rooms = list(dict.fromkeys(talk.location for talk in talks if talk.location))
+        if rooms:
+            self.location = " / ".join(rooms)
+
         if save:
-            self.save(update_fields=["starts_at", "ends_at", "title"])
+            self.save(update_fields=["starts_at", "ends_at", "title", "location"])
 
     @property
     def active_signups(self):

--- a/volunteers/tests/test_schedule_resync.py
+++ b/volunteers/tests/test_schedule_resync.py
@@ -1,0 +1,99 @@
+"""Re-syncing the schedule has to move a shift's room, not just its times.
+
+A shift's location was written once, when the talk was first imported, and
+never again: ``recompute_span`` refreshed starts_at/ends_at/title and left
+location alone. So a room renamed upstream updated the Talk and left the Shift —
+the thing volunteers actually read — pointing at the old room forever.
+"""
+
+import datetime
+
+import pytest
+from django.utils import timezone
+
+from volunteers.models import Role, Shift, Talk
+
+OLD_ROOM = "Sauganash Ballroom"
+NEW_ROOM = "Sauganash Ballroom (West)"
+
+
+@pytest.fixture
+def role(db):
+    return Role.objects.create(name="Session Chair")
+
+
+def make_talk(shift, *, uid, location, offset_hours=10, length_hours=1, title="A Talk"):
+    start = timezone.now() + datetime.timedelta(hours=offset_hours)
+    return Talk.objects.create(
+        shift=shift,
+        external_uid=uid,
+        title=title,
+        location=location,
+        starts_at=start,
+        ends_at=start + datetime.timedelta(hours=length_hours),
+    )
+
+
+def make_shift(role, *, location):
+    start = timezone.now() + datetime.timedelta(hours=10)
+    return Shift.objects.create(
+        role=role,
+        title="A Talk",
+        location=location,
+        starts_at=start,
+        ends_at=start + datetime.timedelta(hours=1),
+    )
+
+
+@pytest.mark.django_db
+class TestLocationFollowsTheTalk:
+    def test_a_renamed_room_reaches_the_shift(self, role):
+        shift = make_shift(role, location=OLD_ROOM)
+        talk = make_talk(shift, uid="uid-1", location=OLD_ROOM)
+
+        # What a re-sync does: update the talk, then recompute its shift.
+        talk.location = NEW_ROOM
+        talk.save(update_fields=["location"])
+        shift.recompute_span()
+
+        shift.refresh_from_db()
+        assert shift.location == NEW_ROOM
+
+    def test_a_merged_shift_lists_every_room_it_covers(self, role):
+        shift = make_shift(role, location=OLD_ROOM)
+        make_talk(shift, uid="uid-1", location=NEW_ROOM, offset_hours=10)
+        make_talk(shift, uid="uid-2", location="Wolf Point Ballroom", offset_hours=11)
+
+        shift.recompute_span()
+
+        shift.refresh_from_db()
+        assert shift.location == f"{NEW_ROOM} / Wolf Point Ballroom"
+
+    def test_one_room_across_several_talks_is_not_repeated(self, role):
+        shift = make_shift(role, location="")
+        make_talk(shift, uid="uid-1", location=NEW_ROOM, offset_hours=10)
+        make_talk(shift, uid="uid-2", location=NEW_ROOM, offset_hours=11)
+
+        shift.recompute_span()
+
+        shift.refresh_from_db()
+        assert shift.location == NEW_ROOM
+
+    def test_a_feed_with_no_room_does_not_wipe_a_manual_one(self, role):
+        """Organizers set locations by hand; a silent feed must not erase them."""
+        shift = make_shift(role, location="Registration Desk")
+        make_talk(shift, uid="uid-1", location="")
+
+        shift.recompute_span()
+
+        shift.refresh_from_db()
+        assert shift.location == "Registration Desk"
+
+    def test_shifts_with_no_talks_are_untouched(self, role):
+        """Desk and manager shifts carry their own location."""
+        shift = make_shift(role, location="LaSalle Ballroom")
+
+        shift.recompute_span()
+
+        shift.refresh_from_db()
+        assert shift.location == "LaSalle Ballroom"


### PR DESCRIPTION
Found while chasing a report that **"Sync schedule now" didn't pick up a room rename** ("Sauganash Ballroom" → "Sauganash Ballroom (West)").

## That specific report is upstream, not us

The sync did its job — the rename isn't in the source:

| Source | Says |
|---|---|
| ICS feed `2026.djangocon.us/schedule.ics` | `Sauganash Ballroom` (all 36 events) |
| pretalx rooms API | `Sauganash Ballroom`, `Wolf Point Ballroom` |
| The website | `Sauganash Ballroom (West)` |

The rename lives only in the site's own labelling and hasn't reached pretalx, which generates the feed. **No code change fixes that** — the room needs renaming upstream.

## But the sync would have failed anyway

Chasing it turned up a real bug that would have bitten the moment the feed *was* corrected.

`Shift.location` is written once, at `import_schedule.py:139`, when the talk is first imported. On every later sync the talk already has a shift, so that line never runs again — and `recompute_span()` refreshed `starts_at`, `ends_at` and `title` but **not** `location`.

Since the cards render `shift.location`, a renamed room would update the `Talk` and leave the `Shift` pointing at the old room permanently. You'd re-sync, see the talk change, and still send volunteers to the wrong place.

`recompute_span()` now carries location too:

- **Merged shifts** list every room they cover (`"Room A / Room B"`), deduped when the talks share one.
- **A blank `LOCATION` doesn't wipe a manual location** — organizers set these by hand on desk shifts, and silently erasing them would be worse than the bug.
- **Shifts with no talks are untouched** — they carry their own location.

## Testing

5 new tests in `test_schedule_resync.py` covering the rename, the merged-shift case, dedup, the blank-feed guard, and talk-less shifts.

- Full suite: **364 passed**
- `just lint`: clean

Nothing visible changes until the feed is corrected upstream — which is a reason to land it now rather than after.