### PR TITLE
Email an online ticket link the moment somebody buys one

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -328,7 +328,21 @@ Q_SCHEDULES = {
         "schedule_type": "CRON",
         "cron": VOLUNTEER_DIGEST_CRON,
     },
+    # The safety net under the purchase webhook. Webhooks are instant but only
+    # cover purchases made since the endpoint went live and only arrive if Ti.to
+    # manages to deliver them; this sweeps up anyone the webhook missed, and
+    # anyone who arrived through the API sync instead. Idempotent, so a sweep
+    # that finds nothing to do is the normal case.
+    "ticket-emails-sweep": {
+        "func": "tickets.tasks.send_pending_ticket_emails",
+        "schedule_type": "HOURLY",
+    },
 }
+
+# Emailing an online ticket link the moment somebody buys one. Off switch rather
+# than a feature flag: if a bad Ti.to payload or an empty link pool ever turns
+# this into a problem, it wants to be stoppable from Coolify without a deploy.
+TICKET_AUTO_EMAIL = env.bool("TICKET_AUTO_EMAIL", default=True)
 
 # Volunteer signup settings
 

--- a/tickets/services.py
+++ b/tickets/services.py
@@ -115,6 +115,25 @@ def queue_ticket_email(
     return log
 
 
+def ensure_ticket_emailed(attendee: OnlineAttendee, *, sent_by=None):
+    """Email ``attendee`` their link unless they have already been emailed one.
+
+    The idempotent entry point, for callers that fire on their own: a purchase
+    webhook, a scheduled sweep. Ti.to retries a webhook it thinks failed, and
+    the sweep runs whether or not the webhook already handled someone, so
+    "have we told this person yet" has to be answered here rather than trusted
+    to the caller. Returns None when there was nothing to do.
+    """
+    already = attendee.email_logs.filter(
+        status__in=[TicketEmailLog.STATUS_SENT, TicketEmailLog.STATUS_QUEUED],
+    ).exists()
+    if already:
+        return None
+
+    _, log = assign_and_email(attendee, sent_by=sent_by)
+    return log
+
+
 def assign_and_email(
     attendee: OnlineAttendee,
     *,

--- a/tickets/tasks.py
+++ b/tickets/tasks.py
@@ -5,7 +5,7 @@ from django.core.mail import EmailMultiAlternatives
 
 from tickets.emails import build_ticket_email
 from tickets.models import OnlineAttendee, TicketEmailLog
-from tickets.services import NoTicketsAvailable, assign_and_email
+from tickets.services import NoTicketsAvailable, ensure_ticket_emailed
 from tickets.sync import DEFAULT_YEAR
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ def send_pending_ticket_emails(year: int = DEFAULT_YEAR, limit: int | None = Non
             break
 
         try:
-            assign_and_email(attendee)
+            ensure_ticket_emailed(attendee)
         except NoTicketsAvailable:
             out_of_links = True
             logger.error("Ran out of ticket links while emailing %s; stopping the batch", attendee.email)
@@ -114,3 +114,34 @@ def send_pending_ticket_emails(year: int = DEFAULT_YEAR, limit: int | None = Non
     }
     logger.info("Pending ticket email run complete: %s", summary)
     return summary
+
+
+def email_new_online_attendee(attendee_id: int) -> bool:
+    """Send one newly-signed-up attendee their link. Queued from the Ti.to webhook.
+
+    Runs in the worker rather than inline in the webhook so Ti.to gets its 200
+    back regardless of how the send goes --- a slow SMTP server or an empty link
+    pool must not turn into a webhook failure and a retry storm.
+    """
+    if not settings.TICKET_AUTO_EMAIL:
+        logger.info("Auto-email is off; not emailing attendee %s", attendee_id)
+        return False
+
+    attendee = OnlineAttendee.objects.filter(pk=attendee_id).first()
+    if attendee is None:
+        logger.warning("Attendee %s vanished before their link could be emailed", attendee_id)
+        return False
+
+    try:
+        log = ensure_ticket_emailed(attendee)
+    except NoTicketsAvailable:
+        # Loud, because the fix is human: somebody has to add links to the pool.
+        logger.error("No ticket links left; %s signed up and could not be emailed", attendee.email)
+        return False
+
+    if log is None:
+        logger.info("Attendee %s was already emailed; nothing to do", attendee.email)
+        return False
+
+    logger.info("Emailed new online attendee %s", attendee.email)
+    return True

--- a/tickets/tests/test_auto_email_on_signup.py
+++ b/tickets/tests/test_auto_email_on_signup.py
@@ -1,0 +1,175 @@
+"""Emailing a link the moment somebody buys an online ticket."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from django.test import Client
+
+from tickets.models import OnlineAttendee, TicketEmailLog, TicketLink, TicketRelease
+from tickets.services import ensure_ticket_emailed
+from tickets.tasks import email_new_online_attendee
+
+WEBHOOK_URL = "/titowebhook/"
+
+
+@pytest.fixture(autouse=True)
+def no_worker():
+    with patch("tickets.services.async_task") as task:
+        yield task
+
+
+@pytest.fixture(autouse=True)
+def online_release(db):
+    return TicketRelease.objects.create(title="Online- Individual", grants_venueless_access=True)
+
+
+def make_attendee(email="ada@example.com", year=2026):
+    return OnlineAttendee.objects.create(name="Ada Lovelace", email=email, year=year)
+
+
+def make_links(n=1):
+    return [TicketLink.objects.create(link=f"https://ti.to/example/{i}") for i in range(n)]
+
+
+# --- the idempotent core -------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_a_new_attendee_gets_their_link():
+    make_links()
+    attendee = make_attendee()
+
+    log = ensure_ticket_emailed(attendee)
+
+    assert log is not None
+    assert attendee.active_ticket_link is not None
+    assert TicketEmailLog.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_somebody_already_emailed_is_left_alone():
+    """Ti.to retries webhooks; a retry must not mean a second link email."""
+    make_links(2)
+    attendee = make_attendee()
+    ensure_ticket_emailed(attendee)
+
+    assert ensure_ticket_emailed(attendee) is None
+    assert TicketEmailLog.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_a_queued_send_also_counts_as_done():
+    make_links(2)
+    attendee = make_attendee()
+    TicketEmailLog.objects.create(attendee=attendee, to_email=attendee.email,
+                                  status=TicketEmailLog.STATUS_QUEUED)
+
+    assert ensure_ticket_emailed(attendee) is None
+
+
+@pytest.mark.django_db
+def test_the_first_send_is_not_labelled_a_resend():
+    make_links()
+    attendee = make_attendee()
+
+    ensure_ticket_emailed(attendee)
+
+    assert TicketEmailLog.objects.get().kind == TicketEmailLog.KIND_INITIAL
+
+
+# --- the worker task -----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_the_task_emails_the_attendee():
+    make_links()
+    attendee = make_attendee()
+
+    assert email_new_online_attendee(attendee.pk) is True
+    assert TicketEmailLog.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_the_task_respects_the_off_switch(settings):
+    settings.TICKET_AUTO_EMAIL = False
+    make_links()
+    attendee = make_attendee()
+
+    assert email_new_online_attendee(attendee.pk) is False
+    assert not TicketEmailLog.objects.exists()
+
+
+@pytest.mark.django_db
+def test_an_empty_link_pool_fails_quietly_and_loudly(caplog):
+    """Nothing to hand out; the fix is a human adding links, so it logs an error."""
+    attendee = make_attendee()
+
+    assert email_new_online_attendee(attendee.pk) is False
+    assert "No ticket links left" in caplog.text
+
+
+@pytest.mark.django_db
+def test_a_missing_attendee_does_not_raise():
+    assert email_new_online_attendee(999999) is False
+
+
+# --- end to end through the webhook --------------------------------------
+
+
+def post_webhook(client, payload, trigger="ticket.completed"):
+    return client.post(
+        WEBHOOK_URL,
+        data=json.dumps(payload),
+        content_type="application/json",
+        headers={"x-webhook-name": trigger},
+    )
+
+
+def ticket_payload(email="new@example.com", release="Online- Individual"):
+    return {
+        "_type": "ticket",
+        "slug": "ti_abc123",
+        "reference": "ABC-1",
+        "email": email,
+        "name": "Grace Hopper",
+        "release_title": release,
+        "state_name": "complete",
+        "created_at": "2026-08-23T12:00:00.000-05:00",
+        "event": {"_type": "event", "slug": "djangocon-us-2026", "account_slug": "defna"},
+    }
+
+
+@pytest.mark.django_db
+def test_buying_an_online_ticket_queues_the_email(settings):
+    settings.TITO_SECURITY_TOKEN = ""
+    make_links()
+
+    with patch("titowebhooks.views.async_task") as queued:
+        response = post_webhook(Client(), ticket_payload())
+
+    assert response.status_code in {200, 201}
+    assert OnlineAttendee.objects.filter(email="new@example.com").exists()
+    assert any(call.args[0] == "tickets.tasks.email_new_online_attendee" for call in queued.call_args_list)
+
+
+@pytest.mark.django_db
+def test_buying_an_in_person_ticket_queues_nothing(settings):
+    """Only releases flagged as granting Venueless access should trigger a send."""
+    settings.TITO_SECURITY_TOKEN = ""
+    make_links()
+
+    with patch("titowebhooks.views.async_task") as queued:
+        post_webhook(Client(), ticket_payload(release="Early-Bird Individual (In-person)"))
+
+    assert not any(call.args[0] == "tickets.tasks.email_new_online_attendee" for call in queued.call_args_list)
+
+
+@pytest.mark.django_db
+def test_a_non_purchase_webhook_queues_nothing(settings):
+    settings.TITO_SECURITY_TOKEN = ""
+
+    with patch("titowebhooks.views.async_task") as queued:
+        post_webhook(Client(), ticket_payload(), trigger="ticket.updated")
+
+    assert not any(call.args[0] == "tickets.tasks.email_new_online_attendee" for call in queued.call_args_list)

--- a/tickets/tests/test_list_page_actions.py
+++ b/tickets/tests/test_list_page_actions.py
@@ -71,8 +71,9 @@ def test_a_first_send_is_not_labelled_a_resend(client, staff):
 def test_a_second_send_is_labelled_a_resend(client, staff):
     attendee = make_attendee()
     link = make_link(email=attendee.email, attendee=attendee)
-    TicketEmailLog.objects.create(attendee=attendee, ticket_link=link, to_email=attendee.email,
-                                  status=TicketEmailLog.STATUS_SENT)
+    TicketEmailLog.objects.create(
+        attendee=attendee, ticket_link=link, to_email=attendee.email, status=TicketEmailLog.STATUS_SENT
+    )
 
     client.post(URL, {"action": "resend", "ticket": link.pk})
 
@@ -150,8 +151,9 @@ def test_issuing_to_a_new_address_adds_them_to_the_roster_and_mails_them(client,
     """The bulk-buyer case: the person attending is not who paid."""
     TicketLink.objects.create(link="https://ti.to/example/spare")
 
-    client.post(URL, {"action": "assign_by_email", "email": "Colleague@Example.com",
-                      "name": "Grace Hopper", "send_email": "on"})
+    client.post(
+        URL, {"action": "assign_by_email", "email": "Colleague@Example.com", "name": "Grace Hopper", "send_email": "on"}
+    )
 
     attendee = OnlineAttendee.objects.get()
     assert attendee.email == "colleague@example.com"  # normalized

--- a/tickets/tests/test_pending_ticket_emails.py
+++ b/tickets/tests/test_pending_ticket_emails.py
@@ -126,7 +126,7 @@ def test_one_bad_attendee_does_not_sink_the_batch():
     make_attendee("bad@example.com")
     make_attendee("good@example.com")
 
-    with patch("tickets.tasks.assign_and_email", side_effect=[RuntimeError("boom"), None]):
+    with patch("tickets.tasks.ensure_ticket_emailed", side_effect=[RuntimeError("boom"), None]):
         summary = send_pending_ticket_emails()
 
     assert summary["failed"] == 1

--- a/titowebhooks/views.py
+++ b/titowebhooks/views.py
@@ -87,9 +87,16 @@ def tito_webhook(request):
     # nightly sync to see a purchase they were just told about.
     if request.headers.get("x-webhook-name") == "ticket.completed":
         try:
-            record_webhook_attendee(payload)
+            attendee = record_webhook_attendee(payload)
         except Exception:
             logger.exception("Failed to record online attendee from webhook payload")
+        else:
+            # Send their link straight away rather than waiting for someone to
+            # run a batch. Handed to the worker so a slow send or an empty pool
+            # cannot fail the webhook and start Ti.to retrying it. Non-online
+            # purchases come back as None and are left alone.
+            if attendee is not None:
+                async_task("tickets.tasks.email_new_online_attendee", attendee.pk)
 
     try:
         if settings.EMAILOCTOPUS_API_KEY:


### PR DESCRIPTION
## The gap

A `ticket.completed` webhook already put online buyers on the roster — but **nothing emailed them**. Every send waited on a human running a batch, so anyone buying in between sat without their link. That's exactly what today looked like.

## Now

**The webhook queues the send.** `record_webhook_attendee` returns the attendee (or `None` for a non-online purchase), and an online one gets `email_new_online_attendee` handed to the worker.

Worker, not inline, deliberately: Ti.to gets its 200 back regardless of how the send goes. A slow SMTP server or an empty link pool must not read as a webhook failure and start a retry storm.

**The double-send guard moved into `ensure_ticket_emailed`**, which the webhook *and* the batch now both call. Ti.to retries webhooks it believes failed, and the sweep below runs whether or not the webhook already handled someone — so "have we told this person yet" is answered in one place rather than trusted to each caller.

**An hourly sweep as the safety net** (`ticket-emails-sweep` → `send_pending_ticket_emails`). Webhooks are instant but only cover purchases made since the endpoint went live, and only arrive if Ti.to manages to deliver them. Today eight `Opportunity Grant- Online` buyers were missing for exactly that class of reason. The sweep is idempotent, so finding nothing to do is the normal case.

**`TICKET_AUTO_EMAIL=false`** stops all of it from Coolify without a deploy. Something that mails people automatically off an external trigger deserves a stop button that doesn't need a release.

## Eligibility is unchanged

Only releases flagged `grants_venueless_access` trigger a send — `is_online_release` still decides, so in-person buyers are ignored exactly as before. There's a test for that.

## Testing

593 pass, 11 new: the idempotent core (fresh attendee, already-emailed, still-queued, correct `initial` labelling), the worker task (success, off switch, empty pool logging an error, missing attendee), and the webhook end to end (online purchase queues it, in-person doesn't, non-purchase trigger doesn't).

## Deploying

The sweep needs registering by hand — `sync_schedules` doesn't run at boot:

```
manage.py sync_schedules
```

Without it the webhook path still works; you just lose the safety net. I'll run it once this is merged and deployed.
