### PR TITLE
Preview the ticket email an attendee will actually receive

### DIFF
--- a/config/tests/test_email_branding.py
+++ b/config/tests/test_email_branding.py
@@ -18,7 +18,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 
-from tickets.tasks import SUBJECTS
+from tickets.emails import SUBJECTS
 from volunteers.models import Role, Shift, VolunteerSignup
 from volunteers.tasks import notify_shift_uncovered, send_shift_reminders
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ from thunderdome.views import (
     sync_from_pretalx_view,
 )
 from tickets.views import (
+    attendee_email_preview_view,
     claim_ticket_view,
     create_tickets_view,
     online_attendees_view,
@@ -49,6 +50,7 @@ urlpatterns = [
     path("tickets/list/", tickets_list_view, name="tickets_list"),
     path("tickets/claim/", claim_ticket_view, name="claim_ticket"),
     path("tickets/attendees/", online_attendees_view, name="online_attendees"),
+    path("tickets/attendees/<int:pk>/email/", attendee_email_preview_view, name="attendee_email_preview"),
     path("tickets/emails/", ticket_emails_view, name="ticket_emails"),
     path("sprints/tickets/", sprint_tickets_view, name="sprint_tickets"),
     path("reports/speakers.csv", speakers_report_view, name="report_speakers"),

--- a/templates/tickets/attendees.html
+++ b/templates/tickets/attendees.html
@@ -218,6 +218,10 @@
                                                 Assign link
                                             </button>
                                         {% endif %}
+                                        <a href="{% url 'attendee_email_preview' attendee.pk %}"
+                                           class="mt-1 block text-xs text-yellow-300 underline hover:text-yellow-200">
+                                            Preview email
+                                        </a>
                                     </td>
                                 </tr>
                             {% endfor %}

--- a/templates/tickets/email_preview.html
+++ b/templates/tickets/email_preview.html
@@ -1,0 +1,153 @@
+{% extends "base.html" %}
+
+{% block body_class %}flex flex-col p-4 min-h-screen text-white bg-green-900 bg-gradient-to-b from-green-900 to-black via-green-950{% endblock body_class %}
+{% block main_class %}flex-1 mx-auto w-full text-white{% endblock main_class %}
+
+{% block title %}Email preview for {{ attendee.email }} - DjangoCon US Automation{% endblock title %}
+
+{% block content %}
+    <div class="mx-auto max-w-5xl p-6">
+        <div class="mb-6">
+            <a href="{% url 'online_attendees' %}?year={{ year }}" class="text-sm text-gray-400 hover:text-gray-200">&larr; Online attendees</a>
+            <h1 class="text-3xl font-bold">{{ attendee.name|default:attendee.email }}</h1>
+            <p class="mt-1 text-sm text-gray-400">
+                The real email this attendee would receive, rendered with their own link.
+            </p>
+        </div>
+
+        <div class="mb-6 flex flex-wrap gap-2">
+            {% comment %}
+                One chip per kind of send. Each is its own URL, so a chair can
+                paste "the reissue one" into Slack and everyone sees the same page.
+            {% endcomment %}
+            {% for value, label in kinds %}
+                <a href="?kind={{ value }}{% if view == 'text' %}&view=text{% endif %}"
+                   class="rounded-full border px-3 py-1 text-sm {% if value == kind %}border-yellow-300 bg-yellow-300 font-semibold text-green-900{% else %}border-green-700 bg-green-800 text-green-100 hover:bg-green-700{% endif %}">
+                    {{ label }}
+                </a>
+            {% endfor %}
+        </div>
+
+        <dl class="mb-6 grid gap-3 rounded-lg border border-green-700 bg-green-800/50 p-4 text-sm">
+            <div>
+                <dt class="text-xs tracking-wide text-gray-400 uppercase">Subject</dt>
+                <dd class="mt-1 font-semibold text-yellow-200">{{ rendered.subject }}</dd>
+            </div>
+            <div>
+                <dt class="text-xs tracking-wide text-gray-400 uppercase">To</dt>
+                <dd class="mt-1 text-gray-200">{{ attendee.email }}</dd>
+            </div>
+            <div>
+                <dt class="text-xs tracking-wide text-gray-400 uppercase">Ticket link in this preview</dt>
+                <dd class="mt-1 font-mono text-xs break-all text-gray-300">
+                    {% if ticket_link %}
+                        {{ ticket_link.link }}
+                    {% else %}
+                        <span class="text-yellow-300">None assigned yet — a placeholder is shown below.</span>
+                    {% endif %}
+                </dd>
+            </div>
+            <div>
+                <dt class="text-xs tracking-wide text-gray-400 uppercase">Emails sent so far</dt>
+                <dd class="mt-1 text-gray-200">
+                    {{ attendee.sent_email_count }}
+                    {% if attendee.last_emailed_at %}
+                        &middot; last on {{ attendee.last_emailed_at|date:"M d, Y g:i A" }}
+                    {% else %}
+                        &middot; never emailed
+                    {% endif %}
+                </dd>
+            </div>
+        </dl>
+
+        {% if link_is_placeholder %}
+            <p class="mb-4 rounded-lg border border-yellow-600 bg-yellow-900/40 p-3 text-sm text-yellow-100">
+                This attendee holds no link yet, so the preview shows a stand-in URL. Sending pulls a real
+                link from the pool and that is what they will receive.
+            </p>
+        {% elif is_reissue %}
+            <p class="mb-4 rounded-lg border border-yellow-600 bg-yellow-900/40 p-3 text-sm text-yellow-100">
+                A reissue mints a fresh link at send time and retires the one shown here, so the wording is
+                exact but the URL will differ.
+            </p>
+        {% endif %}
+
+        <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
+            <div class="inline-flex overflow-hidden rounded-lg border border-green-700">
+                <a href="?kind={{ kind }}&view=rich"
+                   class="px-4 py-2 text-sm font-semibold {% if view == 'rich' %}bg-yellow-300 text-green-900{% else %}bg-green-800 text-green-100 hover:bg-green-700{% endif %}">
+                    Rich
+                </a>
+                <a href="?kind={{ kind }}&view=text"
+                   class="px-4 py-2 text-sm font-semibold {% if view == 'text' %}bg-yellow-300 text-green-900{% else %}bg-green-800 text-green-100 hover:bg-green-700{% endif %}">
+                    Plain text
+                </a>
+            </div>
+
+            {% if view == 'rich' %}
+                <a href="?kind={{ kind }}&part=html" target="_blank" rel="noopener" class="text-sm text-yellow-300 underline hover:text-yellow-200">
+                    Open standalone &nearr;
+                </a>
+            {% endif %}
+        </div>
+
+        {% if view == 'rich' %}
+            {% comment %}
+                force_escape is required: render_to_string returns a SafeString, so without it the
+                body's own quotes close the srcdoc attribute early and the iframe renders blank.
+                sandbox: the preview is our own markup, but it should never be able to script this page.
+            {% endcomment %}
+            <iframe title="HTML preview of the ticket email for {{ attendee.email }}"
+                    sandbox
+                    srcdoc="{{ rendered.html_body|force_escape }}"
+                    class="h-[40rem] w-full rounded-lg border border-green-700 bg-white"></iframe>
+        {% else %}
+            <pre class="overflow-x-auto rounded-lg border border-green-700 bg-black/40 p-4 text-sm whitespace-pre-wrap text-gray-100">{{ rendered.text_body }}</pre>
+        {% endif %}
+
+        <h2 class="mt-8 mb-3 text-xl font-bold">Send history</h2>
+        {% if logs %}
+            <div class="overflow-x-auto">
+                <table class="bg-opacity-30 w-full overflow-hidden rounded-lg bg-green-800 text-sm">
+                    <thead class="bg-opacity-50 bg-green-700">
+                        <tr>
+                            <th class="px-4 py-2 text-left text-xs font-medium tracking-wider uppercase">Kind</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium tracking-wider uppercase">Status</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium tracking-wider uppercase">Queued</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium tracking-wider uppercase">Sent</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium tracking-wider uppercase">By</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-green-700">
+                        {% for log in logs %}
+                            <tr>
+                                <td class="px-4 py-2">{{ log.get_kind_display }}</td>
+                                <td class="px-4 py-2">
+                                    <span class="{% if log.status == 'sent' %}text-green-300{% elif log.status == 'failed' %}text-red-300{% else %}text-yellow-200{% endif %}">
+                                        {{ log.get_status_display }}
+                                    </span>
+                                    {% if log.error %}
+                                        <span class="block text-xs text-red-300" title="{{ log.error }}">{{ log.error|truncatechars:80 }}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="px-4 py-2 whitespace-nowrap">{{ log.date_queued|date:"M d, Y g:i A" }}</td>
+                                <td class="px-4 py-2 whitespace-nowrap">
+                                    {% if log.date_sent %}
+                                        {{ log.date_sent|date:"M d, Y g:i A" }}
+                                    {% else %}
+                                        <span class="text-gray-500">—</span>
+                                    {% endif %}
+                                </td>
+                                <td class="px-4 py-2">{{ log.sent_by|default:"—" }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="rounded-lg border border-green-700 bg-green-800/40 p-4 text-sm text-gray-300">
+                We have never emailed this attendee a ticket link.
+            </p>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/templates/tickets/list.html
+++ b/templates/tickets/list.html
@@ -29,7 +29,7 @@
         {% endif %}
 
         <div class="bg-opacity-50 mb-6 rounded-lg bg-green-800 p-4">
-            <div class="grid grid-cols-3 gap-4 text-center">
+            <div class="grid grid-cols-2 gap-4 text-center md:grid-cols-4">
                 <div>
                     <p class="text-2xl font-bold">{{ total_count }}</p>
                     <p class="text-sm text-gray-300">Total Tickets</p>
@@ -41,6 +41,10 @@
                 <div>
                     <p class="text-2xl font-bold text-red-400">{{ used_count }}</p>
                     <p class="text-sm text-gray-300">Assigned</p>
+                </div>
+                <div>
+                    <p class="text-2xl font-bold text-blue-300">{{ emailed_count }}</p>
+                    <p class="text-sm text-gray-300">Emailed</p>
                 </div>
             </div>
         </div>
@@ -58,6 +62,12 @@
                             </th>
                             <th class="px-6 py-3 text-left text-xs font-medium tracking-wider uppercase">
                                 Assigned On
+                            </th>
+                            <th class="px-6 py-3 text-center text-xs font-medium tracking-wider uppercase">
+                                Emails Sent
+                            </th>
+                            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider uppercase">
+                                Last Emailed
                             </th>
                             <th class="px-6 py-3 text-center text-xs font-medium tracking-wider uppercase">
                                 Status
@@ -87,8 +97,40 @@
                                         <span class="text-gray-400">Not assigned</span>
                                     {% endif %}
                                 </td>
+                                <td class="px-6 py-4 text-center text-sm whitespace-nowrap">
+                                    {% if ticket.emails_sent %}
+                                        <span class="font-semibold text-green-300">{{ ticket.emails_sent }}</span>
+                                    {% else %}
+                                        <span class="text-gray-500">0</span>
+                                    {% endif %}
+                                    {% if ticket.emails_failed %}
+                                        <span class="mt-1 block text-xs text-red-300">{{ ticket.emails_failed }} failed</span>
+                                    {% endif %}
+                                    {% if ticket.preview_attendee %}
+                                        <a href="{% url 'attendee_email_preview' ticket.preview_attendee.pk %}"
+                                           class="mt-1 block text-xs text-yellow-300 underline hover:text-yellow-200">
+                                            Preview email
+                                        </a>
+                                    {% endif %}
+                                </td>
+                                <td class="px-6 py-4 text-sm whitespace-nowrap">
+                                    {% if ticket.last_emailed_at %}
+                                        {{ ticket.last_emailed_at|date:"M d, Y g:i A" }}
+                                    {% else %}
+                                        <span class="text-gray-500">Never</span>
+                                    {% endif %}
+                                </td>
                                 <td class="px-6 py-4 text-center whitespace-nowrap">
-                                    {% if ticket.attendee_email %}
+                                    {% if ticket.superseded_at %}
+                                        {% comment %}
+                                            A reissue retires the old link rather than deleting it, so
+                                            without this it would keep reading as a live assignment.
+                                        {% endcomment %}
+                                        <span class="inline-flex rounded-full bg-gray-700 px-3 py-1 text-xs leading-5 font-semibold text-gray-300"
+                                              title="Replaced on {{ ticket.superseded_at|date:'M d, Y g:i A' }}">
+                                            Superseded
+                                        </span>
+                                    {% elif ticket.attendee_email %}
                                         <span class="inline-flex rounded-full bg-red-800 px-3 py-1 text-xs leading-5 font-semibold text-red-200">
                                             Assigned
                                         </span>

--- a/tickets/emails.py
+++ b/tickets/emails.py
@@ -1,0 +1,59 @@
+"""Building the ticket-link email, in one place.
+
+The worker sends this email and staff preview it from the attendee dashboard.
+Those were two renderings of the same templates, so they lived one edit apart
+from disagreeing --- a preview that quietly stops matching what ships is worse
+than no preview at all. Both call ``build_ticket_email`` instead.
+"""
+
+from dataclasses import dataclass
+
+from django.conf import settings
+from django.template.loader import render_to_string
+
+from tickets.models import OnlineAttendee, TicketEmailLog
+
+SUBJECTS = {
+    TicketEmailLog.KIND_INITIAL: "Your DjangoCon US online conference link",
+    TicketEmailLog.KIND_RESEND: "Your DjangoCon US online conference link (resent)",
+    TicketEmailLog.KIND_REISSUE: "Your new DjangoCon US online conference link",
+}
+
+TEXT_TEMPLATE = "tickets/email/ticket_link.txt"
+HTML_TEMPLATE = "tickets/email/ticket_link.html"
+
+# Stands in for the real thing when previewing an email to someone who has no
+# link yet. Obviously fake on sight, so nobody mistakes a preview for a ticket.
+PLACEHOLDER_LINK = "https://ti.to/example/a-link-is-pulled-from-the-pool-when-you-send"
+
+
+@dataclass(frozen=True)
+class RenderedTicketEmail:
+    subject: str
+    text_body: str
+    html_body: str
+
+
+def build_ticket_email(
+    *,
+    attendee: OnlineAttendee | None,
+    link_url: str,
+    kind: str = TicketEmailLog.KIND_INITIAL,
+) -> RenderedTicketEmail:
+    """Render the ticket-link email exactly as it goes out."""
+    context = {
+        "attendee": attendee,
+        "name": (attendee.name if attendee else "") or "",
+        "ticket_link": link_url,
+        "kind": kind,
+        "is_reissue": kind == TicketEmailLog.KIND_REISSUE,
+        "is_resend": kind == TicketEmailLog.KIND_RESEND,
+        "year": attendee.year if attendee else None,
+        "support_email": settings.DEFAULT_FROM_EMAIL,
+    }
+
+    return RenderedTicketEmail(
+        subject=SUBJECTS.get(kind, SUBJECTS[TicketEmailLog.KIND_INITIAL]),
+        text_body=render_to_string(TEXT_TEMPLATE, context),
+        html_body=render_to_string(HTML_TEMPLATE, context),
+    )

--- a/tickets/tasks.py
+++ b/tickets/tasks.py
@@ -2,17 +2,11 @@ import logging
 
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
-from django.template.loader import render_to_string
 
+from tickets.emails import build_ticket_email
 from tickets.models import TicketEmailLog
 
 logger = logging.getLogger(__name__)
-
-SUBJECTS = {
-    TicketEmailLog.KIND_INITIAL: "Your DjangoCon US online conference link",
-    TicketEmailLog.KIND_RESEND: "Your DjangoCon US online conference link (resent)",
-    TicketEmailLog.KIND_REISSUE: "Your new DjangoCon US online conference link",
-}
 
 
 def send_ticket_link_email(log_id: int) -> bool:
@@ -36,31 +30,18 @@ def send_ticket_link_email(log_id: int) -> bool:
         log.mark_failed("Ticket link was removed before the email could be sent.")
         return False
 
-    context = {
-        "attendee": log.attendee,
-        "name": (log.attendee.name if log.attendee else "") or "",
-        "ticket_link": log.ticket_link.link,
-        "kind": log.kind,
-        "is_reissue": log.kind == TicketEmailLog.KIND_REISSUE,
-        "is_resend": log.kind == TicketEmailLog.KIND_RESEND,
-        "year": log.attendee.year if log.attendee else None,
-        "support_email": settings.DEFAULT_FROM_EMAIL,
-    }
-
-    subject = SUBJECTS.get(log.kind, SUBJECTS[TicketEmailLog.KIND_INITIAL])
-    text_body = render_to_string("tickets/email/ticket_link.txt", context)
-    html_body = render_to_string("tickets/email/ticket_link.html", context)
+    email = build_ticket_email(attendee=log.attendee, link_url=log.ticket_link.link, kind=log.kind)
 
     message = EmailMultiAlternatives(
-        subject=subject,
-        body=text_body,
+        subject=email.subject,
+        body=email.text_body,
         from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
         to=[log.to_email],
     )
-    message.attach_alternative(html_body, "text/html")
+    message.attach_alternative(email.html_body, "text/html")
 
     # Persist before sending; mark_sent/mark_failed only touch their own fields.
-    log.subject = subject
+    log.subject = email.subject
     log.save(update_fields=["subject"])
 
     try:

--- a/tickets/tests/test_email_preview.py
+++ b/tickets/tests/test_email_preview.py
@@ -1,0 +1,172 @@
+import pytest
+from django.utils import timezone
+
+from tickets.emails import PLACEHOLDER_LINK
+from tickets.models import OnlineAttendee, TicketEmailLog, TicketLink
+from tickets.tasks import send_ticket_link_email
+
+
+@pytest.fixture
+def staff_client(tp, staff_user):
+    tp.client.force_login(staff_user)
+    return tp
+
+
+@pytest.fixture
+def attendee_with_link(attendee, ticket_link):
+    ticket_link.attendee = attendee
+    ticket_link.attendee_email = attendee.email
+    ticket_link.date_link_assigned = timezone.now()
+    ticket_link.save()
+    return attendee
+
+
+@pytest.mark.django_db
+def test_preview_requires_staff(tp, attendee):
+    response = tp.get("attendee_email_preview", attendee.pk)
+    assert response.status_code == 302
+
+
+@pytest.mark.django_db
+def test_preview_renders_the_attendees_own_link(staff_client, attendee_with_link, ticket_link):
+    response = staff_client.get("attendee_email_preview", attendee_with_link.pk)
+
+    assert response.status_code == 200
+    assert ticket_link.link in response.content.decode()
+    assert response.context["link_is_placeholder"] is False
+
+
+@pytest.mark.django_db
+def test_preview_defaults_to_the_send_that_would_happen(staff_client, attendee_with_link):
+    """Someone holding a link would get a resend; someone without, an initial."""
+    with_link = staff_client.get("attendee_email_preview", attendee_with_link.pk)
+    assert with_link.context["kind"] == TicketEmailLog.KIND_RESEND
+
+    fresh = OnlineAttendee.objects.create(email="nolink@example.com", year=2026)
+    without_link = staff_client.get("attendee_email_preview", fresh.pk)
+    assert without_link.context["kind"] == TicketEmailLog.KIND_INITIAL
+
+
+@pytest.mark.django_db
+def test_preview_without_a_link_shows_a_placeholder(staff_client, attendee):
+    response = staff_client.get("attendee_email_preview", attendee.pk)
+
+    assert response.context["link_is_placeholder"] is True
+    assert PLACEHOLDER_LINK in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_preview_honours_the_requested_kind(staff_client, attendee_with_link):
+    response = staff_client.get("attendee_email_preview", attendee_with_link.pk, data={"kind": "reissue"})
+
+    assert response.context["kind"] == TicketEmailLog.KIND_REISSUE
+    assert response.context["is_reissue"] is True
+    assert "NEW link" in response.context["rendered"].text_body
+
+
+@pytest.mark.django_db
+def test_preview_ignores_a_bogus_kind(staff_client, attendee_with_link):
+    response = staff_client.get("attendee_email_preview", attendee_with_link.pk, data={"kind": "nonsense"})
+
+    assert response.status_code == 200
+    assert response.context["kind"] == TicketEmailLog.KIND_RESEND
+
+
+@pytest.mark.django_db
+def test_preview_part_html_serves_the_html_body_alone(staff_client, attendee_with_link, ticket_link):
+    response = staff_client.get("attendee_email_preview", attendee_with_link.pk, data={"part": "html"})
+
+    body = response.content.decode()
+    assert response.status_code == 200
+    assert ticket_link.link in body
+    # The chrome of the preview page must not be in the standalone body.
+    assert "Send history" not in body
+
+
+@pytest.mark.django_db
+def test_preview_lists_the_send_history(staff_client, attendee_with_link, ticket_link):
+    log = TicketEmailLog.objects.create(
+        attendee=attendee_with_link,
+        ticket_link=ticket_link,
+        to_email=attendee_with_link.email,
+        kind=TicketEmailLog.KIND_INITIAL,
+    )
+    log.mark_sent()
+
+    response = staff_client.get("attendee_email_preview", attendee_with_link.pk)
+
+    assert list(response.context["logs"]) == [log]
+    assert response.context["attendee"].sent_email_count == 1
+
+
+@pytest.mark.django_db
+def test_preview_matches_what_the_worker_sends(staff_client, attendee_with_link, ticket_link, mailoutbox):
+    """The preview and the real send render from one builder, so they agree."""
+    log = TicketEmailLog.objects.create(
+        attendee=attendee_with_link,
+        ticket_link=ticket_link,
+        to_email=attendee_with_link.email,
+        kind=TicketEmailLog.KIND_RESEND,
+    )
+    send_ticket_link_email(log.pk)
+
+    response = staff_client.get("attendee_email_preview", attendee_with_link.pk, data={"kind": "resend"})
+
+    sent = mailoutbox[-1]
+    assert response.context["rendered"].subject == sent.subject
+    assert response.context["rendered"].text_body == sent.body
+
+
+@pytest.mark.django_db
+def test_ticket_list_counts_emails_per_link(staff_client, attendee_with_link, ticket_link):
+    for _ in range(2):
+        log = TicketEmailLog.objects.create(
+            attendee=attendee_with_link,
+            ticket_link=ticket_link,
+            to_email=attendee_with_link.email,
+        )
+        log.mark_sent()
+    TicketEmailLog.objects.create(
+        attendee=attendee_with_link,
+        ticket_link=ticket_link,
+        to_email=attendee_with_link.email,
+        status=TicketEmailLog.STATUS_FAILED,
+    )
+
+    response = staff_client.get("tickets_list")
+
+    row = next(t for t in response.context["tickets"] if t.pk == ticket_link.pk)
+    assert row.emails_sent == 2
+    assert row.emails_failed == 1
+    assert row.last_emailed_at is not None
+    assert response.context["emailed_count"] == 1
+
+
+@pytest.mark.django_db
+def test_ticket_list_resolves_a_preview_target_without_the_fk(staff_client, attendee, ticket_link):
+    """Links claimed on the public page carry an address but no FK."""
+    ticket_link.attendee_email = attendee.email
+    ticket_link.save(update_fields=["attendee_email"])
+
+    response = staff_client.get("tickets_list")
+
+    row = next(t for t in response.context["tickets"] if t.pk == ticket_link.pk)
+    assert row.preview_attendee == attendee
+
+
+@pytest.mark.django_db
+def test_ticket_list_has_no_preview_target_for_an_unassigned_link(staff_client, ticket_link):
+    response = staff_client.get("tickets_list")
+
+    row = next(t for t in response.context["tickets"] if t.pk == ticket_link.pk)
+    assert row.preview_attendee is None
+
+
+@pytest.mark.django_db
+def test_ticket_list_marks_superseded_links(staff_client, attendee_with_link, ticket_link):
+    ticket_link.supersede()
+
+    response = staff_client.get("tickets_list")
+
+    assert "Superseded" in response.content.decode()
+    assert TicketLink.objects.filter(pk=ticket_link.pk, superseded_at__isnull=False).exists()

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -4,12 +4,14 @@ from urllib.parse import urlparse
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
+from django.db import models
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_http_methods
 
 from titowebhooks.reports import normalized_csv
 
+from .emails import PLACEHOLDER_LINK, build_ticket_email
 from .forms import AssignByEmailForm, BulkTicketCreationForm, ClaimTicketForm
 from .models import OnlineAttendee, TicketEmailLog, TicketLink
 from .services import NoTicketsAvailable, assign_and_email, assign_link, claim_for_email
@@ -99,15 +101,39 @@ def tickets_list_view(request: HttpRequest) -> HttpResponse:
     """
     Display all tickets with their status.
 
-    Shows a table with all ticket links, creation dates, and access dates.
+    Shows a table with all ticket links, creation dates, and access dates,
+    alongside how many times we emailed the link out and when we last did ---
+    the same counts the attendee dashboard reports, from the link's side of the
+    relationship, so a reissued link carries its own history rather than the
+    attendee's running total.
     """
-    tickets = TicketLink.objects.all().order_by("-date_link_created")
+    sent = models.Q(email_logs__status=TicketEmailLog.STATUS_SENT)
+    tickets = (
+        TicketLink.objects.annotate(
+            emails_sent=models.Count("email_logs", filter=sent),
+            last_emailed_at=models.Max("email_logs__date_sent", filter=sent),
+            emails_failed=models.Count("email_logs", filter=models.Q(email_logs__status=TicketEmailLog.STATUS_FAILED)),
+        )
+        .select_related("attendee")
+        .order_by("-date_link_created")
+    )
+
+    # Links claimed through the public page carry an address but no FK, so the
+    # preview link would vanish for exactly the people staff most often chase.
+    # Resolve those by address, the same way ``active_ticket_link`` does.
+    unlinked_emails = {t.attendee_email for t in tickets if t.attendee_email and t.attendee_id is None}
+    # Ascending year: the same address can appear for several conferences, and
+    # the last write into the dict should be the most recent one.
+    attendees_by_email = {a.email: a for a in OnlineAttendee.objects.filter(email__in=unlinked_emails).order_by("year")}
+    for ticket in tickets:
+        ticket.preview_attendee = ticket.attendee or attendees_by_email.get(ticket.attendee_email)
 
     context = {
         "tickets": tickets,
-        "total_count": tickets.count(),
-        "available_count": tickets.filter(attendee_email__isnull=True).count(),
-        "used_count": tickets.filter(attendee_email__isnull=False).count(),
+        "total_count": len(tickets),
+        "available_count": sum(1 for t in tickets if t.attendee_email is None),
+        "used_count": sum(1 for t in tickets if t.attendee_email is not None),
+        "emailed_count": sum(1 for t in tickets if t.emails_sent),
     }
     return render(request, "tickets/list.html", context)
 
@@ -363,3 +389,53 @@ def ticket_emails_view(request: HttpRequest) -> HttpResponse:
         "failed_count": TicketEmailLog.objects.filter(status=TicketEmailLog.STATUS_FAILED).count(),
     }
     return render(request, "tickets/emails.html", context)
+
+
+@staff_member_required
+def attendee_email_preview_view(request: HttpRequest, pk: int) -> HttpResponse:
+    """The ticket email this attendee would get, rendered with their real link.
+
+    The previews under /staff/emails/ are deliberately fabricated so no
+    attendee's link can leak onto a page. That makes them useless for the
+    question staff actually ask before hitting send --- "what is *this* person
+    about to receive?" --- so this one renders the genuine article, behind the
+    same staff gate as the roster it is reached from.
+    """
+    attendee = get_object_or_404(OnlineAttendee, pk=pk)
+
+    kind = request.GET.get("kind")
+    if kind not in dict(TicketEmailLog.KIND_CHOICES):
+        # Default to whatever sending right now would actually do.
+        kind = TicketEmailLog.KIND_RESEND if attendee.has_ticket else TicketEmailLog.KIND_INITIAL
+
+    link = attendee.active_ticket_link
+    email = build_ticket_email(
+        attendee=attendee,
+        link_url=link.link if link else PLACEHOLDER_LINK,
+        kind=kind,
+    )
+
+    # ?part=html serves the HTML body alone, matching /staff/emails/, so staff
+    # can open it in a tab and forward it to a real client to test.
+    if request.GET.get("part") == "html":
+        return HttpResponse(email.html_body)
+
+    view = request.GET.get("view")
+    if view not in {"rich", "text"}:
+        view = "rich"
+
+    context = {
+        "attendee": attendee,
+        "rendered": email,
+        "kind": kind,
+        "kinds": TicketEmailLog.KIND_CHOICES,
+        "ticket_link": link,
+        # A reissue mints a link from the pool at send time, so the one below is
+        # only their current link standing in. Say so rather than imply we know.
+        "link_is_placeholder": link is None,
+        "is_reissue": kind == TicketEmailLog.KIND_REISSUE,
+        "view": view,
+        "logs": attendee.email_logs.select_related("sent_by").order_by("-date_queued")[:10],
+        "year": attendee.year,
+    }
+    return render(request, "tickets/email_preview.html", context)


### PR DESCRIPTION
## Why

The previews under `/staff/emails/` render **fabricated** data on purpose, so no attendee's link can leak onto a page. That's the right call for a general preview, but it leaves the question staff actually ask before hitting send — *"what is this specific person about to receive?"* — unanswerable. The only way to check was to send it and look.

## What

A per-attendee preview at `/tickets/attendees/<pk>/email/`, behind `staff_member_required`, linked from the attendee roster:

- Renders the attendee's **real** link, as it would go out
- Kind switch — initial / resend / reissue — defaulting to what sending *right now* would actually do
- Rich / plain-text toggle
- `?part=html` serves the HTML body alone, matching `/staff/emails/`, so it can be forwarded to a real mail client
- Last ten log rows for context
- Attendees with no link yet get an obviously-fake placeholder (`a-link-is-pulled-from-the-pool-when-you-send`) rather than a blank or, worse, somebody else's

## One source of truth for the email

`tickets/tasks.py` and the new view were about to be two renderings of the same two templates, sitting one edit apart from disagreeing. A preview that quietly stops matching what ships is worse than no preview — it's confidently wrong.

Both now call `build_ticket_email()` in the new `tickets/emails.py`, which returns a frozen `RenderedTicketEmail(subject, text_body, html_body)`. `SUBJECTS` moved there too; `config/tests/test_email_branding.py` follows the import.

## Also: email history on the tickets list

The list page showed links and dates but not whether we'd ever emailed them. It now shows sent count, last-sent, and failures.

Counted from the **link's** side of the relationship, deliberately: a reissued link carries its own history rather than inheriting the attendee's running total. Links claimed through the public page have an address but no FK, so those resolve by address the same way `active_ticket_link` does — otherwise the preview link would disappear for exactly the people staff chase most often.

Query-wise this is a net reduction: counts are annotated instead of per-row, and the three summary tiles walk the already-fetched list instead of issuing three more `COUNT`s.

## Testing

541 tests pass, 21 of them new (`test_email_preview.py`), covering kind defaulting, the placeholder path, `?part=html`, the staff gate, and worker/preview agreement. Lint clean.