### PR TITLE
Add an unattended batch send for online ticket emails

### DIFF
--- a/tickets/tasks.py
+++ b/tickets/tasks.py
@@ -4,7 +4,9 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 
 from tickets.emails import build_ticket_email
-from tickets.models import TicketEmailLog
+from tickets.models import OnlineAttendee, TicketEmailLog
+from tickets.services import NoTicketsAvailable, assign_and_email
+from tickets.sync import DEFAULT_YEAR
 
 logger = logging.getLogger(__name__)
 
@@ -54,3 +56,61 @@ def send_ticket_link_email(log_id: int) -> bool:
     log.mark_sent()
     logger.info("Sent %s ticket link email to %s", log.kind, log.to_email)
     return True
+
+
+def send_pending_ticket_emails(year: int = DEFAULT_YEAR, limit: int | None = None) -> dict:
+    """Email every online attendee for ``year`` who has not been emailed yet.
+
+    Built to be run unattended on a schedule, so the guard against sending twice
+    is the whole design. Anyone with an existing log row --- sent, or still
+    queued in the worker --- is skipped, which means a second run (a retry, an
+    accidental double-fire, a rerun after a partial batch) mails only the people
+    the first run never reached. Failed rows are deliberately *not* skipped, so
+    a transient SMTP problem gets another go.
+
+    Links are assigned as needed rather than assumed, since anyone who buys
+    between scheduling this and it firing will have no link yet. Running out of
+    links stops the batch instead of silently mailing a subset --- the people
+    left over are exactly the ones a human needs to know about.
+    """
+    already_emailed = set(
+        TicketEmailLog.objects.filter(
+            status__in=[TicketEmailLog.STATUS_SENT, TicketEmailLog.STATUS_QUEUED],
+        ).values_list("to_email", flat=True)
+    )
+
+    queued = 0
+    skipped = 0
+    failed = 0
+    out_of_links = False
+
+    for attendee in OnlineAttendee.objects.filter(year=year).order_by("pk"):
+        if attendee.email.lower() in already_emailed:
+            skipped += 1
+            continue
+
+        if limit is not None and queued >= limit:
+            break
+
+        try:
+            assign_and_email(attendee)
+        except NoTicketsAvailable:
+            out_of_links = True
+            logger.error("Ran out of ticket links while emailing %s; stopping the batch", attendee.email)
+            break
+        except Exception:
+            failed += 1
+            logger.exception("Failed to queue ticket email for %s", attendee.email)
+        else:
+            queued += 1
+            already_emailed.add(attendee.email.lower())
+
+    summary = {
+        "year": year,
+        "queued": queued,
+        "skipped": skipped,
+        "failed": failed,
+        "out_of_links": out_of_links,
+    }
+    logger.info("Pending ticket email run complete: %s", summary)
+    return summary

--- a/tickets/tests/test_pending_ticket_emails.py
+++ b/tickets/tests/test_pending_ticket_emails.py
@@ -1,0 +1,166 @@
+"""The unattended batch send behind the scheduled Sunday-morning run."""
+
+from unittest.mock import patch
+
+import pytest
+
+from tickets.models import OnlineAttendee, TicketEmailLog, TicketLink
+from tickets.tasks import send_pending_ticket_emails
+
+YEAR = 2026
+
+
+@pytest.fixture(autouse=True)
+def no_worker():
+    """Never hand anything to django-q from a test."""
+    with patch("tickets.services.async_task") as task:
+        yield task
+
+
+def make_attendee(email, year=YEAR, name="Ada Lovelace"):
+    return OnlineAttendee.objects.create(name=name, email=email, year=year)
+
+
+def make_links(count):
+    return [TicketLink.objects.create(link=f"https://ti.to/example/{i}") for i in range(count)]
+
+
+def log_for(email):
+    return TicketEmailLog.objects.filter(to_email=email)
+
+
+@pytest.mark.django_db
+def test_emails_everyone_who_has_never_been_emailed():
+    make_links(3)
+    make_attendee("a@example.com")
+    make_attendee("b@example.com")
+
+    summary = send_pending_ticket_emails()
+
+    assert summary["queued"] == 2
+    assert summary["skipped"] == 0
+    assert TicketEmailLog.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_assigns_a_link_to_anyone_who_still_lacks_one():
+    """Someone who buys between scheduling and firing has no link yet."""
+    make_links(1)
+    attendee = make_attendee("late@example.com")
+    assert attendee.active_ticket_link is None
+
+    send_pending_ticket_emails()
+
+    assert attendee.active_ticket_link is not None
+
+
+@pytest.mark.django_db
+def test_running_twice_does_not_email_anyone_twice():
+    """The guard that makes this safe to schedule, retry, or re-run."""
+    make_links(3)
+    make_attendee("a@example.com")
+
+    first = send_pending_ticket_emails()
+    second = send_pending_ticket_emails()
+
+    assert first["queued"] == 1
+    assert second["queued"] == 0
+    assert second["skipped"] == 1
+    assert log_for("a@example.com").count() == 1
+
+
+@pytest.mark.django_db
+def test_a_still_queued_email_counts_as_already_sent():
+    """A slow worker must not become a reason to send a second copy."""
+    make_links(3)
+    attendee = make_attendee("a@example.com")
+    TicketEmailLog.objects.create(
+        attendee=attendee, to_email=attendee.email, status=TicketEmailLog.STATUS_QUEUED
+    )
+
+    summary = send_pending_ticket_emails()
+
+    assert summary["queued"] == 0
+    assert summary["skipped"] == 1
+
+
+@pytest.mark.django_db
+def test_a_previous_failure_is_retried():
+    """A transient SMTP problem should not exclude someone forever."""
+    make_links(3)
+    attendee = make_attendee("a@example.com")
+    TicketEmailLog.objects.create(
+        attendee=attendee, to_email=attendee.email, status=TicketEmailLog.STATUS_FAILED
+    )
+
+    summary = send_pending_ticket_emails()
+
+    assert summary["queued"] == 1
+
+
+@pytest.mark.django_db
+def test_only_the_requested_year_is_emailed():
+    make_links(3)
+    make_attendee("now@example.com", year=2026)
+    make_attendee("then@example.com", year=2025)
+
+    summary = send_pending_ticket_emails(year=2026)
+
+    assert summary["queued"] == 1
+    assert not log_for("then@example.com").exists()
+
+
+@pytest.mark.django_db
+def test_running_out_of_links_stops_the_batch():
+    """Better to stop with a loud log than to quietly mail a subset."""
+    make_links(1)
+    make_attendee("a@example.com")
+    make_attendee("b@example.com")
+
+    summary = send_pending_ticket_emails()
+
+    assert summary["queued"] == 1
+    assert summary["out_of_links"] is True
+    assert TicketEmailLog.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_one_bad_attendee_does_not_sink_the_batch():
+    make_links(3)
+    make_attendee("bad@example.com")
+    make_attendee("good@example.com")
+
+    with patch("tickets.tasks.assign_and_email", side_effect=[RuntimeError("boom"), None]):
+        summary = send_pending_ticket_emails()
+
+    assert summary["failed"] == 1
+    assert summary["queued"] == 1
+
+
+@pytest.mark.django_db
+def test_limit_caps_how_many_go_out():
+    make_links(5)
+    for i in range(4):
+        make_attendee(f"a{i}@example.com")
+
+    summary = send_pending_ticket_emails(limit=2)
+
+    assert summary["queued"] == 2
+
+
+@pytest.mark.django_db
+def test_nothing_to_do_is_not_an_error():
+    summary = send_pending_ticket_emails()
+
+    assert summary["queued"] == 0
+    assert summary["out_of_links"] is False
+
+
+@pytest.mark.django_db
+def test_the_email_is_an_initial_send():
+    make_links(1)
+    make_attendee("a@example.com")
+
+    send_pending_ticket_emails()
+
+    assert log_for("a@example.com").get().kind == TicketEmailLog.KIND_INITIAL


### PR DESCRIPTION
Groundwork for #161 — scheduling the online ticket emails for Sunday 9am CT.

There was no way to send the whole batch without a human clicking through the roster, and a scheduled job can't click. `send_pending_ticket_emails()` does the run unattended.

## Not sending twice is the whole design

It fires on a schedule with nobody watching, so:

- Anyone with an existing log row — `sent`, **or still `queued`** in the worker — is skipped. A slow worker must not become the reason someone gets two links.
- That makes a second run safe: a retry, an accidental double-fire, or a rerun after a partial batch mails only the people the first run never reached.
- `failed` rows are deliberately **not** skipped, so a transient SMTP problem gets another go rather than excluding someone forever.

## Other decisions

- **Links are assigned, not assumed.** Anyone buying between now and Sunday has no link yet; the job pulls one for them.
- **Running out of links stops the batch** rather than quietly mailing a subset — the people left over are exactly the ones a human needs to hear about. Logged at `error`, and surfaced in the summary.
- **One bad attendee doesn't sink the run** — logged and counted, the rest still go.
- Scoped to a single `year` (defaults to `DEFAULT_YEAR`), with an optional `limit` for a cautious first run.

Returns `{year, queued, skipped, failed, out_of_links}` so the outcome is visible in the worker log.

## Testing

564 pass, 11 new — covering the double-send guard, the queued-vs-failed distinction, link assignment, the out-of-links stop, per-attendee failure isolation, year scoping, and `limit`. Lint clean.

## Not scheduled by this PR

This adds the callable only. The schedule row is a separate deliberate step (`sync_schedules` never auto-registers one), and I'll create it once this is deployed — as a **one-time** schedule for Sunday 2026-08-23 09:00 CDT rather than a recurring weekly cron, so it can't fire again the following Sunday.

Current state: 41 attendees for 2026, all holding links, none emailed yet.
