### PR TITLE
:bug: Stop sync_schedules silently downgrading unknown schedule types

### DIFF
--- a/titowebhooks/management/commands/sync_schedules.py
+++ b/titowebhooks/management/commands/sync_schedules.py
@@ -13,23 +13,59 @@ SCHEDULE_TYPE_MAP = {
     "MONTHLY": Schedule.MONTHLY,
     "QUARTERLY": Schedule.QUARTERLY,
     "YEARLY": Schedule.YEARLY,
+    # Cron expressions are evaluated against django.utils.timezone.localtime(),
+    # so they run in TIME_ZONE (America/Chicago) and follow DST on their own.
+    "CRON": Schedule.CRON,
 }
 
 
-def _ensure_schedule(*, name, func, schedule_type, args=None):
+class UnknownScheduleType(click.ClickException):
+    pass
+
+
+def _resolve_type(name, config):
+    """Map a Q_SCHEDULES entry's schedule_type, refusing anything unrecognised.
+
+    This used to be ``SCHEDULE_TYPE_MAP.get(..., Schedule.DAILY)``, which turned
+    a typo — or a type this map simply didn't know, as CRON was — into a daily
+    job firing at whatever time the command happened to run. The digest sat at
+    16:57 for days because of it. Better to fail the deploy than to schedule
+    something silently wrong.
+    """
+    raw = config["schedule_type"]
+    if raw not in SCHEDULE_TYPE_MAP:
+        known = ", ".join(sorted(SCHEDULE_TYPE_MAP))
+        raise UnknownScheduleType(f"{name}: unknown schedule_type {raw!r}. Known types: {known}.")
+
+    schedule_type = SCHEDULE_TYPE_MAP[raw]
+    if schedule_type == Schedule.CRON and not config.get("cron"):
+        raise UnknownScheduleType(f"{name}: schedule_type CRON needs a 'cron' expression.")
+    return schedule_type
+
+
+def _ensure_schedule(*, name, func, schedule_type, args=None, cron=None):
     """Create a schedule if it doesn't exist. Never updates or deletes existing schedules."""
-    schedule, created = Schedule.objects.get_or_create(
-        name=name,
-        defaults={
-            "func": func,
-            "schedule_type": schedule_type,
-            **({"args": args} if args else {}),
-        },
-    )
+    defaults = {
+        "func": func,
+        "schedule_type": schedule_type,
+        **({"args": args} if args else {}),
+        **({"cron": cron} if cron else {}),
+    }
+    schedule, created = Schedule.objects.get_or_create(name=name, defaults=defaults)
     if created:
         print(f"[green]Created {name} ({func})[/green]")
     else:
-        print(f"[yellow]Exists {name} ({schedule.func}) — skipping[/yellow]")
+        # Worth saying out loud: a schedule whose settings changed keeps its old
+        # row, so correcting one means editing it directly.
+        drifted = schedule.schedule_type != schedule_type or (cron and schedule.cron != cron)
+        if drifted:
+            print(
+                f"[red]Exists {name} but does NOT match settings "
+                f"(is {schedule.schedule_type}/{schedule.cron!r}, "
+                f"settings say {schedule_type}/{cron!r}) — edit the row to change it[/red]"
+            )
+        else:
+            print(f"[yellow]Exists {name} ({schedule.func}) — skipping[/yellow]")
 
 
 @click.command()
@@ -37,12 +73,12 @@ def command():
     """Ensure all scheduled tasks exist. Never modifies or deletes existing schedules."""
     # Sync schedules defined in settings.Q_SCHEDULES
     for name, config in getattr(settings, "Q_SCHEDULES", {}).items():
-        schedule_type = SCHEDULE_TYPE_MAP.get(config["schedule_type"], Schedule.DAILY)
         _ensure_schedule(
             name=name,
             func=config["func"],
-            schedule_type=schedule_type,
+            schedule_type=_resolve_type(name, config),
             args=config.get("args"),
+            cron=config.get("cron"),
         )
 
     # Sync pretalx event schedules from the database

--- a/titowebhooks/tests/test_sync_schedules.py
+++ b/titowebhooks/tests/test_sync_schedules.py
@@ -1,0 +1,82 @@
+"""Registering background jobs from Q_SCHEDULES.
+
+The map used to fall back to DAILY for anything it didn't recognise, so adding
+``schedule_type: "CRON"`` — a type it had never been taught — silently produced
+a daily job firing at whatever time the command happened to run. The volunteer
+digest sat at 16:57 local for days looking correctly configured in settings.
+These tests pin that cron works and that an unknown type fails loudly.
+"""
+
+import pytest
+from django.core.management import call_command
+from django_q.models import Schedule
+
+from titowebhooks.management.commands.sync_schedules import UnknownScheduleType, _resolve_type
+
+CRON_7AM = "0 7 * * *"
+
+
+@pytest.fixture
+def only_digest(settings):
+    """One schedule, so a test isn't asserting against the whole roster."""
+    settings.Q_SCHEDULES = {
+        "volunteer-daily-digest": {
+            "func": "volunteers.tasks.send_daily_shift_digest",
+            "schedule_type": "CRON",
+            "cron": CRON_7AM,
+        }
+    }
+    return settings
+
+
+@pytest.mark.django_db
+class TestCronSchedules:
+    def test_a_cron_entry_is_created_as_cron(self, only_digest):
+        call_command("sync_schedules")
+
+        schedule = Schedule.objects.get(name="volunteer-daily-digest")
+        assert schedule.schedule_type == Schedule.CRON, "CRON must not silently become DAILY"
+        assert schedule.cron == CRON_7AM
+
+    def test_the_next_run_lands_at_7am_chicago(self, only_digest):
+        """django-q feeds croniter timezone.localtime(), so 0 7 is 7am in TIME_ZONE.
+
+        Asserted in Chicago rather than UTC on purpose: a UTC cron would drift an
+        hour twice a year when daylight saving flips.
+        """
+        from django.utils.timezone import localtime
+
+        call_command("sync_schedules")
+        schedule = Schedule.objects.get(name="volunteer-daily-digest")
+
+        assert localtime(schedule.calculate_next_run()).hour == 7
+
+    def test_running_twice_does_not_duplicate(self, only_digest):
+        call_command("sync_schedules")
+        call_command("sync_schedules")
+
+        assert Schedule.objects.filter(name="volunteer-daily-digest").count() == 1
+
+
+class TestUnknownTypesFailLoudly:
+    def test_an_unrecognised_type_raises(self):
+        with pytest.raises(UnknownScheduleType) as exc:
+            _resolve_type("some-job", {"schedule_type": "FORTNIGHTLY"})
+
+        assert "FORTNIGHTLY" in str(exc.value)
+
+    def test_a_typo_does_not_quietly_become_daily(self):
+        """The actual failure mode: 'CRON' wasn't in the map, so it became DAILY."""
+        with pytest.raises(UnknownScheduleType):
+            _resolve_type("some-job", {"schedule_type": "Daily"})  # wrong case
+
+    def test_cron_without_an_expression_raises(self):
+        with pytest.raises(UnknownScheduleType) as exc:
+            _resolve_type("some-job", {"schedule_type": "CRON"})
+
+        assert "cron" in str(exc.value).lower()
+
+    def test_known_types_still_resolve(self):
+        assert _resolve_type("j", {"schedule_type": "HOURLY"}) == Schedule.HOURLY
+        assert _resolve_type("j", {"schedule_type": "DAILY"}) == Schedule.DAILY
+        assert _resolve_type("j", {"schedule_type": "CRON", "cron": CRON_7AM}) == Schedule.CRON


### PR DESCRIPTION
## The bug

```python
schedule_type = SCHEDULE_TYPE_MAP.get(config["schedule_type"], Schedule.DAILY)
```

Anything the map hadn't been taught became **DAILY**, firing at whatever time the command happened to run. `CRON` was never in the map, so the digest I added in #148 looked correct in settings and ran at **16:57 local** — an evening "here are your shifts today" email.

I caused this by assuming django-q reads `Q_SCHEDULES`. It doesn't; this repo's own command does, and it defaulted silently.

## The fix

- `CRON` is mapped, and its expression is passed through to the row.
- An unrecognised `schedule_type` **raises** instead of guessing — including a case typo like `"Daily"`, which would previously have worked by accident.
- `CRON` without a `cron` expression raises too.
- When an existing schedule no longer matches settings, the command now says so in red. It still never updates (that's deliberate), so correcting one means editing the row.

## Timezone

django-q evaluates cron against `timezone.localtime()`:

```python
return croniter(self.cron, localtime()).get_next(datetime)   # django_q/models.py:249
```

So `0 7 * * *` is **7am America/Chicago** and follows DST on its own. A UTC expression would have drifted an hour twice a year. There's a test asserting the next run lands at hour 7 *in local time* rather than UTC.

## Production is already corrected

The existing row couldn't be fixed by code, since the command only ever creates:

```
BEFORE  type=D cron=None next_local=2026-08-18 16:57:33-05:00
AFTER   type=C cron='0 7 * * *' next_local=2026-08-18 07:00:00-05:00
```

## Testing

7 new tests: cron created as cron, next run at 7am Chicago, no duplicate on re-run, unknown type raises, case typo raises, CRON without an expression raises, known types still resolve.

- Full suite: **454 passed**
- `just lint`: clean