### PR TITLE
Compare the retention cutoff against the local date, not UTC

### DIFF
--- a/travel_safety/tasks.py
+++ b/travel_safety/tasks.py
@@ -12,7 +12,13 @@ RETENTION_DAYS = 30
 def enforce_retention():
     """Delete travel safety registrations 30 days after the conference ends."""
     cutoff_date = settings.CONFERENCE_END_DATE + datetime.timedelta(days=RETENTION_DAYS)
-    today = timezone.now().date()
+    # localdate(), not now().date(): the register page promises deletion 30 days
+    # after the conference in the reader's terms, and CONFERENCE_END_DATE is a
+    # plain local date. Comparing it against the UTC date fires the deletion up
+    # to five hours early every evening, which is silent -- it destroys travel
+    # details rather than raising. The __date lookup below is already evaluated
+    # in TIME_ZONE, so this also keeps the two halves consistent.
+    today = timezone.localdate()
 
     if today < cutoff_date:
         return

--- a/travel_safety/tests/test_retention.py
+++ b/travel_safety/tests/test_retention.py
@@ -103,3 +103,46 @@ def test_an_empty_table_is_a_no_op(settings, today):
     enforce_retention()
 
     assert TravelRegistration.objects.count() == 0
+
+
+@pytest.fixture
+def evening_before(monkeypatch):
+    """Pin the clock to 23:30 in Chicago, when UTC has already rolled over.
+
+    2026-08-21 04:30 UTC is 2026-08-20 23:30 CDT, so ``timezone.now().date()``
+    and ``timezone.localdate()`` disagree by a day. Patching ``now`` covers both,
+    since ``localdate`` is derived from it. Without a fixed instant these cases
+    would only fail during the five-hour window each evening --- which is exactly
+    how the bug reached main unnoticed.
+    """
+    instant = datetime.datetime(2026, 8, 21, 4, 30, tzinfo=datetime.timezone.utc)
+    monkeypatch.setattr(timezone, "now", lambda: instant)
+    return instant
+
+
+@pytest.mark.django_db
+def test_the_cutoff_follows_the_local_date_not_utc(settings, evening_before):
+    """The day before the window closes, nothing goes --- even after UTC midnight.
+
+    Local date is the 20th and the cutoff is the 21st, so this must keep the
+    row. Reading the UTC date instead makes it the 21st and deletes a day early.
+    """
+    assert timezone.now().date() != timezone.localdate()  # guards the fixture itself
+
+    settings.CONFERENCE_END_DATE = timezone.localdate() - datetime.timedelta(days=RETENTION_DAYS - 1)
+    make_registration()
+
+    enforce_retention()
+
+    assert TravelRegistration.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_the_window_still_closes_on_the_local_day_it_should(settings, evening_before):
+    """The other half of the promise: once the local date arrives, data goes."""
+    settings.CONFERENCE_END_DATE = timezone.localdate() - datetime.timedelta(days=RETENTION_DAYS)
+    make_registration(created_days_ago=45)
+
+    enforce_retention()
+
+    assert TravelRegistration.objects.count() == 0


### PR DESCRIPTION
## The bug

`enforce_retention` decided *"is it time yet"* using the **UTC** date, against a `CONFERENCE_END_DATE` that is a plain **local** date:

```python
cutoff_date = settings.CONFERENCE_END_DATE + datetime.timedelta(days=RETENTION_DAYS)
today = timezone.now().date()          # UTC
if today < cutoff_date:
    return
```

`TIME_ZONE` is `America/Chicago`, so the two disagree for five hours every evening (19:00–24:00 CDT / 00:00–05:00 UTC). In that window the job can delete travel details **up to five hours before the local date reaches the cutoff** — breaking the 30-day promise the register page makes to attendees, and doing it silently, since deleting early raises nothing.

`timezone.localdate()` matches how `CONFERENCE_END_DATE` is written, and how the `created_at__date__lte` lookup on the next line already behaves (Django evaluates `__date` in `TIME_ZONE`). So this also makes the two halves of the function agree with each other.

## This is what failed CI on #159

The existing test read `localdate()` while the task read UTC, so it failed for anything merged inside that evening window and passed the rest of the day:

| Merge | Time (UTC) | In window? | Result |
|---|---|---|---|
| #158 | 20:50 | no | pass |
| #159 | **00:09** | **yes** | **fail** |
| #162 | 20:59 | no | pass |

Deterministic on the clock, not flaky — and it would have kept happening.

## Tests

Two new cases pin the clock to `2026-08-21 04:30 UTC` = `2026-08-20 23:30 CDT`, the moment the two dates disagree, so they hold regardless of when the suite runs. They cover both halves of the promise — nothing goes early, and the window still closes on the local day it should. One asserts the fixture itself is doing its job (`now().date() != localdate()`), so it can't quietly stop testing anything.

I verified they actually catch it by reintroducing the bug:

```
FAILED travel_safety/tests/test_retention.py::test_the_cutoff_follows_the_local_date_not_utc
1 failed, 8 passed
```

555 pass with the fix in place. Lint clean.

## Production impact

Low right now, worth fixing anyway. The schedule's `next_run` is 15:43 UTC (10:43 CDT), outside the window, and with `CONFERENCE_END_DATE = 2026-08-28` the cutoff lands 2026-09-27. But it's a daily schedule whose run time can drift, and the failure mode is deleting attendee data without an error.