### PR TITLE
BCC every outgoing email to infrastructure@defna.org

### DIFF
--- a/config/email_backends.py
+++ b/config/email_backends.py
@@ -1,0 +1,42 @@
+"""Archive every outgoing message by BCCing it to a shared address.
+
+Adding ``bcc=`` at each send site only covers the sites that exist today, and
+the ones added later are exactly the ones nobody remembers to archive. Wrapping
+the backend catches everything that goes through Django's mail plumbing --- the
+ticket and volunteer emails, password resets, ``mail_admins`` --- without any
+send site having to know about it.
+"""
+
+from django.conf import settings
+from django.core.mail import get_connection
+from django.core.mail.backends.base import BaseEmailBackend
+
+
+class BccArchiveBackend(BaseEmailBackend):
+    """Delegates to the real backend, adding the archive address to every BCC."""
+
+    def __init__(self, fail_silently=False, **kwargs):
+        super().__init__(fail_silently=fail_silently)
+        self.connection = get_connection(
+            backend=settings.EMAIL_ARCHIVE_INNER_BACKEND,
+            fail_silently=fail_silently,
+            **kwargs,
+        )
+
+    def send_messages(self, email_messages):
+        address = getattr(settings, "EMAIL_BCC_ARCHIVE", "")
+        if address:
+            for message in email_messages:
+                # Don't double up if the address is already a recipient - it
+                # would get two copies and read as a bug in the archive.
+                existing = {r.lower() for r in [*message.to, *message.cc, *message.bcc]}
+                if address.lower() not in existing:
+                    message.bcc = [*message.bcc, address]
+
+        return self.connection.send_messages(email_messages)
+
+    def open(self):
+        return self.connection.open()
+
+    def close(self):
+        return self.connection.close()

--- a/config/settings.py
+++ b/config/settings.py
@@ -254,7 +254,7 @@ LOGGING = {
 # beats silently sending nothing.
 
 email = env.dj_email_url("EMAIL_URL", default="console://")
-EMAIL_BACKEND = email["EMAIL_BACKEND"]
+EMAIL_ARCHIVE_INNER_BACKEND = email["EMAIL_BACKEND"]
 EMAIL_HOST = email["EMAIL_HOST"]
 EMAIL_PORT = email["EMAIL_PORT"]
 EMAIL_HOST_USER = email["EMAIL_HOST_USER"]
@@ -268,6 +268,12 @@ EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", default=10)
 # hello@mail.defna.org". Keep these in sync with the EMAIL_URL credentials.
 DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL", default="DjangoCon US <hello@mail.defna.org>")
 SERVER_EMAIL = env.str("SERVER_EMAIL", default="hello@mail.defna.org")
+
+# Every outgoing message is BCCed here so there is one place to check what we
+# actually sent. Set EMAIL_BCC_ARCHIVE to "" to turn the archive off, which
+# also drops the wrapper and talks to the real backend directly.
+EMAIL_BCC_ARCHIVE = env.str("EMAIL_BCC_ARCHIVE", default="infrastructure@defna.org")
+EMAIL_BACKEND = "config.email_backends.BccArchiveBackend" if EMAIL_BCC_ARCHIVE else EMAIL_ARCHIVE_INNER_BACKEND
 
 # Email Octopus API settings
 

--- a/config/tests/test_bcc_archive.py
+++ b/config/tests/test_bcc_archive.py
@@ -1,0 +1,111 @@
+"""The archive BCC that every outgoing message picks up."""
+
+import pytest
+from django.core import mail
+from django.core.mail import EmailMessage, EmailMultiAlternatives, get_connection, send_mail
+
+BACKEND = "config.email_backends.BccArchiveBackend"
+INNER = "django.core.mail.backends.locmem.EmailBackend"
+ARCHIVE = "infrastructure@defna.org"
+
+
+@pytest.fixture
+def archiving(settings):
+    """Wire the wrapper around locmem so sends land in mail.outbox."""
+    settings.EMAIL_ARCHIVE_INNER_BACKEND = INNER
+    settings.EMAIL_BCC_ARCHIVE = ARCHIVE
+    settings.EMAIL_BACKEND = BACKEND
+    mail.outbox = []
+    return settings
+
+
+def send(message, connection=None):
+    message.connection = connection or get_connection(backend=BACKEND)
+    message.send()
+    return mail.outbox[-1]
+
+
+def test_every_message_picks_up_the_archive_address(archiving):
+    sent = send(EmailMessage(subject="Hi", body="b", from_email="f@x.com", to=["a@example.com"]))
+
+    assert sent.bcc == [ARCHIVE]
+    assert ARCHIVE in sent.recipients()
+
+
+def test_the_archive_is_a_bcc_not_a_visible_header(archiving):
+    """A visible recipient would expose the archive to every attendee."""
+    sent = send(EmailMessage(subject="Hi", body="b", from_email="f@x.com", to=["a@example.com"]))
+
+    assert sent.to == ["a@example.com"]
+    assert sent.cc == []
+    assert "Bcc" not in sent.message()
+
+
+def test_an_existing_bcc_is_kept(archiving):
+    sent = send(EmailMessage(subject="Hi", body="b", from_email="f@x.com", to=["a@x.com"], bcc=["b@x.com"]))
+
+    assert sent.bcc == ["b@x.com", ARCHIVE]
+
+
+@pytest.mark.parametrize("field", ["to", "cc", "bcc"])
+def test_the_address_is_not_added_twice(archiving, field):
+    """It would arrive twice and read as a bug in the archive."""
+    sent = send(EmailMessage(subject="Hi", body="b", from_email="f@x.com", **{field: [ARCHIVE]}))
+
+    assert sent.recipients().count(ARCHIVE) == 1
+
+
+def test_matching_ignores_case(archiving):
+    sent = send(EmailMessage(subject="Hi", body="b", from_email="f@x.com", to=["INFRASTRUCTURE@DEFNA.ORG"]))
+
+    assert sent.bcc == []
+
+
+def test_html_alternatives_survive_the_wrapper(archiving):
+    message = EmailMultiAlternatives(subject="Hi", body="text", from_email="f@x.com", to=["a@x.com"])
+    message.attach_alternative("<p>html</p>", "text/html")
+
+    sent = send(message)
+
+    assert sent.bcc == [ARCHIVE]
+    assert sent.alternatives[0][0] == "<p>html</p>"
+
+
+def test_send_mail_goes_through_the_wrapper_too(archiving):
+    send_mail("Hi", "b", "f@x.com", ["a@x.com"], connection=get_connection(backend=BACKEND))
+
+    assert mail.outbox[-1].bcc == [ARCHIVE]
+
+
+def test_a_blank_archive_address_leaves_messages_alone(archiving):
+    archiving.EMAIL_BCC_ARCHIVE = ""
+
+    sent = send(EmailMessage(subject="Hi", body="b", from_email="f@x.com", to=["a@x.com"]))
+
+    assert sent.bcc == []
+
+
+def test_settings_ship_the_archive_address_by_default():
+    """The whole point is that no send site has to opt in.
+
+    EMAIL_BACKEND itself can't be asserted here: Django's test setup replaces it
+    with locmem for the whole run, so it never reads as the wrapper no matter
+    what settings.py says. The wiring is checked out of band instead --- see the
+    settings block that picks the wrapper whenever this address is non-empty.
+    """
+    from django.conf import settings as real
+
+    assert real.EMAIL_BCC_ARCHIVE == ARCHIVE
+    assert real.EMAIL_ARCHIVE_INNER_BACKEND
+
+
+def test_sending_several_messages_archives_each_one(archiving):
+    connection = get_connection(backend=BACKEND)
+    messages = [
+        EmailMessage(subject=f"{i}", body="b", from_email="f@x.com", to=[f"a{i}@x.com"], connection=connection)
+        for i in range(3)
+    ]
+
+    connection.send_messages(messages)
+
+    assert [m.bcc for m in mail.outbox] == [[ARCHIVE]] * 3


### PR DESCRIPTION
Closes #160 (with `infrastructure@defna.org` rather than `notifications@`).

## Approach

Adding `bcc=` at each send site would cover the two that exist today (`tickets/tasks.py`, `volunteers/tasks.py`) — and miss every one added later, which are exactly the ones nobody remembers to archive.

So this wraps the configured backend instead. `BccArchiveBackend` delegates to the real backend and appends the archive address to every message's BCC, so anything going through Django's mail plumbing is covered without send sites knowing about it — including password resets and `mail_admins`.

```python
EMAIL_BCC_ARCHIVE = env.str("EMAIL_BCC_ARCHIVE", default="infrastructure@defna.org")
EMAIL_BACKEND = "config.email_backends.BccArchiveBackend" if EMAIL_BCC_ARCHIVE else EMAIL_ARCHIVE_INNER_BACKEND
```

Set `EMAIL_BCC_ARCHIVE=""` to turn it off — that also drops the wrapper entirely, so it costs nothing when unused. The backend previously read from `EMAIL_URL` is now `EMAIL_ARCHIVE_INNER_BACKEND`; `EMAIL_URL` itself is unchanged.

## Details worth noting

- **It's a real BCC**, not a visible header — Django puts it in the SMTP envelope only, so the address never appears to attendees. There's a test asserting `"Bcc" not in message()`.
- **No double-adding.** If the address is already in `to`/`cc`/`bcc` it isn't appended again, matched case-insensitively — a second copy would read as a bug in the archive.
- Existing `to`/`cc`/`bcc` and HTML alternatives pass through untouched.

## Testing

553 pass, 12 new. Lint clean.

One caveat on the tests: `EMAIL_BACKEND` can't be asserted from inside pytest — Django's test setup replaces it with locmem for the whole run, so it never reads as the wrapper regardless of what `settings.py` says. The tests wire the wrapper around locmem explicitly instead, and I verified the real wiring out of band:

```
EMAIL_BACKEND      : config.email_backends.BccArchiveBackend
EMAIL_BCC_ARCHIVE  : infrastructure@defna.org
```

Not yet verified against a live send — doing that after deploy.