### PR TITLE
:sparkles: Make the Venueless link configurable via VENUELESS_URL

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -351,6 +351,12 @@ VOLUNTEER_HANDBOOK_URL = env.str(
     default="https://docs.google.com/document/d/1jpRr5jUxiQCgeXvnX-RPee1AsB1parzHRzCg3YcLCXA/edit?usp=sharing",
 )
 
+# Venueless instance for the online conference, linked from the ticket-claim
+# page. It changes every year, so it is set per environment rather than pinned
+# in here; blank (the default) hides the link instead of shipping a stale one.
+VENUELESS_URL = env.str("VENUELESS_URL", default="")
+
+
 # Slack settings
 
 SLACK_OAUTH_TOKEN = env("SLACK_OAUTH_TOKEN", default="")

--- a/config/settings.py
+++ b/config/settings.py
@@ -352,9 +352,9 @@ VOLUNTEER_HANDBOOK_URL = env.str(
 )
 
 # Venueless instance for the online conference, linked from the ticket-claim
-# page. It changes every year, so it is set per environment rather than pinned
-# in here; blank (the default) hides the link instead of shipping a stale one.
-VENUELESS_URL = env.str("VENUELESS_URL", default="")
+# page. The host changes every year, so it is overridable per environment;
+# blank hides the link rather than pointing people at a dead instance.
+VENUELESS_URL = env.str("VENUELESS_URL", default="https://dcus26.venueless.events")
 
 
 # Slack settings

--- a/templates/tickets/info.html
+++ b/templates/tickets/info.html
@@ -98,16 +98,18 @@
                             If you've already claimed a ticket, enter your email to retrieve it.
                         </p>
 
-                        <div class="bg-opacity-30 rounded-lg bg-blue-800 p-4">
-                            <p class="text-sm text-blue-200">
-                                <strong>Already registered?</strong> You can go directly to:
-                            </p>
-                            <a href="https://dcus25.venueless.events"
-                               target="_blank"
-                               class="mt-2 inline-block rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-green-900 transition-colors duration-300 hover:bg-yellow-400">
-                                dcus25.venueless.events
-                            </a>
-                        </div>
+                        {% if venueless_url %}
+                            <div class="bg-opacity-30 rounded-lg bg-blue-800 p-4">
+                                <p class="text-sm text-blue-200">
+                                    <strong>Already registered?</strong> You can go directly to:
+                                </p>
+                                <a href="{{ venueless_url }}"
+                                   target="_blank"
+                                   class="mt-2 inline-block rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-green-900 transition-colors duration-300 hover:bg-yellow-400">
+                                    {{ venueless_label|default:venueless_url }}
+                                </a>
+                            </div>
+                        {% endif %}
                     </div>
                 {% else %}
                     <div class="py-8 text-center">

--- a/tickets/tests/test_views.py
+++ b/tickets/tests/test_views.py
@@ -64,3 +64,26 @@ def test_tickets_info_view_with_no_available_tickets(tp):
     assert "tickets_available" in response.context
     assert response.context["tickets_available"] is False
     assert b"No Tickets Available" in response.content
+
+
+@pytest.mark.django_db
+def test_tickets_info_view_shows_venueless_link(tp, ticket_links, settings):
+    settings.VENUELESS_URL = "https://dcus26.venueless.events"
+
+    response = tp.get("tickets_info")
+
+    assert response.status_code == 200
+    assert response.context["venueless_url"] == "https://dcus26.venueless.events"
+    # The button reads as a bare domain even though the setting carries a scheme.
+    assert response.context["venueless_label"] == "dcus26.venueless.events"
+    assert b"https://dcus26.venueless.events" in response.content
+
+
+@pytest.mark.django_db
+def test_tickets_info_view_hides_venueless_link_when_unset(tp, ticket_links, settings):
+    settings.VENUELESS_URL = ""
+
+    response = tp.get("tickets_info")
+
+    assert response.status_code == 200
+    assert b"Already registered?" not in response.content

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -1,5 +1,7 @@
 import logging
+from urllib.parse import urlparse
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpRequest, HttpResponse
@@ -37,11 +39,15 @@ def tickets_info(request: HttpRequest) -> HttpResponse:
     else:
         form = ClaimTicketForm()
 
+    venueless_url = settings.VENUELESS_URL
     context = {
         "tickets_available": tickets_available,
         "form": form,
         "ticket_link": ticket_link,
         "is_existing": is_existing,
+        "venueless_url": venueless_url,
+        # The button reads as a domain rather than a full URL, so drop the scheme.
+        "venueless_label": urlparse(venueless_url).netloc if venueless_url else "",
     }
     return render(request, "tickets/info.html", context)
 


### PR DESCRIPTION
## Problem

The ticket-claim page linked to `https://dcus25.venueless.events`, hardcoded in `templates/tickets/info.html`. That is last year's instance, and updating it means a code change every conference.

## Change

- New `VENUELESS_URL` setting (`config/settings.py`), defaulting to `https://dcus26.venueless.events` and overridable per environment via the env var.
- `tickets_info` passes `venueless_url` plus `venueless_label` (the netloc), so the button keeps reading as a bare domain while the setting carries a full URL.
- The template block is wrapped in `{% if venueless_url %}` — setting the env var to blank hides the link rather than pointing people at a dead instance.

## Notes

No action needed in Coolify: the default is this year's host. Set `VENUELESS_URL` there only if the host changes mid-season, or to blank to hide the button.

## Testing

- Two new tests in `tickets/tests/test_views.py`: link renders when set, block hidden when blank.
- Full suite passes (456), `just lint` clean.