### PR TITLE
:lipstick: Give the homepage nav the same cards as Volunteers and Reports

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -5,7 +5,7 @@
 {% block title %}DjangoCon US - Homepage{% endblock title %}
 
 {% block content %}
-    <div class="mx-auto flex max-w-3xl flex-col gap-8 rounded-xl bg-green-900 p-12 text-center text-green-200 shadow-inner">
+    <div class="mx-auto flex max-w-5xl flex-col gap-8 rounded-xl bg-green-900 p-12 text-center text-green-200 shadow-inner">
         <div class="text-6xl font-bold sm:tracking-tight">
             <div class="text-yellow-200">DjangoCon US</div>
             <div class="text-green-300">Automations</div>
@@ -47,7 +47,7 @@
                     {% for report in reports %}
                         <li>
                             <a href="{{ report.url }}"
-                               class="flex flex-col rounded-lg border border-green-700 bg-green-900 px-4 py-3 hover:border-yellow-300">
+                               class="flex h-full flex-col rounded-lg border border-green-700 bg-green-900 px-4 py-3 hover:border-yellow-300">
                                 <span class="font-semibold text-yellow-200">⬇ {{ report.label }}</span>
                                 <span class="text-xs text-green-300">{{ report.description }}</span>
                             </a>
@@ -58,10 +58,6 @@
         {% endif %}
 
         {% if user.is_authenticated %}
-            <a href="{% url 'volunteers:my_shifts' %}" class="text-sm text-yellow-300 underline hover:text-yellow-200">
-                View my shifts
-            </a>
-
             {% django_simple_nav "config.nav.MainNav" %}
         {% else %}
             <a href="{% url 'account_login' %}"

--- a/templates/nav/main.html
+++ b/templates/nav/main.html
@@ -1,19 +1,35 @@
-<nav class="w-full">
+{% comment %}
+    Rendered on the homepage under the Volunteers/Traveling cards and the
+    Reports panel, so it borrows their shapes rather than inventing a third:
+    a group is a bordered panel with a yellow heading, and each link inside is
+    a card on the darker green, same as a report row.
+{% endcomment %}
+{% comment %}
+    items-start: panels size to their own content, so a one-link group next to a
+    four-link one does not inherit its height as empty space.
+{% endcomment %}
+<nav class="grid w-full items-start gap-6 text-left md:grid-cols-2">
     {% for item in items %}
         {% if item.items %}
-            <div class="space-y-2 text-2xl {% if not forloop.first %}mt-4 pt-4 border-t border-green-700{% endif %}">
-                <h3 class="mb-4 text-3xl font-semibold text-green-100">{{ item.title }}</h3>
-                {% for child in item.items %}
-                    <div>
-                        <a class="p-2 text-yellow-300 underline hover:text-yellow-200" href="{{ child.url }}">{{ child.title }}</a>
-                    </div>
-                {% endfor %}
+            <div class="rounded-xl border border-green-700 bg-green-800 p-6">
+                <h2 class="mb-4 text-2xl font-bold text-yellow-200">{{ item.title }}</h2>
+                <ul class="grid gap-2">
+                    {% for child in item.items %}
+                        <li>
+                            <a href="{{ child.url }}"
+                               class="flex h-full items-center rounded-lg border border-green-700 bg-green-900 px-4 py-3 font-semibold text-yellow-200 hover:border-yellow-300">
+                                {{ child.title }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
             </div>
         {% else %}
             {% if not item.anonymous_only or not request.user.is_authenticated %}
-                <div class="text-2xl">
-                    <a class="p-2 text-yellow-300 underline" href="{{ item.url }}">{{ item.title }}</a>
-                </div>
+                <a href="{{ item.url }}"
+                   class="mx-auto block w-full max-w-md rounded-lg bg-green-600 px-6 py-4 text-center text-xl font-semibold text-white shadow hover:bg-green-700 md:col-span-2">
+                    {{ item.title }}
+                </a>
             {% endif %}
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
The homepage changed visual language halfway down: the Volunteers/Traveling cards and the Reports panel are bordered cards, then the nav below them was a column of large underlined text links.

## What changed

Each nav group is now a bordered panel with a yellow heading, and its links are cards on the darker green — the same shapes the Reports panel already used, so `nav/main.html` borrows them rather than inventing a third style.

Two layout fixes came out of actually looking at the rendered page:

- **Two-up on wider screens** (container `max-w-3xl` → `max-w-5xl`). Eight stacked full-width panels made the page ~2400px tall; it's now ~1600px.
- **`items-start`** so a panel sizes to its own content. Without it, Thunderdome (one link) stretched to match Ticket Management (three) and sat in a pool of empty green.

Also drops the standalone "View my shifts" link — the Volunteers panel immediately below it already has **My Shifts**, so it was a duplicate.

## Verified in the browser

Ran the app and screenshotted both states rather than trusting the markup:

- **Staff, signed in** — hero, two feature cards, Reports panel, then six nav panels two-up: Ticket Management, Thunderdome, Sprints, Sales, Volunteers, Administration.
- **Signed out** — hero, two feature cards, Sign In button. Unchanged.

Worth noting for anyone doing this next: **django_simple_nav caches the rendered nav**, so edits to `nav/main.html` don't appear until the web container restarts. My first screenshot was silently stale.

## Testing

- Full suite: **416 passed** (no Python touched)
- `just lint`: clean — rustywind reordered one Tailwind class list