### PR TITLE
:sparkles: Add Speaker and Sponsor reports, normalize every CSV

### DIFF
--- a/config/tests/test_reports.py
+++ b/config/tests/test_reports.py
@@ -75,8 +75,15 @@ def tito_events(db):
     webhook("speaker@example.com", "Speaker", trigger="ticket.updated", created="2026-01-04T10:00:00Z")
 
     # One sprinter signed up for both days — two releases, one person.
-    webhook("sprinter@example.com", "Sprint (In Person)- Thursday (August 27)")
-    webhook("sprinter@example.com", "Sprint (In Person)- Friday (August 28)")
+    webhook("sprinter@example.com", "Sprint (In Person)- Thursday (August 27)", name="Grace Hopper")
+    webhook("sprinter@example.com", "Sprint (In Person)- Friday (August 28)", name="Grace Hopper")
+
+    # Refunded their sponsor ticket: must not reach a sponsor mailing list.
+    webhook("refunded@example.com", "Sponsor")
+    webhook("refunded@example.com", "Sponsor", trigger="ticket.voided", created="2026-01-05T10:00:00Z")
+
+    # A plain attendee — proof the reports filter by ticket type at all.
+    webhook("regular@example.com", "Individual (In-person)", name="Nobody Special")
 
     # An online attendee for the attendees report.
     OnlineAttendee.objects.create(year=2026, email="Online@Example.com", name="Ada", release_title="Online- Individual")
@@ -198,3 +205,78 @@ class TestOneRowPerPerson:
         emails = [row["Email"] for row in rows]
         assert emails == [email.lower() for email in emails]
         assert len(emails) == len(set(emails))
+
+
+@pytest.mark.django_db
+class TestReportsActuallyContainPeople:
+    """Guard the guards.
+
+    Assertions like "no address appears twice" are trivially true of an empty
+    file, so a report that silently returned nothing would sail through the
+    tests above. These pin the actual contents, from fabricated data only —
+    nobody's real address belongs in a test fixture.
+    """
+
+    @pytest.mark.parametrize("report", REPORTS, ids=lambda r: r["url_name"] + "?" + r.get("query", ""))
+    def test_every_report_returns_rows(self, client, staff, report, tito_events):
+        client.force_login(staff)
+        url = reverse(report["url_name"])
+        query = report.get("query")
+
+        response = client.get(f"{url}?{query}" if query else url)
+
+        rows = list(csv.DictReader(io.StringIO(response.content.decode())))
+        assert rows, f"{report['label']} produced a header and nothing else"
+
+    def test_speakers_lists_the_speaker_and_nobody_else(self, client, staff, tito_events):
+        client.force_login(staff)
+        rows = list(csv.DictReader(io.StringIO(client.get(reverse("report_speakers")).content.decode())))
+
+        assert [row["Email"] for row in rows] == ["speaker@example.com"]
+        assert rows[0]["Name"] == "Ada Lovelace"
+        assert rows[0]["Ticket Type"] == "Speaker"
+        assert rows[0]["Online"] == ""
+
+    def test_sponsors_drops_a_refunded_sponsor(self, client, staff, tito_events):
+        client.force_login(staff)
+        rows = list(csv.DictReader(io.StringIO(client.get(reverse("report_sponsors")).content.decode())))
+        emails = [row["Email"] for row in rows]
+
+        assert "sponsor@example.com" in emails
+        assert "refunded@example.com" not in emails, "a voided ticket must not reach a mailing list"
+
+    def test_reports_exclude_other_ticket_types(self, client, staff, tito_events):
+        """A plain attendee is neither a speaker nor a sponsor."""
+        client.force_login(staff)
+
+        for url_name in ("report_speakers", "report_sponsors"):
+            body = client.get(reverse(url_name)).content.decode()
+            assert "regular@example.com" not in body
+
+    def test_the_sponsors_online_flag_follows_the_release(self, client, staff, tito_events):
+        """The sponsor's latest ticket is the "Sponsor- Online" one."""
+        client.force_login(staff)
+        rows = list(csv.DictReader(io.StringIO(client.get(reverse("report_sponsors")).content.decode())))
+        sponsor = next(row for row in rows if row["Email"] == "sponsor@example.com")
+
+        assert sponsor["Ticket Type"] == "Sponsor- Online"
+        assert sponsor["Online"] == "Yes"
+
+    def test_sprint_report_still_shows_which_days(self, client, staff, tito_events):
+        """One person on both days: one row, both day columns marked."""
+        client.force_login(staff)
+        body = client.get(reverse("sprint_tickets"), {"format": "csv"}).content.decode()
+        rows = list(csv.DictReader(io.StringIO(body)))
+        sprinter = next(row for row in rows if row["Email"] == "sprinter@example.com")
+
+        assert sprinter["Thursday"] == "Yes"
+        assert sprinter["Friday"] == "Yes"
+        assert sprinter["Ticket Type"] == "Sprint — Thursday & Friday"
+
+    def test_online_attendees_lists_the_attendee(self, client, staff, tito_events):
+        client.force_login(staff)
+        body = client.get(reverse("online_attendees"), {"format": "csv", "year": 2026}).content.decode()
+        rows = list(csv.DictReader(io.StringIO(body)))
+
+        assert [row["Email"] for row in rows] == ["online@example.com"]
+        assert rows[0]["Ticket Type"] == "Online- Individual"

--- a/config/tests/test_reports.py
+++ b/config/tests/test_reports.py
@@ -1,0 +1,200 @@
+"""Every CSV report shares a column contract, and staff can find them all.
+
+The reports grew up separately: the ticket type was "Release" in one report,
+"Ticket Type" in another and absent from a third, the date was "Purchased" or
+"Ticket Date" depending, and the historical export led with two extra columns.
+Anything reading more than one file had to special-case each. These tests pin
+the shared prefix so they can't drift apart again.
+"""
+
+import csv
+import io
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils.html import escape
+
+from config.views import REPORTS, available_reports
+from tickets.models import OnlineAttendee
+from titowebhooks.models import TitoWebhookEvent
+from titowebhooks.reports import CORE_COLUMNS
+from titowebhooks.views import EVENT_SLUG, VOLUNTEER_QUESTION_SLUG, VOLUNTEER_YES
+
+User = get_user_model()
+
+
+@pytest.fixture
+def staff(db):
+    """A superuser: the volunteer interest report is not open to staff at large."""
+    return User.objects.create_superuser(username="staff", email="staff@example.com", password="pw12345!")
+
+
+@pytest.fixture
+def plain_staff(db):
+    return User.objects.create_user(username="desk", email="desk@example.com", password="pw12345!", is_staff=True)
+
+
+@pytest.fixture
+def civilian(db):
+    return User.objects.create_user(username="nobody", email="nobody@example.com", password="pw12345!")
+
+
+def webhook(email, release, *, trigger="ticket.completed", name="Ada Lovelace", created="2026-01-01T10:00:00Z"):
+    return TitoWebhookEvent.objects.create(
+        trigger=trigger,
+        payload={
+            "event": {"slug": EVENT_SLUG, "title": "DjangoCon US 2026"},
+            "email": email,
+            "name": name,
+            "release_title": release,
+            "release": {"title": release},
+            "created_at": created,
+            "reference": "ABCD-1",
+            "company_name": "Acme",
+            "responses": {VOLUNTEER_QUESTION_SLUG: VOLUNTEER_YES},
+        },
+    )
+
+
+@pytest.fixture
+def tito_events(db):
+    """The same people, seen several times — which is how Ti.to really behaves.
+
+    Ti.to fires a hook per ticket event, so one person arrives repeatedly: a
+    completed ticket, an update, a second sprint day, a different case in the
+    address. Without this the dedup assertions would pass on an empty file.
+    """
+    # One sponsor, three hooks, two spellings of the same address.
+    webhook("Sponsor@Example.com", "Sponsor")
+    webhook("sponsor@example.com", "Sponsor", trigger="ticket.updated", created="2026-01-02T10:00:00Z")
+    webhook("SPONSOR@example.com", "Sponsor- Online", created="2026-01-03T10:00:00Z")
+
+    # One speaker, twice.
+    webhook("speaker@example.com", "Speaker")
+    webhook("speaker@example.com", "Speaker", trigger="ticket.updated", created="2026-01-04T10:00:00Z")
+
+    # One sprinter signed up for both days — two releases, one person.
+    webhook("sprinter@example.com", "Sprint (In Person)- Thursday (August 27)")
+    webhook("sprinter@example.com", "Sprint (In Person)- Friday (August 28)")
+
+    # An online attendee for the attendees report.
+    OnlineAttendee.objects.create(year=2026, email="Online@Example.com", name="Ada", release_title="Online- Individual")
+    return None
+
+
+def header_of(response):
+    body = response.content.decode()
+    return next(csv.reader(io.StringIO(body)))
+
+
+@pytest.mark.django_db
+class TestNormalizedColumns:
+    @pytest.mark.parametrize("report", REPORTS, ids=lambda r: r["url_name"] + "?" + r.get("query", ""))
+    def test_every_report_starts_with_the_core_columns(self, client, staff, report):
+        client.force_login(staff)
+        url = reverse(report["url_name"])
+        query = report.get("query")
+
+        response = client.get(f"{url}?{query}" if query else url)
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/csv"
+        assert header_of(response)[: len(CORE_COLUMNS)] == CORE_COLUMNS
+
+    @pytest.mark.parametrize("report", REPORTS, ids=lambda r: r["url_name"] + "?" + r.get("query", ""))
+    def test_every_report_downloads_rather_than_renders(self, client, staff, report):
+        client.force_login(staff)
+        url = reverse(report["url_name"])
+        query = report.get("query")
+
+        response = client.get(f"{url}?{query}" if query else url)
+
+        assert response["Content-Disposition"].startswith("attachment;")
+        assert ".csv" in response["Content-Disposition"]
+
+    def test_the_old_column_names_are_gone(self, client, staff):
+        """'Release' and 'Purchased' were the two odd ones out."""
+        client.force_login(staff)
+        header = header_of(client.get(reverse("online_attendees"), {"format": "csv"}))
+        assert "Release" not in header
+        assert "Purchased" not in header
+        assert "Ticket Type" in header
+        assert "Ticket Date" in header
+
+
+@pytest.mark.django_db
+class TestReportsOnTheHomepage:
+    def test_staff_see_every_report(self, client, staff):
+        client.force_login(staff)
+        response = client.get(reverse("home"))
+        content = response.content.decode()
+
+        assert "Reports" in content
+        for report in available_reports(staff):
+            # escape(): the historical report's "&" is rendered as "&amp;".
+            assert escape(report["url"]) in content, f"{report['label']} is missing from the homepage"
+
+    def test_a_report_someone_cannot_open_is_not_linked(self, client, plain_staff):
+        """Volunteer interest is superusers and chairs, not staff at large.
+
+        Listing it for everyone would hand plain staff a 403 on click.
+        """
+        client.force_login(plain_staff)
+        response = client.get(reverse("home"))
+        labels = [report["label"] for report in response.context["reports"]]
+
+        assert "Speakers" in labels
+        assert "Volunteer interest" not in labels
+
+    def test_non_staff_see_no_reports_panel(self, client, civilian):
+        client.force_login(civilian)
+        response = client.get(reverse("home"))
+
+        assert response.context["reports"] == []
+        assert reverse("report_speakers") not in response.content.decode()
+
+    def test_anonymous_sees_no_reports_panel(self, client, db):
+        response = client.get(reverse("home"))
+        assert response.context["reports"] == []
+
+
+@pytest.mark.django_db
+class TestReportAccess:
+    @pytest.mark.parametrize("url_name", ["report_speakers", "report_sponsors"])
+    def test_new_reports_require_staff(self, client, civilian, url_name):
+        client.force_login(civilian)
+        response = client.get(reverse(url_name))
+        assert response.status_code == 302
+
+
+@pytest.mark.django_db
+class TestOneRowPerPerson:
+    """A mailing list with the same address twice mails that person twice."""
+
+    @pytest.mark.parametrize("report", REPORTS, ids=lambda r: r["url_name"] + "?" + r.get("query", ""))
+    def test_no_report_repeats_an_email_address(self, client, staff, report, tito_events):
+        client.force_login(staff)
+        url = reverse(report["url_name"])
+        query = report.get("query")
+
+        response = client.get(f"{url}?{query}" if query else url)
+
+        rows = list(csv.DictReader(io.StringIO(response.content.decode())))
+        emails = [row["Email"] for row in rows if row["Email"]]
+        if report.get("query") == "scope=historical&format=csv":
+            # Historical is deliberately one row per person *per year*.
+            pairs = [(row["Email"], row["Year"]) for row in rows if row["Email"]]
+            assert len(pairs) == len(set(pairs))
+        else:
+            assert len(emails) == len(set(emails)), f"{report['label']} repeats an address"
+
+    def test_addresses_are_matched_regardless_of_case(self, client, staff, tito_events):
+        """Ti.to and hand-typed addresses disagree on case constantly."""
+        client.force_login(staff)
+        response = client.get(reverse("report_sponsors"))
+
+        rows = list(csv.DictReader(io.StringIO(response.content.decode())))
+        emails = [row["Email"] for row in rows]
+        assert emails == [email.lower() for email in emails]
+        assert len(emails) == len(set(emails))

--- a/config/urls.py
+++ b/config/urls.py
@@ -21,6 +21,8 @@ from tickets.views import (
     tickets_list_view,
 )
 from titowebhooks.views import (
+    speakers_report_view,
+    sponsors_report_view,
     sprint_tickets_view,
     tito_sales_dashboard_view,
     tito_sync_tickets_view,
@@ -49,6 +51,8 @@ urlpatterns = [
     path("tickets/attendees/", online_attendees_view, name="online_attendees"),
     path("tickets/emails/", ticket_emails_view, name="ticket_emails"),
     path("sprints/tickets/", sprint_tickets_view, name="sprint_tickets"),
+    path("reports/speakers.csv", speakers_report_view, name="report_speakers"),
+    path("reports/sponsors.csv", sponsors_report_view, name="report_sponsors"),
     path("tito/sales/", tito_sales_dashboard_view, name="tito_sales_dashboard"),
     path("tito/volunteer-interest/", volunteer_interest_view, name="volunteer_interest"),
     path("tito/sync/", tito_sync_view, name="tito_sync"),

--- a/config/views.py
+++ b/config/views.py
@@ -1,12 +1,84 @@
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import render
+from django.urls import reverse
 
 from config.emails import EMAIL_PREVIEWS, get_preview
+from volunteers.permissions import can_view_volunteer_interest
+
+
+def _is_staff(user) -> bool:
+    return user.is_active and user.is_staff
+
+
+# The CSV exports, listed in one place so the homepage and any future index stay
+# in step with each other. Each URL downloads a file directly — no page in
+# between — and every report shares the columns in titowebhooks.reports.
+#
+# ``can_view`` mirrors the decorator on the view itself. The reports don't all
+# share one rule — the volunteer interest report is superusers and volunteer
+# chairs, not staff at large — so listing a report someone can't open would just
+# hand them a 403.
+REPORTS = [
+    {
+        "label": "Online attendees",
+        "description": "Who bought an online ticket, their link, and whether we've emailed it.",
+        "url_name": "online_attendees",
+        "query": "format=csv",
+        "can_view": _is_staff,
+    },
+    {
+        "label": "Speakers",
+        "description": "Everyone holding a Speaker ticket.",
+        "url_name": "report_speakers",
+        "can_view": _is_staff,
+    },
+    {
+        "label": "Sponsors",
+        "description": "Everyone holding a Sponsor ticket, in person or online.",
+        "url_name": "report_sponsors",
+        "can_view": _is_staff,
+    },
+    {
+        "label": "Sprint tickets",
+        "description": "In-person sprinters for this year, by day.",
+        "url_name": "sprint_tickets",
+        "query": "format=csv",
+        "can_view": _is_staff,
+    },
+    {
+        "label": "Sprint tickets — historical",
+        "description": "Sprinters across the last few conference years.",
+        "url_name": "sprint_tickets",
+        "query": "scope=historical&format=csv",
+        "can_view": _is_staff,
+    },
+    {
+        "label": "Volunteer interest",
+        "description": "Attendees who said yes to volunteering on their ticket.",
+        "url_name": "volunteer_interest",
+        "query": "format=csv",
+        "can_view": can_view_volunteer_interest,
+    },
+]
+
+
+def available_reports(user) -> list[dict]:
+    """The reports ``user`` may actually download, with their URLs built."""
+    reports = []
+    for report in REPORTS:
+        if not report["can_view"](user):
+            continue
+        url = reverse(report["url_name"])
+        query = report.get("query")
+        reports.append({**report, "url": f"{url}?{query}" if query else url})
+    return reports
 
 
 def homepage_view(request: HttpRequest) -> HttpResponse:
-    return render(request, "homepage.html")
+    # The views enforce their own access; this only decides what to link.
+    reports = available_reports(request.user) if request.user.is_authenticated else []
+    return render(request, "homepage.html", {"reports": reports})
 
 
 @staff_member_required

--- a/docs/emails.md
+++ b/docs/emails.md
@@ -1,0 +1,172 @@
+# Email templates, messages, and triggers
+
+Every email this app sends, what it looks like, and what causes it to go out.
+
+Staff can preview all of these rendered at **`/staff/emails/`** ("Email Previews" in the
+nav). The previews are driven by the registry in `config/emails.py`; `config/tests/test_email_previews.py`
+walks the repo for email templates and fails if one isn't registered, so this list and that
+page can't quietly drift from the code.
+
+## At a glance
+
+| Email | Recipient | Trigger | Sent by |
+| --- | --- | --- | --- |
+| [Sign-in code](#sign-in-code) | Anyone signing in | User requests a code at `/accounts/login/code/` | allauth (inline) |
+| [Password reset](#password-reset) | Anyone resetting a password | User submits `/accounts/password/reset/` | allauth (inline) |
+| [Ticket link — initial](#ticket-link) | Online attendee | Staff assigns a link to an attendee who had none | django-q2 worker |
+| [Ticket link — resent](#ticket-link) | Online attendee | Staff re-emails an attendee who already holds a link | django-q2 worker |
+| [Ticket link — reissued](#ticket-link) | Online attendee | Staff reissues, superseding the old link | django-q2 worker |
+| [Volunteer shift reminder](#volunteer-shift-reminder) | Volunteer with a shift in <24h | **Hourly schedule** | django-q2 schedule |
+| [Uncovered shift alert](#uncovered-shift-alert) | `VOLUNTEER_COORDINATOR_EMAILS` | A near-term shift loses its last volunteer | django-q2 worker |
+
+Only two of the seven are time-driven; everything else is a user or staff action.
+
+---
+
+## Sign-in code
+
+- **Templates:** `templates/account/email/login_code_subject.txt`,
+  `templates/account/email/login_code_message.txt` (extends
+  `templates/account/email/base_message.txt`)
+- **Subject:** "Your DjangoCon US sign-in code"
+- **Preview slug:** `login-code`
+
+The passwordless sign-in code — this is how nearly everyone logs in
+(`ACCOUNT_LOGIN_BY_CODE_ENABLED = True`, `ACCOUNT_LOGIN_METHODS = {"email"}`). The body
+carries both the 6-digit code and a one-click confirm link back to
+`account_confirm_login_code`.
+
+**Trigger:** requesting a code at `/accounts/login/code/`. `ACCOUNT_FORMS` points
+`request_login_code` at `config.account_forms.AutoSignupRequestLoginCodeForm`, so an
+address with no account yet gets one created rather than being rejected — meaning this mail
+doubles as the signup path.
+
+allauth builds the whole message, subject included. `ACCOUNT_EMAIL_SUBJECT_PREFIX` is `""`,
+so no `[example.com]` prefix is prepended.
+
+## Password reset
+
+- **Templates:** `templates/account/email/password_reset_key_subject.txt` (ours);
+  allauth's default body, rendered on our `base_message.txt`
+- **Subject:** "Reset your DjangoCon US password"
+- **Preview slug:** `password-reset`
+
+**Trigger:** submitting the form at `/accounts/password/reset/`. Rarely used in practice
+given the sign-in-code flow above.
+
+## Ticket link
+
+- **Templates:** `templates/tickets/email/ticket_link.txt` + `.html` (multipart; one
+  template pair serves all three variants, branching on `is_resend` / `is_reissue`)
+- **Sender:** `tickets/tasks.py::send_ticket_link_email`, queued by
+  `tickets/services.py::queue_ticket_email` via `async_task`
+- **Preview slugs:** `ticket-link-initial`, `ticket-link-resend`, `ticket-link-reissue`
+
+Delivers the online-conference link to an attendee. Three variants, distinguished by
+`TicketEmailLog.kind`, which `assign_and_email` picks automatically:
+
+| Kind | Chosen when | Subject |
+| --- | --- | --- |
+| `initial` | The attendee held no link | Your DjangoCon US online conference link |
+| `resend` | The attendee already had a live link | Your DjangoCon US online conference link (resent) |
+| `reissue` | Called with `reissue=True`; the old link is superseded | Your new DjangoCon US online conference link |
+
+**Triggers** — all staff actions on the online-attendees page (`tickets/views.py`), never
+automatic:
+
+- **Assign by email** (`_handle_assign_by_email`) — staff pastes an address into the box
+  with *send email* checked. Unchecked assigns a link silently, with no mail.
+- **Bulk action `assign_and_email`** — assign a link and mail the selected attendees.
+- **Bulk action `email`** — re-send only to selected attendees who *already* hold a link;
+  it skips the rest, so a nudge can't drain the link pool.
+- **Bulk action `reissue`** — supersede each selected attendee's link and mail the new one.
+
+**Delivery bookkeeping:** a `TicketEmailLog` row is written *before* the task is dispatched,
+so a send that never runs still shows as `queued` on the ticket-emails dashboard
+(`/tickets/emails/`) rather than vanishing. The task is idempotent — an already-`sent` log is skipped, so a
+retried task won't mail somebody twice — and failures are recorded on the log rather than
+raised, so one bad address doesn't kill the rest of a bulk send.
+
+## Volunteer shift reminder
+
+- **Template:** `volunteers/templates/volunteers/email/shift_reminder.txt` (plain text)
+- **Subject:** `Reminder: your DjangoCon US volunteer shift "<shift title>"`
+- **Sender:** `volunteers/tasks.py::send_shift_reminders`
+- **Preview slug:** `shift-reminder`
+
+**Trigger: scheduled.** `Q_SCHEDULES["volunteer-shift-reminders"]` runs
+`volunteers.tasks.send_shift_reminders` **hourly**. Each run mails every non-cancelled,
+not-yet-reminded signup whose shift starts within the next `REMINDER_WINDOW_HOURS` (24).
+`VolunteerSignup.reminded` is set on send, so each signup is reminded at most once.
+
+Because the job is hourly and the window is 24h, a volunteer who signs up *inside* the
+window gets their reminder at the next hourly run, not 24h ahead.
+
+## Uncovered shift alert
+
+- **Template:** `volunteers/templates/volunteers/email/shift_uncovered.txt` (plain text)
+- **Subject:** `DjangoCon US volunteer needed: "<shift title>" just lost its only volunteer`
+- **Sender:** `volunteers/tasks.py::notify_shift_uncovered`
+- **Preview slug:** `shift-uncovered`
+
+The only email that goes to organizers rather than an attendee or volunteer.
+
+**Trigger:** a volunteer cancels a signup. `volunteers/views.py` dispatches
+`async_task("volunteers.tasks.notify_shift_uncovered", signup.pk)`. The task then bails
+quietly unless *all* of these hold:
+
+1. `VOLUNTEER_COORDINATOR_EMAILS` is non-empty — blank (the default) disables the alert.
+2. The shift has no remaining active signups.
+3. The shift starts within `VOLUNTEER_UNCOVERED_ALERT_WINDOW_HOURS` (default 48) and hasn't
+   already started.
+4. More than `VOLUNTEER_UNCOVERED_ALERT_BUFFER_MINUTES` (default 60) elapsed between signup
+   and cancellation — a quick change of mind isn't worth waking anyone up.
+
+Send failures are logged and swallowed so a broken mail server can't break the volunteer's
+cancel action.
+
+---
+
+## Not sent by this app
+
+**EmailOctopus** is where bulk/marketing mail lives, and it is composed and sent *there*,
+not here. This repo only pushes contacts and pulls stats:
+
+- `titowebhooks/management/commands/send_to_emailoctopus.py` — manual command; queues
+  `emailoctopus.utils.send_to_emailoctopus` per `TitoWebhookEvent`, subscribing each
+  address to the default `Campaign` lists. Nothing is mailed by us; subscribing is what
+  eventually puts them on an EmailOctopus send.
+- `Q_SCHEDULES["emailoctopus-sync-campaigns"]` — **hourly** `emailoctopus.utils.sync_campaigns`,
+  read-only campaign stats sync.
+
+`Q_SCHEDULES["travel-safety-retention-policy"]` (**daily**) sends nothing; it enforces data
+retention. `travel_safety`, `thunderdome`, `titowebhooks`, and `social_monitor` store email
+addresses but never send mail.
+
+## Delivery configuration
+
+| Setting | Source | Note |
+| --- | --- | --- |
+| `EMAIL_URL` | env, via `dj_email_url` | Defaults to `console://` — **local dev prints mail to stdout instead of sending**. |
+| `DEFAULT_FROM_EMAIL` | env | `DjangoCon US <hello@mail.defna.org>`. Also used as `support_email` in ticket emails. |
+| `SERVER_EMAIL` | env | `hello@mail.defna.org` |
+| `EMAIL_TIMEOUT` | env | 10s |
+| `VOLUNTEER_COORDINATOR_EMAILS` | env (list) | Empty by default; gates the uncovered-shift alert. |
+
+Production values are set in the Coolify UI, not in version control.
+
+Everything except the two allauth emails is delivered by the **django-q2 worker**
+(`start-worker.sh`), so if mail stops flowing but logins still work, check the worker
+first.
+
+## Adding a new email
+
+1. Add the template(s) under an app's `templates/<app>/email/` directory.
+2. Send it from a task (prefer the worker over the request path).
+3. Register an `EmailPreview` in `config/emails.py` — with sample context that is
+   **fabricated**, never read from the database, so no attendee's name or live ticket link
+   can leak onto a preview page.
+4. Add a row to the table at the top of this file.
+
+Step 3 isn't optional: `config/tests/test_email_previews.py` fails the build on any email template that
+isn't registered.

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -31,6 +31,32 @@
             </a>
         </div>
 
+        {% if user.is_staff %}
+            {% comment %}
+                Every link here downloads a CSV directly — no landing page in
+                between. They all share the same first four columns
+                (Name, Email, Ticket Type, Ticket Date); see titowebhooks/reports.py.
+            {% endcomment %}
+            <div class="rounded-xl border border-green-700 bg-green-800 p-6 text-left">
+                <h2 class="mb-1 text-2xl font-bold text-yellow-200">Reports</h2>
+                <p class="mb-4 text-sm text-green-300">
+                    Each link downloads a CSV. Every report starts with the same columns:
+                    <span class="font-mono text-xs">Name, Email, Ticket Type, Ticket Date</span>.
+                </p>
+                <ul class="grid gap-2 sm:grid-cols-2">
+                    {% for report in reports %}
+                        <li>
+                            <a href="{{ report.url }}"
+                               class="flex flex-col rounded-lg border border-green-700 bg-green-900 px-4 py-3 hover:border-yellow-300">
+                                <span class="font-semibold text-yellow-200">⬇ {{ report.label }}</span>
+                                <span class="text-xs text-green-300">{{ report.description }}</span>
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
+
         {% if user.is_authenticated %}
             <a href="{% url 'volunteers:my_shifts' %}" class="text-sm text-yellow-300 underline hover:text-yellow-200">
                 View my shifts

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -1,4 +1,3 @@
-import csv
 import logging
 
 from django.contrib import messages
@@ -6,6 +5,8 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.views.decorators.http import require_http_methods
+
+from titowebhooks.reports import normalized_csv
 
 from .forms import AssignByEmailForm, BulkTicketCreationForm, ClaimTicketForm
 from .models import OnlineAttendee, TicketEmailLog, TicketLink
@@ -222,25 +223,22 @@ def _handle_bulk_action(request: HttpRequest, action: str) -> None:
 
 
 def _attendees_csv(attendees, year: int) -> HttpResponse:
-    response = HttpResponse(content_type="text/csv")
-    response["Content-Disposition"] = f'attachment; filename="online_attendees_{year}.csv"'
-    writer = csv.writer(response)
-    writer.writerow(["Name", "Email", "Release", "Purchased", "Ticket Link", "Emails Sent", "Last Emailed"])
-    for attendee in attendees:
-        link = attendee.active_ticket_link
-        last_emailed = attendee.last_emailed_at
-        writer.writerow(
-            [
-                attendee.name,
-                attendee.email,
-                attendee.release_title,
-                attendee.purchased_at.isoformat() if attendee.purchased_at else "",
-                link.link if link else "",
-                attendee.sent_email_count,
-                last_emailed.isoformat() if last_emailed else "",
-            ]
-        )
-    return response
+    return normalized_csv(
+        f"online_attendees_{year}.csv",
+        ["Ticket Link", "Emails Sent", "Last Emailed"],
+        [
+            {
+                "Name": attendee.name,
+                "Email": attendee.email,
+                "Ticket Type": attendee.release_title,
+                "Ticket Date": attendee.purchased_at,
+                "Ticket Link": attendee.active_ticket_link.link if attendee.active_ticket_link else "",
+                "Emails Sent": attendee.sent_email_count,
+                "Last Emailed": attendee.last_emailed_at,
+            }
+            for attendee in attendees
+        ],
+    )
 
 
 @staff_member_required

--- a/titowebhooks/reports.py
+++ b/titowebhooks/reports.py
@@ -1,0 +1,120 @@
+"""One shape for every CSV report we hand out.
+
+The reports grew up separately and drifted: the ticket type was called
+``Release`` in one and ``Ticket Type`` in another and was missing entirely from
+a third, the purchase date was ``Purchased`` or ``Ticket Date`` depending on
+where you looked, and the historical export led with two extra columns so
+"column 0 is the name" was true of some files and not others.
+
+Every report now starts with the same four columns, in the same order. Anything
+a particular report knows beyond that is appended after them, so a consumer can
+rely on the prefix without the reports losing what makes them useful.
+"""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime, timezone
+
+from django.http import HttpResponse
+
+from titowebhooks.models import TitoWebhookEvent
+
+# The stable prefix. Do not reorder — spreadsheets and scripts key off it.
+CORE_COLUMNS = ["Name", "Email", "Ticket Type", "Ticket Date"]
+
+
+def normalized_csv(filename: str, extra_columns: list[str], rows: list[dict]) -> HttpResponse:
+    """Write a report as CSV: the core columns, then whatever else it carries.
+
+    Each row is a dict of ``{"Name": ..., "Ticket Date": ...}``. A column with
+    no value in a given row is written blank rather than shifting the columns.
+    """
+    columns = CORE_COLUMNS + extra_columns
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    writer = csv.writer(response)
+    writer.writerow(columns)
+    for row in rows:
+        writer.writerow([format_cell(row.get(column, "")) for column in columns])
+    return response
+
+
+def format_cell(value) -> str:
+    """Dates as ISO 8601, booleans as Yes/blank, everything else as-is."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "Yes" if value else ""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def release_title(payload: dict) -> str:
+    """Ti.to puts the release title in one of two places depending on the hook."""
+    title = payload.get("release_title")
+    if title:
+        return title
+    return (payload.get("release") or {}).get("title") or ""
+
+
+def parse_created_at(value: str | None):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def ticket_holders(match, *, event_slug: str) -> list[dict]:
+    """Everyone holding a ticket whose release title satisfies ``match``.
+
+    Ti.to fires several webhooks per ticket (completed, updated, voided...), so
+    the same person appears many times. Keep the most recent event per email,
+    then drop anyone whose latest event voided their ticket — a refunded sponsor
+    should not land on a sponsor mailing list.
+    """
+    events = TitoWebhookEvent.objects.order_by("timestamp")
+
+    latest_by_email: dict[str, TitoWebhookEvent] = {}
+    for event in events:
+        payload = event.payload or {}
+        if (payload.get("event") or {}).get("slug", "") != event_slug:
+            continue
+        if not match(release_title(payload)):
+            continue
+        email = (payload.get("email") or "").strip().lower()
+        if email:
+            latest_by_email[email] = event
+
+    people = []
+    for email, event in latest_by_email.items():
+        if event.trigger == "ticket.voided":
+            continue
+        payload = event.payload or {}
+        title = release_title(payload)
+        people.append(
+            {
+                "Name": payload.get("name") or "",
+                "Email": email,
+                "Ticket Type": title,
+                "Ticket Date": parse_created_at(payload.get("created_at")) or datetime.min.replace(tzinfo=timezone.utc),
+                "Company": payload.get("company_name") or "",
+                "Ticket Reference": payload.get("reference") or "",
+                "Online": "online" in title.lower(),
+            }
+        )
+
+    return sorted(people, key=lambda person: (person["Name"] or "").lower())
+
+
+def matches_speaker(title: str) -> bool:
+    """Speaker tickets, including any future "Speaker- Online" variant."""
+    return "speaker" in title.lower()
+
+
+def matches_sponsor(title: str) -> bool:
+    """Sponsor tickets — currently "Sponsor" and "Sponsor- Online"."""
+    return "sponsor" in title.lower()

--- a/titowebhooks/tests/test_views.py
+++ b/titowebhooks/tests/test_views.py
@@ -303,7 +303,10 @@ class TestHistoricalSprintTicketsCsv(TestCase):
         body = self._download()
 
         header = body.splitlines()[0]
-        assert header.startswith("Year,Event,Name,Email")
+        # Year and Event moved after the shared core columns so every report
+        # starts the same way; they are still present, just at the end.
+        assert header.startswith("Name,Email,Ticket Type,Ticket Date")
+        assert header.endswith("Year,Event")
         assert "DjangoCon US 2024" in body
         assert "DjangoCon US 2026" in body
         assert "alice@example.com" in body
@@ -378,7 +381,8 @@ class TestHistoricalSprintTicketsCsv(TestCase):
         body = self._download()
         rows = [line for line in body.splitlines()[1:] if "repeat@example.com" in line]
         assert len(rows) == 2
-        merged_2025 = next(r for r in rows if r.startswith("2025"))
+        # Year is now the second-to-last column rather than the first.
+        merged_2025 = next(r for r in rows if r.split(",")[-2] == "2025")
         # Both Thursday (leading) and Friday (joining) captured on one row.
         assert merged_2025.count("Yes") >= 2
 

--- a/titowebhooks/views.py
+++ b/titowebhooks/views.py
@@ -1,5 +1,4 @@
 import base64
-import csv
 import hashlib
 import hmac
 import json
@@ -21,6 +20,12 @@ from rich import print
 from emailoctopus.models import Campaign
 from tickets.sync import record_webhook_attendee
 from titowebhooks.models import TitoHistoricalEvent, TitoTicket, TitoWebhookEvent
+from titowebhooks.reports import (
+    matches_speaker,
+    matches_sponsor,
+    normalized_csv,
+    ticket_holders,
+)
 from titowebhooks.sales_curve import sales_curves
 from volunteers.models import VolunteerSignup
 from volunteers.permissions import volunteer_interest_required
@@ -316,45 +321,57 @@ def _extract_sprint_tickets(include_online: bool = False):
     return sorted(people.values(), key=lambda t: t["created_at"], reverse=True)
 
 
+SPRINT_EXTRA_COLUMNS = [
+    "Thursday",
+    "Thursday Leading",
+    "Thursday Joining",
+    "Friday",
+    "Friday Leading",
+    "Friday Joining",
+    "Online",
+]
+
+
+def _sprint_row(row: dict) -> dict:
+    """A sprint person in the shared column shape.
+
+    The sprint reports never carried a ticket type of their own — the release
+    title was decomposed into Thursday/Friday/Online flags and then discarded.
+    Rebuilding it from those flags keeps the core columns honest.
+    """
+    days = [day for day, present in (("Thursday", row["thursday"]), ("Friday", row["friday"])) if present]
+    kind = "Online Sprint" if row["online"] else "Sprint"
+    ticket_type = f"{kind} — {' & '.join(days)}" if days else kind
+    return {
+        "Name": row["name"],
+        "Email": row["email"],
+        "Ticket Type": ticket_type,
+        "Ticket Date": row["created_at"],
+        "Thursday": bool(row["thursday"]),
+        "Thursday Leading": row["thursday_leading"],
+        "Thursday Joining": row["thursday_joining"],
+        "Friday": bool(row["friday"]),
+        "Friday Leading": row["friday_leading"],
+        "Friday Joining": row["friday_joining"],
+        "Online": bool(row["online"]),
+    }
+
+
 def _historical_sprints_csv(include_online: bool) -> HttpResponse:
     rows = _extract_historical_sprints(include_online=include_online)
-    response = HttpResponse(content_type="text/csv")
-    response["Content-Disposition"] = 'attachment; filename="sprint_tickets_historical.csv"'
-    writer = csv.writer(response)
-    writer.writerow(
-        [
-            "Year",
-            "Event",
-            "Name",
-            "Email",
-            "Thursday",
-            "Thursday Leading",
-            "Thursday Joining",
-            "Friday",
-            "Friday Leading",
-            "Friday Joining",
-            "Online",
-            "Ticket Date",
-        ]
-    )
+    people = []
     for row in rows:
-        writer.writerow(
-            [
-                row["year"],
-                row["event_title"],
-                row["name"],
-                row["email"],
-                "Yes" if row["thursday"] else "",
-                row["thursday_leading"],
-                row["thursday_joining"],
-                "Yes" if row["friday"] else "",
-                row["friday_leading"],
-                row["friday_joining"],
-                "Yes" if row["online"] else "",
-                row["created_at"].isoformat() if row["created_at"] else "",
-            ]
-        )
-    return response
+        person = _sprint_row(row)
+        # Year and Event are what makes this report historical, but they go after
+        # the core columns so "column 0 is the name" holds here too.
+        person["Year"] = row["year"]
+        person["Event"] = row["event_title"]
+        people.append(person)
+    return normalized_csv(
+        "sprint_tickets_historical.csv",
+        SPRINT_EXTRA_COLUMNS + ["Year", "Event"],
+        people,
+    )
 
 
 @staff_member_required
@@ -367,39 +384,11 @@ def sprint_tickets_view(request: HttpRequest) -> HttpResponse:
     sprint_tickets = _extract_sprint_tickets(include_online=include_online)
 
     if request.GET.get("format") == "csv":
-        response = HttpResponse(content_type="text/csv")
-        response["Content-Disposition"] = 'attachment; filename="sprint_tickets.csv"'
-        writer = csv.writer(response)
-        writer.writerow(
-            [
-                "Name",
-                "Email",
-                "Thursday",
-                "Thursday Leading",
-                "Thursday Joining",
-                "Friday",
-                "Friday Leading",
-                "Friday Joining",
-                "Online",
-                "Ticket Date",
-            ]
+        return normalized_csv(
+            "sprint_tickets.csv",
+            SPRINT_EXTRA_COLUMNS,
+            [_sprint_row(ticket) for ticket in sprint_tickets],
         )
-        for ticket in sprint_tickets:
-            writer.writerow(
-                [
-                    ticket["name"],
-                    ticket["email"],
-                    "Yes" if ticket["thursday"] else "",
-                    ticket["thursday_leading"],
-                    ticket["thursday_joining"],
-                    "Yes" if ticket["friday"] else "",
-                    ticket["friday_leading"],
-                    ticket["friday_joining"],
-                    "Yes" if ticket["online"] else "",
-                    ticket["created_at"].isoformat() if ticket["created_at"] else "",
-                ]
-            )
-        return response
 
     leaders_count = sum(1 for t in sprint_tickets if t["thursday_leading"] == "Yes" or t["friday_leading"] == "Yes")
     joiners_count = sum(1 for t in sprint_tickets if t["thursday_joining"] == "Yes" or t["friday_joining"] == "Yes")
@@ -618,22 +607,21 @@ def _extract_volunteer_interest() -> list[dict]:
 
 
 def _volunteer_interest_csv(people: list[dict]) -> HttpResponse:
-    response = HttpResponse(content_type="text/csv")
-    response["Content-Disposition"] = 'attachment; filename="volunteer_interest.csv"'
-    writer = csv.writer(response)
-    writer.writerow(["Name", "Email", "Company", "Ticket Reference", "Ticket Type", "Ticket Date"])
-    for person in people:
-        writer.writerow(
-            [
-                person["name"],
-                person["email"],
-                person["company_name"],
-                person["reference"],
-                person["release_title"],
-                person["created_at"].isoformat() if person["created_at"] else "",
-            ]
-        )
-    return response
+    return normalized_csv(
+        "volunteer_interest.csv",
+        ["Company", "Ticket Reference"],
+        [
+            {
+                "Name": person["name"],
+                "Email": person["email"],
+                "Ticket Type": person["release_title"],
+                "Ticket Date": person["created_at"],
+                "Company": person["company_name"],
+                "Ticket Reference": person["reference"],
+            }
+            for person in people
+        ],
+    )
 
 
 @volunteer_interest_required
@@ -658,3 +646,17 @@ def volunteer_interest_view(request: HttpRequest) -> HttpResponse:
         "not_signed_up_count": sum(1 for p in people if not p["has_signed_up"]),
     }
     return render(request, "titowebhooks/volunteer_interest.html", context)
+
+
+@staff_member_required
+def speakers_report_view(request: HttpRequest) -> HttpResponse:
+    """Speaker ticket holders, as a CSV download."""
+    people = ticket_holders(matches_speaker, event_slug=EVENT_SLUG)
+    return normalized_csv("speakers.csv", ["Company", "Ticket Reference", "Online"], people)
+
+
+@staff_member_required
+def sponsors_report_view(request: HttpRequest) -> HttpResponse:
+    """Sponsor ticket holders, as a CSV download."""
+    people = ticket_holders(matches_sponsor, event_slug=EVENT_SLUG)
+    return normalized_csv("sponsors.csv", ["Company", "Ticket Reference", "Online"], people)


### PR DESCRIPTION
Two new reports, one shared column contract, and a Reports panel on the homepage.

## New reports

Both key off the Ti.to release title, matched case-insensitively so the `- Online` variants come along:

| Report | URL | Matches |
|---|---|---|
| Speakers | `/reports/speakers.csv` | `"speaker" in release_title` |
| Sponsors | `/reports/sponsors.csv` | `"sponsor" in release_title` — `Sponsor`, `Sponsor- Online` |

Verified against the production webhook log: **22 speakers, 30 sponsors, every address distinct.** The dedup earns its keep — 30 raw `Speaker` tickets collapse to 22 people.

## One shape for every report

`titowebhooks/reports.py` now owns the contract. Every report starts with the same four columns and appends its own after them:

```
Name, Email, Ticket Type, Ticket Date, <report-specific columns…>
```

What changed, and why each was a problem:

- **`Release` → `Ticket Type`** (online attendees) — the same concept had two names.
- **`Purchased` → `Ticket Date`** (online attendees) — likewise.
- **Sprint reports gained a `Ticket Type`** — they decomposed the release title into Thursday/Friday/Online flags and then *discarded* it, so the ticket type never appeared. It's rebuilt from those flags (e.g. `Sprint — Thursday & Friday`).
- **Historical: `Year, Event` moved to the end** — it led with them, so "column 0 is the name" held for three reports and not the fourth.

⚠️ **This is a breaking change** for any existing spreadsheet or script keyed to the old headers. Flagged deliberately — it's the whole point of the change, but worth knowing before someone's saved filter stops working.

## Distinct by email

Confirmed each report is one row per person, and pinned it with parametrized tests over *all* of them:

| Report | Dedup |
|---|---|
| Speakers / Sponsors | latest event per address, voided dropped |
| Volunteer interest | latest event per address, voided dropped |
| Sprint tickets | consolidated per address, days merged |
| Sprint historical | per address **per year** — deliberate, asserted as such |
| Online attendees | DB constraint on `(year, email)` |

Addresses are lowercased and stripped everywhere, so Ti.to's inconsistent casing can't produce two rows for one person. The test fixture feeds in the same person three times under three spellings, so the assertions can't pass vacuously on empty data.

## Reports panel

Staff-only section on the homepage; each link downloads a CSV directly, no landing page.

It lists only what **that** user can open. The reports don't share one access rule — volunteer interest is superusers and volunteer chairs, not staff at large — so a blanket `is_staff` panel would have handed plain staff a 403 on click. `REPORTS` carries a `can_view` per entry mirroring the decorator on each view.

## Testing

- New `config/tests/test_reports.py`: 26 tests — core-column prefix and `Content-Disposition: attachment` across every report, dedup across every report, the old column names gone, and the panel's visibility rules.
- Two existing tests updated: both pinned the old `Year,Event,Name,Email` ordering, which is the behaviour being changed.
- Full suite: **390 passed**
- `just lint`: clean