### PR TITLE
:wrench: Stop registering background jobs on every worker boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,19 @@ The web container runs `/src/start-web.sh`, the worker runs `/src/start-worker.s
 ssh defna-node1 'docker inspect -f "{{.Name}} {{.Config.Cmd}}" $(docker ps -q)'
 ```
 
+**Background jobs are not registered automatically.** `sync_schedules` creates
+django-q `Schedule` rows from `Q_SCHEDULES`, and it used to run on every worker
+boot — so a deploy could silently add a job. It no longer runs at startup.
+Schedules already in the database keep running; adding a new one is a deliberate,
+manual step:
+
+```bash
+ssh defna-node1 'docker exec -w /src <web-container> uv run --no-sync manage.py sync_schedules'
+```
+
+Note it only ever *creates* — it never updates or deletes an existing schedule,
+so correcting one means editing or deleting the row itself.
+
 Run Django management commands in the web container (app lives at `/src`, deps via uv):
 
 ```bash

--- a/start-worker.sh
+++ b/start-worker.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 uv run -m manage migrate --noinput
-uv run -m manage sync_schedules
 
+# sync_schedules is deliberately NOT run here. It creates django-q Schedule rows
+# from Q_SCHEDULES on every worker boot, which meant a deploy could quietly add
+# or re-add a background job. Schedules already in the database keep running
+# untouched; this only stops deploys from registering them behind our backs.
+#
+# To register a new or missing job, run it by hand:
+#     ssh defna-node1
+#     docker exec -w /src <web-container> uv run --no-sync manage.py sync_schedules
 uv run -m manage qcluster


### PR DESCRIPTION
`start-worker.sh` ran `manage.py sync_schedules` on every boot, which created django-q `Schedule` rows from `Q_SCHEDULES` — so a deploy could quietly add a background job. Registering one is now a deliberate, manual step.

**Nothing stops running.** Schedules already in the database are untouched; this only stops deploys from adding them. To register a new or missing job:

```bash
ssh defna-node1 'docker exec -w /src <web-container> uv run --no-sync manage.py sync_schedules'
```

Documented in CLAUDE.md, including the sharp edge that `sync_schedules` only ever *creates* — it never updates or deletes — so correcting a schedule means editing the row itself.

## Verified: nothing auto-imports the conference schedule

Checked all three places it could hide:

| Where | Result |
|---|---|
| `Q_SCHEDULES` in settings | 4 entries: emailoctopus, travel-safety retention, volunteer reminders, volunteer digest |
| django-q `Schedule` table in production | 7 rows, **0** matching `import_schedule` or `sync_schedules` |
| Pending task queue (`OrmQ`) | empty |

And the only caller of `import_schedule` anywhere in the repo is `volunteers/views.py:406` — the "Sync schedule now" button. No task, no schedule, no host cron reaches it. The conference schedule changes only when a human presses that button.

## Testing

- Full suite: **431 passed** (no Python touched)
- `sh -n start-worker.sh` parses; file mode still 755
- `just lint`: clean