### PR TITLE
Resend, reissue, and issue-by-address from the ticket list page

### DIFF
--- a/templates/tickets/list.html
+++ b/templates/tickets/list.html
@@ -21,12 +21,45 @@
         {% if messages %}
             <div class="mb-6">
                 {% for message in messages %}
-                    <div class="p-4 mb-3 rounded-lg {% if message.tags == 'success' %}bg-green-800{% elif message.tags == 'warning' %}bg-yellow-800{% else %}bg-blue-800{% endif %}">
+                    <div class="p-4 mb-3 rounded-lg {% if message.tags == 'success' %}bg-green-800{% elif message.tags == 'warning' %}bg-yellow-800{% elif message.tags == 'error' %}bg-red-800{% else %}bg-blue-800{% endif %}">
                         {{ message }}
                     </div>
                 {% endfor %}
             </div>
         {% endif %}
+
+        <div class="bg-opacity-50 mb-6 rounded-lg bg-green-800 p-4">
+            <h2 class="mb-1 font-semibold">Issue a ticket to an address</h2>
+            {% comment %}
+                One person from billing often buys several tickets under their own
+                address, so the people who actually attend are never on the roster
+                under the address they read mail at. This hands them a link directly
+                and adds them to the roster, so they can be resent later like anyone
+                who came in through Ti.to.
+            {% endcomment %}
+            <p class="mb-3 text-sm text-gray-300">
+                For attendees who are not on the roster &mdash; a bulk buyer's colleagues, say. They are added to the roster so you can resend later.
+            </p>
+            <form method="post" class="flex flex-wrap items-end gap-3">
+                {% csrf_token %}
+                <div class="min-w-56 flex-1">
+                    <label for="{{ assign_form.email.id_for_label }}" class="mb-1 block text-sm text-gray-300">{{ assign_form.email.label }}</label>
+                    {{ assign_form.email }}
+                </div>
+                <div class="min-w-40 flex-1">
+                    <label for="{{ assign_form.name.id_for_label }}" class="mb-1 block text-sm text-gray-300">{{ assign_form.name.label }}</label>
+                    {{ assign_form.name }}
+                </div>
+                <label class="flex items-center gap-2 pb-2 text-sm text-gray-300">
+                    {{ assign_form.send_email }}
+                    Email it to them
+                </label>
+                <button type="submit" name="action" value="assign_by_email"
+                        class="rounded-lg bg-green-600 px-4 py-2 font-semibold text-white hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:outline-none">
+                    Issue ticket
+                </button>
+            </form>
+        </div>
 
         <div class="bg-opacity-50 mb-6 rounded-lg bg-green-800 p-4">
             <div class="grid grid-cols-2 gap-4 text-center md:grid-cols-4">
@@ -71,6 +104,9 @@
                             </th>
                             <th class="px-6 py-3 text-center text-xs font-medium tracking-wider uppercase">
                                 Status
+                            </th>
+                            <th class="px-6 py-3 text-center text-xs font-medium tracking-wider uppercase">
+                                Actions
                             </th>
                         </tr>
                     </thead>
@@ -138,6 +174,33 @@
                                         <span class="inline-flex rounded-full bg-green-800 px-3 py-1 text-xs leading-5 font-semibold text-green-200">
                                             Available
                                         </span>
+                                    {% endif %}
+                                </td>
+                                <td class="px-6 py-4 text-center whitespace-nowrap">
+                                    {% comment %}
+                                        Only live, assigned links can be mailed. A superseded row points
+                                        at a URL that no longer works, and an unassigned one has nobody
+                                        to send to, so neither gets a button rather than a button that
+                                        only ever errors.
+                                    {% endcomment %}
+                                    {% if ticket.attendee_email and not ticket.superseded_at %}
+                                        <form method="post" class="inline">
+                                            {% csrf_token %}
+                                            <input type="hidden" name="ticket" value="{{ ticket.pk }}">
+                                            <button type="submit" name="action" value="resend"
+                                                    class="rounded bg-green-700 px-3 py-1 text-xs font-semibold text-white hover:bg-green-600 focus:ring-2 focus:ring-green-500 focus:outline-none"
+                                                    title="Email this same link again">
+                                                Resend
+                                            </button>
+                                            <button type="submit" name="action" value="reissue"
+                                                    class="ml-1 rounded bg-yellow-700 px-3 py-1 text-xs font-semibold text-white hover:bg-yellow-600 focus:ring-2 focus:ring-yellow-500 focus:outline-none"
+                                                    title="Issue a brand new link and email it. This link stops working."
+                                                    onclick="return confirm('Issue {{ ticket.attendee_email|escapejs }} a new link? Their current link will stop working immediately.')">
+                                                Reissue
+                                            </button>
+                                        </form>
+                                    {% else %}
+                                        <span class="text-xs text-gray-600">&mdash;</span>
                                     {% endif %}
                                 </td>
                             </tr>

--- a/tickets/services.py
+++ b/tickets/services.py
@@ -122,12 +122,20 @@ def assign_and_email(
     sent_by=None,
 ) -> tuple[TicketLink, TicketEmailLog]:
     """Ensure the attendee holds a link and email it to them."""
-    had_link = attendee.has_ticket
+    # Whether they have been *emailed* before, not whether they hold a link.
+    # Those came apart the moment links were assigned in one pass and emailed in
+    # another: everyone already had a link, so a first send announced itself as
+    # "here it is again, the same link we sent you before" to people who had
+    # never heard from us. The subject line says "(resent)" too, so getting this
+    # wrong is squarely user-visible.
+    emailed_before = attendee.email_logs.filter(
+        status__in=[TicketEmailLog.STATUS_SENT, TicketEmailLog.STATUS_QUEUED],
+    ).exists()
     link = assign_link(attendee.email, attendee=attendee, reissue=reissue)
 
     if reissue:
         kind = TicketEmailLog.KIND_REISSUE
-    elif had_link:
+    elif emailed_before:
         kind = TicketEmailLog.KIND_RESEND
     else:
         kind = TicketEmailLog.KIND_INITIAL

--- a/tickets/tests/test_list_page_actions.py
+++ b/tickets/tests/test_list_page_actions.py
@@ -1,0 +1,217 @@
+"""Resend, reissue, and issue-by-address, driven from the ticket list page."""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from tickets.models import OnlineAttendee, TicketEmailLog, TicketLink
+
+User = get_user_model()
+URL = "/tickets/list/"
+
+
+@pytest.fixture(autouse=True)
+def no_worker():
+    with patch("tickets.services.async_task") as task:
+        yield task
+
+
+@pytest.fixture
+def staff(client):
+    user = User.objects.create_superuser(username="root", email="r@example.com", password="pw12345!")
+    client.force_login(user)
+    return user
+
+
+def make_attendee(email="ada@example.com", year=2026):
+    return OnlineAttendee.objects.create(name="Ada Lovelace", email=email, year=year)
+
+
+def make_link(email=None, attendee=None, superseded=False):
+    link = TicketLink.objects.create(
+        link="https://ti.to/example/one",
+        attendee_email=email,
+        attendee=attendee,
+        superseded_at=timezone.now() if superseded else None,
+    )
+    return link
+
+
+def test_the_page_needs_staff(client):
+    assert client.get(URL).status_code in {302, 403}
+
+
+@pytest.mark.django_db
+def test_resend_queues_the_same_link_again(client, staff):
+    attendee = make_attendee()
+    link = make_link(email=attendee.email, attendee=attendee)
+
+    client.post(URL, {"action": "resend", "ticket": link.pk})
+
+    log = TicketEmailLog.objects.get()
+    assert log.to_email == attendee.email
+    assert log.ticket_link_id == link.pk
+    assert log.sent_by_id == staff.pk
+
+
+@pytest.mark.django_db
+def test_a_first_send_is_not_labelled_a_resend(client, staff):
+    """Holding a link is not the same as having been emailed one."""
+    attendee = make_attendee()
+    make_link(email=attendee.email, attendee=attendee)
+
+    client.post(URL, {"action": "resend", "ticket": TicketLink.objects.get().pk})
+
+    assert TicketEmailLog.objects.get().kind == TicketEmailLog.KIND_INITIAL
+
+
+@pytest.mark.django_db
+def test_a_second_send_is_labelled_a_resend(client, staff):
+    attendee = make_attendee()
+    link = make_link(email=attendee.email, attendee=attendee)
+    TicketEmailLog.objects.create(attendee=attendee, ticket_link=link, to_email=attendee.email,
+                                  status=TicketEmailLog.STATUS_SENT)
+
+    client.post(URL, {"action": "resend", "ticket": link.pk})
+
+    assert TicketEmailLog.objects.latest("pk").kind == TicketEmailLog.KIND_RESEND
+
+
+@pytest.mark.django_db
+def test_reissue_supersedes_the_old_link_and_mails_a_new_one(client, staff):
+    attendee = make_attendee()
+    old = make_link(email=attendee.email, attendee=attendee)
+    spare = TicketLink.objects.create(link="https://ti.to/example/spare")
+
+    client.post(URL, {"action": "reissue", "ticket": old.pk})
+
+    old.refresh_from_db()
+    spare.refresh_from_db()
+    assert old.superseded_at is not None
+    assert spare.attendee_email == attendee.email
+    assert TicketEmailLog.objects.get().kind == TicketEmailLog.KIND_REISSUE
+
+
+@pytest.mark.django_db
+def test_reissue_without_a_spare_link_changes_nothing(client, staff):
+    """Better to refuse than to strand somebody with no link at all."""
+    attendee = make_attendee()
+    old = make_link(email=attendee.email, attendee=attendee)
+
+    client.post(URL, {"action": "reissue", "ticket": old.pk})
+
+    old.refresh_from_db()
+    assert old.superseded_at is None
+    assert not TicketEmailLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_a_superseded_row_cannot_be_mailed(client, staff):
+    """Its URL stopped working, so sending it would be actively unhelpful."""
+    attendee = make_attendee()
+    dead = make_link(email=attendee.email, attendee=attendee, superseded=True)
+
+    client.post(URL, {"action": "resend", "ticket": dead.pk})
+
+    assert not TicketEmailLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_an_unassigned_row_cannot_be_mailed(client, staff):
+    link = make_link()
+
+    client.post(URL, {"action": "resend", "ticket": link.pk})
+
+    assert not TicketEmailLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_a_made_up_ticket_id_does_not_blow_up(client, staff):
+    response = client.post(URL, {"action": "resend", "ticket": "not-a-number"})
+
+    assert response.status_code == 302
+    assert not TicketEmailLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_a_link_held_by_someone_off_the_roster_is_refused(client, staff):
+    """No attendee row means no address we are confident belongs to a person."""
+    make_link(email="ghost@example.com")
+
+    client.post(URL, {"action": "resend", "ticket": TicketLink.objects.get().pk})
+
+    assert not TicketEmailLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_issuing_to_a_new_address_adds_them_to_the_roster_and_mails_them(client, staff):
+    """The bulk-buyer case: the person attending is not who paid."""
+    TicketLink.objects.create(link="https://ti.to/example/spare")
+
+    client.post(URL, {"action": "assign_by_email", "email": "Colleague@Example.com",
+                      "name": "Grace Hopper", "send_email": "on"})
+
+    attendee = OnlineAttendee.objects.get()
+    assert attendee.email == "colleague@example.com"  # normalized
+    assert attendee.name == "Grace Hopper"
+    assert attendee.source == OnlineAttendee.SOURCE_MANUAL
+    assert TicketLink.objects.get().attendee_email == "colleague@example.com"
+    assert TicketEmailLog.objects.get().to_email == "colleague@example.com"
+
+
+@pytest.mark.django_db
+def test_issuing_without_the_email_box_ticked_sends_nothing(client, staff):
+    TicketLink.objects.create(link="https://ti.to/example/spare")
+
+    client.post(URL, {"action": "assign_by_email", "email": "quiet@example.com"})
+
+    assert TicketLink.objects.get().attendee_email == "quiet@example.com"
+    assert not TicketEmailLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_issuing_to_an_address_that_already_holds_a_link_does_not_burn_a_second(client, staff):
+    attendee = make_attendee("dup@example.com")
+    held = make_link(email=attendee.email, attendee=attendee)
+    TicketLink.objects.create(link="https://ti.to/example/spare")
+
+    client.post(URL, {"action": "assign_by_email", "email": "dup@example.com", "send_email": "on"})
+
+    assert TicketEmailLog.objects.get().ticket_link_id == held.pk
+    assert TicketLink.objects.filter(attendee_email__isnull=True, superseded_at__isnull=True).count() == 1
+
+
+@pytest.mark.django_db
+def test_a_bad_address_is_rejected(client, staff):
+    TicketLink.objects.create(link="https://ti.to/example/spare")
+
+    client.post(URL, {"action": "assign_by_email", "email": "not-an-email", "send_email": "on"})
+
+    assert not OnlineAttendee.objects.exists()
+    assert not TicketEmailLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_an_unknown_action_does_nothing(client, staff):
+    attendee = make_attendee()
+    make_link(email=attendee.email, attendee=attendee)
+
+    response = client.post(URL, {"action": "nonsense", "ticket": TicketLink.objects.get().pk})
+
+    assert response.status_code == 302
+    assert not TicketEmailLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_the_buttons_render_only_for_live_assigned_rows(client, staff):
+    attendee = make_attendee()
+    make_link(email=attendee.email, attendee=attendee)
+    make_link()  # unassigned
+
+    body = client.get(URL).content.decode()
+
+    assert body.count('value="resend"') == 1
+    assert body.count('value="reissue"') == 1
+    assert "Issue a ticket to an address" in body

--- a/tickets/tests/test_pending_ticket_emails.py
+++ b/tickets/tests/test_pending_ticket_emails.py
@@ -74,9 +74,7 @@ def test_a_still_queued_email_counts_as_already_sent():
     """A slow worker must not become a reason to send a second copy."""
     make_links(3)
     attendee = make_attendee("a@example.com")
-    TicketEmailLog.objects.create(
-        attendee=attendee, to_email=attendee.email, status=TicketEmailLog.STATUS_QUEUED
-    )
+    TicketEmailLog.objects.create(attendee=attendee, to_email=attendee.email, status=TicketEmailLog.STATUS_QUEUED)
 
     summary = send_pending_ticket_emails()
 
@@ -89,9 +87,7 @@ def test_a_previous_failure_is_retried():
     """A transient SMTP problem should not exclude someone forever."""
     make_links(3)
     attendee = make_attendee("a@example.com")
-    TicketEmailLog.objects.create(
-        attendee=attendee, to_email=attendee.email, status=TicketEmailLog.STATUS_FAILED
-    )
+    TicketEmailLog.objects.create(attendee=attendee, to_email=attendee.email, status=TicketEmailLog.STATUS_FAILED)
 
     summary = send_pending_ticket_emails()
 

--- a/tickets/views.py
+++ b/tickets/views.py
@@ -96,7 +96,58 @@ def create_tickets_view(request: HttpRequest) -> HttpResponse:
     return render(request, "tickets/create.html", context)
 
 
+def _handle_list_link_action(request: HttpRequest, action: str) -> None:
+    """Resend or reissue one link, straight from the list page.
+
+    Resend mails the link already on the row; reissue supersedes it and mails a
+    fresh one from the pool. They are separate buttons rather than one because
+    reissue is destructive --- the old URL stops working the moment it runs, so
+    it must never be what a mis-aimed "send it again" click does.
+    """
+    # The pk arrives as raw POST text, so a hand-crafted value must not 500.
+    raw_pk = (request.POST.get("ticket") or "").strip()
+    ticket = TicketLink.objects.filter(pk=raw_pk).select_related("attendee").first() if raw_pk.isdigit() else None
+    if ticket is None:
+        messages.error(request, "That ticket link no longer exists.")
+        return
+
+    if ticket.superseded_at is not None:
+        # Resending a dead link mails somebody a URL that no longer works, and
+        # reissuing from it would replace a link they already stopped using.
+        messages.error(request, "That link was superseded by a newer one, so there is nothing to send.")
+        return
+
+    if not ticket.attendee_email:
+        messages.error(request, "That link has not been assigned to anyone yet.")
+        return
+
+    attendee = ticket.attendee or OnlineAttendee.objects.filter(email=ticket.attendee_email).order_by("-year").first()
+    if attendee is None:
+        messages.error(
+            request,
+            f"{ticket.attendee_email} holds this link but is not on the attendee roster, so there is nobody to email.",
+        )
+        return
+
+    reissue = action == "reissue"
+    try:
+        assign_and_email(attendee, reissue=reissue, sent_by=request.user)
+    except NoTicketsAvailable:
+        messages.error(request, "No unassigned ticket links are left. Add more links before reissuing.")
+    except Exception:
+        logger.exception("Failed to %s ticket link %s for %s", action, ticket.pk, attendee.email)
+        messages.error(request, f"Could not queue that email to {attendee.email}.")
+    else:
+        if reissue:
+            messages.success(
+                request, f"Issued {attendee.email} a new link and queued their email. The old one no longer works."
+            )
+        else:
+            messages.success(request, f"Queued a resend of this link to {attendee.email}.")
+
+
 @staff_member_required
+@require_http_methods(["GET", "POST"])
 def tickets_list_view(request: HttpRequest) -> HttpResponse:
     """
     Display all tickets with their status.
@@ -107,6 +158,18 @@ def tickets_list_view(request: HttpRequest) -> HttpResponse:
     relationship, so a reissued link carries its own history rather than the
     attendee's running total.
     """
+    if request.method == "POST":
+        action = request.POST.get("action")
+        if action in {"resend", "reissue"}:
+            _handle_list_link_action(request, action)
+        elif action == "assign_by_email":
+            # Same handler the roster uses, so an address issued from either
+            # page lands on the roster identically instead of two ways.
+            _handle_assign_by_email(request, DEFAULT_YEAR)
+        else:
+            messages.error(request, "Unknown action.")
+        return redirect("tickets_list")
+
     sent = models.Q(email_logs__status=TicketEmailLog.STATUS_SENT)
     tickets = (
         TicketLink.objects.annotate(
@@ -130,6 +193,7 @@ def tickets_list_view(request: HttpRequest) -> HttpResponse:
 
     context = {
         "tickets": tickets,
+        "assign_form": AssignByEmailForm(),
         "total_count": len(tickets),
         "available_count": sum(1 for t in tickets if t.attendee_email is None),
         "used_count": sum(1 for t in tickets if t.attendee_email is not None),


### PR DESCRIPTION
`/tickets/list/` was read-only. Acting on what it showed meant crossing to the roster and finding the person again — and for someone not on the roster at all, there was nowhere to go.

## Three additions

**Per-row Resend** — mails the link already on that row.

**Per-row Reissue** — supersedes it, pulls a fresh link from the pool, mails that. Separate button, not a dropdown, because reissue is destructive: the old URL dies the moment it runs, so it must never be what a mis-aimed "send it again" click does. It confirms first, naming the address.

**Issue a ticket to an address** — the bulk-buyer case you described. One person in billing pays for several seats, so the people actually attending are never on the roster under an address they read mail at. This hands them a link directly and adds them as a manual attendee via the same `_handle_assign_by_email` the roster uses, so they can be resent later like anyone who came through Ti.to. "Email it to them" is a checkbox, so you can issue quietly.

Rows that are **superseded or unassigned get no buttons** rather than buttons that only error — one points at a URL that stopped working, the other has nobody to send to.

## Also: the "(resent)" wording bug

`assign_and_email` inferred the email kind from whether someone held a **link**, not whether they'd ever been **emailed**. Those came apart the moment we assigned links in one pass and mailed in another — which is exactly what happened this morning:

```
('resend',  'Your DjangoCon US online conference link (resent)') : 41
('initial', 'Your DjangoCon US online conference link')          :  1
```

41 first-time sends told people it was "the same link we sent you before". Now it keys off prior sends (`sent` or `queued`), which is what both the template and the subject line actually claim. **No corrective emails are queued by this PR** — it only changes what future sends are labelled.

## Incidental

Errors on this page rendered blue, identical to informational messages. These handlers emit errors often enough that it mattered, so `error` now renders red.

## Testing

580 pass, 16 new — covering both button paths, the destructive-reissue guard, the no-spare-links refusal, superseded/unassigned/off-roster refusals, address normalization, the roster row's `source=manual`, the don't-burn-a-second-link case, and that buttons render only for live assigned rows.

One test earned its keep immediately: posting a non-numeric `ticket` value 500'd the view, since the pk goes straight into a `filter()`. Now guarded with `.isdigit()`, matching `_handle_assign_one`.
